### PR TITLE
IPv6 extension headers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,22 @@ flowchart LR
   I6 -->|58| IC6[ICMPv6]
   I6 -->|6| T
   I6 -->|17| U
+  I6 -->|0, 43, 44, 60| X[IPv6 extension headers]
+  X --> X
+  X -->|58| IC6
+  X -->|6| T
+  X -->|17| U
 ```
+
+IPv6 extension headers (Hop-by-Hop Options, Routing, Fragment,
+Destination Options) chain like any other protocol — each names what
+follows via `next_header` — and may stack. Two guardrails: the
+registry hands them out only inside an IPv6 chain (a garbage IPv4
+packet with `protocol=0` cannot conjure a Hop-by-Hop layer), and a
+Fragment header chains onward only when `fragment_offset == 0` — a
+non-first fragment carries a slice from the middle of the original
+payload, so no upper-layer header exists at its start. The same
+offset rule applies to fragmented IPv4.
 
 The numbers on the arrows are the wire values — EtherTypes out of
 Ethernet, IP protocol numbers out of IPv4/IPv6 — and they live in

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Requires Python 3.12+. Fully typed (`py.typed`, mypy strict).
 | 2 | Ethernet II | `Ethernet` | IEEE 802.3 |
 | 2 | ARP | `ARP` | RFC 826, IPv4-over-Ethernet binding |
 | 3 | IPv4 | `IPv4` | RFC 791, IHL/options aware |
-| 3 | IPv6 | `IPv6` | RFC 8200, fixed header |
+| 3 | IPv6 | `IPv6` | RFC 8200 |
+| 3 | IPv6 Hop-by-Hop Options | `IPv6HopByHopOptions` | RFC 8200 §4.3 |
+| 3 | IPv6 Routing | `IPv6Routing` | RFC 8200 §4.4 |
+| 3 | IPv6 Fragment | `IPv6Fragment` | RFC 8200 §4.5, first-fragment chaining |
+| 3 | IPv6 Destination Options | `IPv6DestinationOptions` | RFC 8200 §4.6 |
 | 3 | ICMPv4 | `ICMPv4` | RFC 792, 8-byte header |
 | 3 | ICMPv6 | `ICMPv6` | RFC 4443, 8-byte header |
 | 4 | TCP | `TCP` | RFC 9293, data-offset/options aware |
@@ -125,9 +129,6 @@ network traffic monitor built on it.
 
 ## Roadmap
 
-- IPv6 extension headers (hop-by-hop, routing, fragment, destination
-  options) — today the decode chain ends at `IPv6` for traffic behind
-  them (e.g. MLD).
 - 802.1Q VLAN tags, DNS, DHCP, IGMP, GRE.
 - Checksum computation on encode and verification flags on decode.
 - Fuzzing of the decode path.

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -16,6 +16,12 @@ from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
 from netprotocols.layer3.ip import IPv4, IPv6
+from netprotocols.layer3.ipv6_ext import (
+    IPv6DestinationOptions,
+    IPv6Fragment,
+    IPv6HopByHopOptions,
+    IPv6Routing,
+)
 from netprotocols.layer4.tcp import TCP
 from netprotocols.layer4.udp import UDP
 from netprotocols.packet import Packet
@@ -45,6 +51,10 @@ __all__ = [
     "IPProtocol",
     "IPv4",
     "IPv6",
+    "IPv6DestinationOptions",
+    "IPv6Fragment",
+    "IPv6HopByHopOptions",
+    "IPv6Routing",
     "InvalidFieldError",
     "InvalidIPv4AddressError",
     "InvalidMACAddressError",

--- a/src/netprotocols/_enums.py
+++ b/src/netprotocols/_enums.py
@@ -36,11 +36,15 @@ class IPProtocol(IntEnum):
     ``next_header``, so a single registry serves both.
     """
 
+    HOPOPT = 0x00
     ICMP = 0x01
     IGMP = 0x02
     TCP = 0x06
     UDP = 0x11
+    IPV6_ROUTE = 0x2B
+    IPV6_FRAG = 0x2C
     IPV6_ICMP = 0x3A
+    IPV6_DSTOPTS = 0x3C
 
     @property
     def display_name(self) -> str:
@@ -48,11 +52,15 @@ class IPProtocol(IntEnum):
 
 
 _IP_PROTOCOL_NAMES = {
+    IPProtocol.HOPOPT: "IPv6 Hop-by-Hop Options",
     IPProtocol.ICMP: "ICMP",
     IPProtocol.IGMP: "IGMP",
     IPProtocol.TCP: "TCP",
     IPProtocol.UDP: "UDP",
+    IPProtocol.IPV6_ROUTE: "IPv6 Routing",
+    IPProtocol.IPV6_FRAG: "IPv6 Fragment",
     IPProtocol.IPV6_ICMP: "IPv6-ICMP",
+    IPProtocol.IPV6_DSTOPTS: "IPv6 Destination Options",
 }
 
 

--- a/src/netprotocols/layer3/__init__.py
+++ b/src/netprotocols/layer3/__init__.py
@@ -1,4 +1,19 @@
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
 from netprotocols.layer3.ip import IPv4, IPv6
+from netprotocols.layer3.ipv6_ext import (
+    IPv6DestinationOptions,
+    IPv6Fragment,
+    IPv6HopByHopOptions,
+    IPv6Routing,
+)
 
-__all__ = ["ICMPv4", "ICMPv6", "IPv4", "IPv6"]
+__all__ = [
+    "ICMPv4",
+    "ICMPv6",
+    "IPv4",
+    "IPv6",
+    "IPv6DestinationOptions",
+    "IPv6Fragment",
+    "IPv6HopByHopOptions",
+    "IPv6Routing",
+]

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -23,20 +23,48 @@ from netprotocols.utils.ipv4 import validate_ipv4_addr
 __all__ = ["IPv4", "IPv6"]
 
 
-def _ip_protocol_class(number: int) -> type[Protocol] | None:
+#: Numbers that only make sense inside an IPv6 chain (RFC 8200 §4.1):
+#: extension headers follow the IPv6 fixed header or one another, never
+#: an IPv4 header.
+_IPV6_ONLY_NUMBERS = frozenset(
+    {
+        IPProtocol.HOPOPT,
+        IPProtocol.IPV6_ROUTE,
+        IPProtocol.IPV6_FRAG,
+        IPProtocol.IPV6_DSTOPTS,
+    }
+)
+
+
+def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
     """Map an IP protocol number to the class that decodes its payload.
 
     The number space is shared between IPv4 ``protocol`` and IPv6
     ``next_header`` (the values are disjoint), so both classes dispatch
-    through this single registry.
+    through this single registry — but the IPv6 extension headers are
+    handed out only when the caller is part of an IPv6 chain
+    (``ipv6=True``): a garbage IPv4 packet with ``protocol=0`` must not
+    decode a Hop-by-Hop layer.
     """
     from netprotocols.layer3.icmp import ICMPv4, ICMPv6
+    from netprotocols.layer3.ipv6_ext import (
+        IPv6DestinationOptions,
+        IPv6Fragment,
+        IPv6HopByHopOptions,
+        IPv6Routing,
+    )
     from netprotocols.layer4.tcp import TCP
     from netprotocols.layer4.udp import UDP
 
+    if not ipv6 and number in _IPV6_ONLY_NUMBERS:
+        return None
     mapping: dict[int, type[Protocol]] = {
+        IPProtocol.HOPOPT: IPv6HopByHopOptions,
         IPProtocol.ICMP: ICMPv4,
+        IPProtocol.IPV6_ROUTE: IPv6Routing,
+        IPProtocol.IPV6_FRAG: IPv6Fragment,
         IPProtocol.IPV6_ICMP: ICMPv6,
+        IPProtocol.IPV6_DSTOPTS: IPv6DestinationOptions,
         IPProtocol.TCP: TCP,
         IPProtocol.UDP: UDP,
     }
@@ -180,7 +208,7 @@ class IPv4(Protocol):
         """
         if self.fragment_offset > 0:
             return None
-        return _ip_protocol_class(self.protocol)
+        return _ip_protocol_class(self.protocol, ipv6=False)
 
     @property
     def protocol_name(self) -> str:
@@ -258,7 +286,7 @@ class IPv6(Protocol):
         )
 
     def next_protocol(self) -> type[Protocol] | None:
-        return _ip_protocol_class(self.next_header)
+        return _ip_protocol_class(self.next_header, ipv6=True)
 
     @property
     def next_header_name(self) -> str:

--- a/src/netprotocols/layer3/ipv6_ext.py
+++ b/src/netprotocols/layer3/ipv6_ext.py
@@ -1,0 +1,253 @@
+"""IPv6 extension headers (RFC 8200 §4.3-4.6).
+
+Extension headers sit between the IPv6 fixed header and the upper-layer
+protocol, each naming what follows via ``next_header`` — so they chain
+exactly like every other protocol in this library. They are valid only
+inside an IPv6 chain: the shared protocol-number registry dispatches to
+these classes exclusively when asked by IPv6 or by another extension
+header (see ``_ip_protocol_class``).
+
+The TLV-shaped headers (Hop-by-Hop Options, Routing, Destination
+Options) declare their own length in ``hdr_ext_len``, counted in
+8-octet units *excluding* the first 8; the Fragment header is a fixed
+8 bytes. Option/data contents are kept as raw ``bytes`` — TLV parsing
+inside options is deliberately out of scope for now.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from struct import Struct
+from typing import ClassVar, Self
+
+from netprotocols._base import Protocol
+from netprotocols.utils.exceptions import (
+    InvalidFieldError,
+    TruncatedHeaderError,
+)
+
+__all__ = [
+    "IPv6DestinationOptions",
+    "IPv6Fragment",
+    "IPv6HopByHopOptions",
+    "IPv6Routing",
+]
+
+
+def _next_in_ipv6_chain(number: int) -> type[Protocol] | None:
+    from netprotocols.layer3.ip import _ip_protocol_class
+
+    return _ip_protocol_class(number, ipv6=True)
+
+
+def _next_header_name(number: int) -> str:
+    from netprotocols.layer3.ip import _ip_protocol_name
+
+    return _ip_protocol_name(number)
+
+
+@dataclass(frozen=True, slots=True)
+class _IPv6OptionsHeader(Protocol):
+    """Shared shape of the TLV-style extension headers.
+
+    :param next_header: Protocol number of what follows this header.
+    :param hdr_ext_len: Header length in 8-octet units, excluding the
+        first 8 octets; must equal ``(len(options) - 6) // 8``.
+    :param options: The header's remaining bytes (TLV-encoded options),
+        exactly ``6 + hdr_ext_len * 8`` bytes.
+    """
+
+    next_header: int
+    hdr_ext_len: int
+    options: bytes
+
+    _struct: ClassVar[Struct] = Struct("!BB")
+
+    def __post_init__(self) -> None:
+        expected = 6 + self.hdr_ext_len * 8
+        if len(self.options) != expected:
+            raise InvalidFieldError(
+                f"{self.__class__.__name__} hdr_ext_len {self.hdr_ext_len} "
+                f"disagrees with options length {len(self.options)} "
+                f"(expected {expected} bytes)"
+            )
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        next_header, hdr_ext_len = cls._unpack_fixed(data)
+        declared = (hdr_ext_len + 1) * 8
+        if declared > len(data):
+            raise TruncatedHeaderError(
+                f"{cls.__name__} declares {declared} bytes, buffer holds "
+                f"{len(data)}"
+            )
+        return cls(
+            next_header=next_header,
+            hdr_ext_len=hdr_ext_len,
+            options=bytes(data[cls._struct.size : declared]),
+        )
+
+    def __bytes__(self) -> bytes:
+        return (
+            self._struct.pack(self.next_header, self.hdr_ext_len) + self.options
+        )
+
+    @property
+    def header_len(self) -> int:
+        return (self.hdr_ext_len + 1) * 8
+
+    def next_protocol(self) -> type[Protocol] | None:
+        return _next_in_ipv6_chain(self.next_header)
+
+    @property
+    def next_header_name(self) -> str:
+        """Display name of what follows, e.g. ``"IPv6-ICMP"``."""
+        return _next_header_name(self.next_header)
+
+
+@dataclass(frozen=True, slots=True)
+class IPv6HopByHopOptions(_IPv6OptionsHeader):
+    """The Hop-by-Hop Options header (RFC 8200 §4.3), protocol 0.
+
+    Examined by every node along the path; MLD reports ride behind one
+    (carrying a Router Alert option).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class IPv6DestinationOptions(_IPv6OptionsHeader):
+    """The Destination Options header (RFC 8200 §4.6), protocol 60."""
+
+
+@dataclass(frozen=True, slots=True)
+class IPv6Routing(Protocol):
+    """The Routing header (RFC 8200 §4.4), protocol 43.
+
+    :param next_header: Protocol number of what follows this header.
+    :param hdr_ext_len: Header length in 8-octet units, excluding the
+        first 8; must equal ``(len(data) - 4) // 8``.
+    :param routing_type: Routing variant (e.g. 2 for Mobile IPv6,
+        3 for RPL source routing).
+    :param segments_left: Route segments still to be visited.
+    :param data: Type-specific data, exactly ``4 + hdr_ext_len * 8``
+        bytes.
+    """
+
+    next_header: int
+    hdr_ext_len: int
+    routing_type: int
+    segments_left: int
+    data: bytes
+
+    _struct: ClassVar[Struct] = Struct("!BBBB")
+
+    def __post_init__(self) -> None:
+        expected = 4 + self.hdr_ext_len * 8
+        if len(self.data) != expected:
+            raise InvalidFieldError(
+                f"IPv6Routing hdr_ext_len {self.hdr_ext_len} disagrees "
+                f"with data length {len(self.data)} (expected {expected} "
+                f"bytes)"
+            )
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        next_header, hdr_ext_len, routing_type, segments_left = (
+            cls._unpack_fixed(data)
+        )
+        declared = (hdr_ext_len + 1) * 8
+        if declared > len(data):
+            raise TruncatedHeaderError(
+                f"IPv6Routing declares {declared} bytes, buffer holds "
+                f"{len(data)}"
+            )
+        return cls(
+            next_header=next_header,
+            hdr_ext_len=hdr_ext_len,
+            routing_type=routing_type,
+            segments_left=segments_left,
+            data=bytes(data[cls._struct.size : declared]),
+        )
+
+    def __bytes__(self) -> bytes:
+        return (
+            self._struct.pack(
+                self.next_header,
+                self.hdr_ext_len,
+                self.routing_type,
+                self.segments_left,
+            )
+            + self.data
+        )
+
+    @property
+    def header_len(self) -> int:
+        return (self.hdr_ext_len + 1) * 8
+
+    def next_protocol(self) -> type[Protocol] | None:
+        return _next_in_ipv6_chain(self.next_header)
+
+    @property
+    def next_header_name(self) -> str:
+        """Display name of what follows, e.g. ``"TCP"``."""
+        return _next_header_name(self.next_header)
+
+
+@dataclass(frozen=True, slots=True)
+class IPv6Fragment(Protocol):
+    """The Fragment header (RFC 8200 §4.5), protocol 44 — fixed 8 bytes.
+
+    :param next_header: Protocol number of the *reassembled* payload.
+    :param reserved: Reserved byte, carried verbatim.
+    :param fragment_offset: Offset of this fragment's data in 8-octet
+        units (13 bits).
+    :param res: Reserved 2-bit field, carried verbatim.
+    :param m_flag: 1 when more fragments follow, 0 on the last one.
+    :param identification: Fragment-group identification value.
+    """
+
+    next_header: int
+    reserved: int
+    fragment_offset: int
+    res: int
+    m_flag: int
+    identification: int
+
+    _struct: ClassVar[Struct] = Struct("!BBHI")
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        next_header, reserved, offset_res_m, identification = cls._unpack_fixed(
+            data
+        )
+        return cls(
+            next_header=next_header,
+            reserved=reserved,
+            fragment_offset=offset_res_m >> 3,
+            res=(offset_res_m >> 1) & 0b11,
+            m_flag=offset_res_m & 1,
+            identification=identification,
+        )
+
+    def __bytes__(self) -> bytes:
+        return self._struct.pack(
+            self.next_header,
+            self.reserved,
+            (self.fragment_offset << 3) | (self.res << 1) | self.m_flag,
+            self.identification,
+        )
+
+    def next_protocol(self) -> type[Protocol] | None:
+        """See :meth:`Protocol.next_protocol`.
+
+        Only the first fragment (``fragment_offset == 0``) starts with
+        the upper-layer header; the chain ends here for all others.
+        """
+        if self.fragment_offset > 0:
+            return None
+        return _next_in_ipv6_chain(self.next_header)
+
+    @property
+    def next_header_name(self) -> str:
+        """Display name of the reassembled payload's protocol."""
+        return _next_header_name(self.next_header)

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -1,0 +1,177 @@
+"""IPv6 extension headers (RFC 8200 §4.3-4.6), driven by corpus frames."""
+
+import pytest
+
+from conftest import FIXTURES, read_pcap
+from netprotocols import (
+    Ethernet,
+    ICMPv6,
+    InvalidFieldError,
+    IPProtocol,
+    IPv4,
+    IPv6,
+    IPv6DestinationOptions,
+    IPv6Fragment,
+    IPv6HopByHopOptions,
+    IPv6Routing,
+    TruncatedHeaderError,
+)
+from test_corpus import walk
+
+
+class TestMLDBehindHopByHop:
+    """The flagship corpus scenario: MLD reports ride behind a
+    hop-by-hop header carrying a Router Alert option."""
+
+    def frames(self) -> list[bytes]:
+        return read_pcap(FIXTURES / "ipv6_mld.pcap")
+
+    def test_chain_reaches_icmpv6_through_the_extension_header(self):
+        for frame in self.frames():
+            layers, _ = walk(frame)
+            assert [type(layer) for layer in layers] == [
+                Ethernet,
+                IPv6,
+                IPv6HopByHopOptions,
+                ICMPv6,
+            ]
+
+    def test_hop_by_hop_fields(self):
+        layers, _ = walk(self.frames()[0])
+        hbh = layers[2]
+        assert isinstance(hbh, IPv6HopByHopOptions)
+        assert hbh.hdr_ext_len == 0
+        assert hbh.header_len == 8
+        assert hbh.next_header == IPProtocol.IPV6_ICMP
+        assert hbh.next_header_name == "IPv6-ICMP"
+        # Router Alert option (type 5, length 2, value 0 = MLD).
+        assert hbh.options[:4] == b"\x05\x02\x00\x00"
+
+    def test_mld_message_types(self):
+        types = {walk(frame)[0][3].type for frame in self.frames()}
+        # MLDv2 Listener Report (143) and/or v1 report/done (131/132).
+        assert types <= {130, 131, 132, 143}
+        assert types
+
+
+class TestFragmentHeader:
+    def fragments(self) -> list[IPv6Fragment]:
+        frames = read_pcap(FIXTURES / "ipv6_fragments.pcap")
+        out = []
+        for frame in frames:
+            layers, _ = walk(frame)
+            assert type(layers[2]) is IPv6Fragment
+            out.append(layers[2])
+        return out
+
+    def test_corpus_contains_first_and_non_first_fragments(self):
+        offsets = {fragment.fragment_offset for fragment in self.fragments()}
+        assert 0 in offsets
+        assert any(offset > 0 for offset in offsets)
+
+    def test_first_fragments_chain_to_icmpv6(self):
+        for fragment in self.fragments():
+            if fragment.fragment_offset == 0:
+                assert fragment.next_protocol() is ICMPv6
+                assert fragment.m_flag == 1
+
+    def test_non_first_fragments_do_not_chain(self):
+        for fragment in self.fragments():
+            if fragment.fragment_offset > 0:
+                assert fragment.next_protocol() is None
+
+    def test_fragment_group_shares_identification(self):
+        fragments = self.fragments()
+        assert len({f.identification for f in fragments}) < len(fragments)
+
+
+class TestDecodeContract:
+    RAW_HBH = b"\x3a\x00\x05\x02\x00\x00\x01\x00"  # from the MLD corpus shape
+
+    def test_round_trip(self):
+        for cls in (IPv6HopByHopOptions, IPv6DestinationOptions):
+            header = cls.decode(self.RAW_HBH)
+            assert bytes(header) == self.RAW_HBH
+            assert cls.decode(bytes(header)) == header
+
+    def test_routing_round_trip(self):
+        raw = b"\x3a\x00\x03\x01" + b"\x00" * 4
+        routing = IPv6Routing.decode(raw)
+        assert routing.routing_type == 3
+        assert routing.segments_left == 1
+        assert bytes(routing) == raw
+
+    def test_fragment_round_trip_preserves_reserved_bits(self):
+        raw = b"\x3a\xa5\x01\x5b\xde\xad\xbe\xef"
+        fragment = IPv6Fragment.decode(raw)
+        assert fragment.reserved == 0xA5
+        assert fragment.fragment_offset == 0x15B >> 3
+        assert fragment.res == 0b01
+        assert fragment.m_flag == 1
+        assert bytes(fragment) == raw
+
+    def test_trailing_bytes_tolerated(self):
+        header = IPv6HopByHopOptions.decode(self.RAW_HBH + b"payload")
+        assert header.header_len == 8
+
+    def test_lying_hdr_ext_len_raises(self):
+        lying = b"\x3a\x02" + b"\x00" * 6  # declares 24 bytes, holds 8
+        with pytest.raises(TruncatedHeaderError):
+            IPv6HopByHopOptions.decode(lying)
+
+    def test_truncated_fixed_header_raises(self):
+        with pytest.raises(TruncatedHeaderError):
+            IPv6Fragment.decode(b"\x3a\x00\x00")
+
+    def test_options_length_invariant(self):
+        with pytest.raises(InvalidFieldError):
+            IPv6HopByHopOptions(
+                next_header=58, hdr_ext_len=1, options=b"\x00" * 6
+            )
+        with pytest.raises(InvalidFieldError):
+            IPv6Routing(
+                next_header=58,
+                hdr_ext_len=0,
+                routing_type=3,
+                segments_left=0,
+                data=b"\x00" * 12,
+            )
+
+
+class TestRegistryGating:
+    def test_ipv4_never_dispatches_extension_headers(self, raw_ipv4_header):
+        for number in (0, 43, 44, 60):
+            garbage = (
+                b"\x45"
+                + raw_ipv4_header[1:9]
+                + bytes([number])
+                + raw_ipv4_header[10:]
+            )
+            assert IPv4.decode(garbage).next_protocol() is None
+
+    def test_ipv6_dispatches_extension_headers(self, raw_ipv6_header):
+        expected = {
+            0: IPv6HopByHopOptions,
+            43: IPv6Routing,
+            44: IPv6Fragment,
+            60: IPv6DestinationOptions,
+        }
+        for number, cls in expected.items():
+            frame = raw_ipv6_header[:6] + bytes([number]) + raw_ipv6_header[7:]
+            assert IPv6.decode(frame).next_protocol() is cls
+
+    def test_extension_headers_chain_among_themselves(self):
+        dst_opts = IPv6HopByHopOptions(
+            next_header=60, hdr_ext_len=0, options=b"\x01\x04\x00\x00\x00\x00"
+        )
+        assert dst_opts.next_protocol() is IPv6DestinationOptions
+
+
+class TestEnumCompleteness:
+    def test_every_ip_protocol_member_has_a_display_name(self):
+        for member in IPProtocol:
+            assert member.display_name
+
+    def test_extension_header_display_names(self):
+        assert IPProtocol.HOPOPT.display_name == "IPv6 Hop-by-Hop Options"
+        assert IPProtocol.IPV6_FRAG.display_name == "IPv6 Fragment"


### PR DESCRIPTION
Milestone v1.1, item L-1. Hop-by-Hop / Routing / Fragment / Destination Options with chain-aware registry gating and first-fragment-only chaining; driven by the corpus MLD and fragment fixtures. 304 tests, mypy strict, ruff clean.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)