### PR TITLE
Checksum computation and verification

### DIFF
--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -12,6 +12,7 @@ from netprotocols._enums import (
     EtherType,
     IPProtocol,
 )
+from netprotocols.checksum import compute, internet_checksum, verify
 from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
@@ -64,7 +65,10 @@ __all__ = [
     "ProtocolError",
     "TruncatedHeaderError",
     "__version__",
+    "compute",
+    "internet_checksum",
     "random_mac",
     "validate_ipv4_addr",
     "validate_mac_addr",
+    "verify",
 ]

--- a/src/netprotocols/checksum.py
+++ b/src/netprotocols/checksum.py
@@ -1,0 +1,158 @@
+"""Internet checksum computation and verification (RFC 1071).
+
+The primitive, :func:`internet_checksum`, returns the raw ones'-
+complement result — ``0x0000`` is a legal return value, and TCP, ICMP,
+and the IPv4 header checksum legitimately transmit it. The famous
+``0x0000 → 0xFFFF`` substitution is a **UDP-only transmit rule**
+(RFC 768; RFC 8200 §8.1) and lives solely in the UDP arm of
+:func:`compute`.
+
+Length fields are trusted, not reconciled: UDP uses ``layer.length``
+for the pseudo-header, TCP uses ``layer.header_len + len(payload)``,
+and nothing checks ``IPv4.total_length`` against the payload you pass.
+Feed these helpers the payload exactly as it appears on the wire.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from netprotocols._base import (
+    Protocol,
+    ipv4_to_bytes,
+    ipv6_to_bytes,
+)
+from netprotocols._enums import IPProtocol
+from netprotocols.layer3.icmp import ICMPv4, ICMPv6
+from netprotocols.layer3.ip import IPv4, IPv6
+from netprotocols.layer4.tcp import TCP
+from netprotocols.layer4.udp import UDP
+from netprotocols.utils.exceptions import InvalidFieldError
+
+__all__ = ["compute", "internet_checksum", "verify"]
+
+
+def internet_checksum(data: bytes | memoryview) -> int:
+    """The RFC 1071 checksum of ``data``: the ones' complement of the
+    ones'-complement sum of its 16-bit words (odd lengths are padded
+    with a zero byte).
+
+    Returns the raw result: ``0x0000`` is a legal value here. Protocol
+    rules such as UDP's zero substitution belong to :func:`compute`.
+    """
+    if len(data) % 2:
+        data = bytes(data) + b"\x00"
+    words: tuple[int, ...] = struct.unpack(f"!{len(data) // 2}H", data)
+    total = sum(words)
+    while total >> 16:
+        total = (total & 0xFFFF) + (total >> 16)
+    return ~total & 0xFFFF
+
+
+def _pseudo_header(ip: IPv4 | IPv6, protocol: int, length: int) -> bytes:
+    """The pseudo-header prepended to transport checksums.
+
+    IPv4 (RFC 793/768): src, dst, zero byte, protocol, 16-bit length.
+    IPv6 (RFC 8200 §8.1): src, dst, 32-bit length, three zero bytes,
+    next-header.
+    """
+    if isinstance(ip, IPv4):
+        return (
+            ipv4_to_bytes(ip.src)
+            + ipv4_to_bytes(ip.dst)
+            + struct.pack("!BBH", 0, protocol, length)
+        )
+    return (
+        ipv6_to_bytes(ip.src)
+        + ipv6_to_bytes(ip.dst)
+        + struct.pack("!IBBBB", length, 0, 0, 0, protocol)
+    )
+
+
+def _require_ip(layer: Protocol, ip: IPv4 | IPv6 | None) -> IPv4 | IPv6:
+    if ip is None:
+        raise InvalidFieldError(
+            f"Computing a {type(layer).__name__} checksum requires the "
+            f"enclosing IPv4/IPv6 layer (its pseudo-header covers the "
+            f"addresses)"
+        )
+    return ip
+
+
+def _zeroed(layer_bytes: bytes, checksum_offset: int) -> bytes:
+    return (
+        layer_bytes[:checksum_offset]
+        + b"\x00\x00"
+        + layer_bytes[checksum_offset + 2 :]
+    )
+
+
+def compute(
+    layer: Protocol,
+    *,
+    ip: IPv4 | IPv6 | None = None,
+    payload: bytes = b"",
+) -> int:
+    """The correct checksum field value for ``layer``.
+
+    :param layer: The header to checksum. ``IPv4`` covers its own
+        header only (options included; ``ip``/``payload`` ignored);
+        ``ICMPv4`` covers header plus ``payload`` (no pseudo-header);
+        ``TCP``, ``UDP``, and ``ICMPv6`` prepend the pseudo-header
+        built from ``ip``.
+    :param ip: The enclosing IP layer, required for TCP/UDP/ICMPv6.
+    :param payload: The bytes following ``layer`` on the wire.
+    :raises InvalidFieldError: For layers without a checksum field, or
+        a missing ``ip`` where the pseudo-header needs one.
+    """
+    if isinstance(layer, IPv4):
+        return internet_checksum(_zeroed(bytes(layer), 10))
+    if isinstance(layer, ICMPv4):
+        return internet_checksum(_zeroed(bytes(layer), 2) + payload)
+    if isinstance(layer, ICMPv6):
+        enclosing = _require_ip(layer, ip)
+        segment = _zeroed(bytes(layer), 2) + payload
+        return internet_checksum(
+            _pseudo_header(enclosing, IPProtocol.IPV6_ICMP, len(segment))
+            + segment
+        )
+    if isinstance(layer, TCP):
+        enclosing = _require_ip(layer, ip)
+        segment = _zeroed(bytes(layer), 16) + payload
+        return internet_checksum(
+            _pseudo_header(enclosing, IPProtocol.TCP, len(segment)) + segment
+        )
+    if isinstance(layer, UDP):
+        enclosing = _require_ip(layer, ip)
+        datagram = _zeroed(bytes(layer), 6) + payload
+        raw = internet_checksum(
+            _pseudo_header(enclosing, IPProtocol.UDP, layer.length) + datagram
+        )
+        # UDP-only transmit rule: 0 means "no checksum", so a computed
+        # 0x0000 is sent as 0xFFFF (RFC 768; mandatory path RFC 8200).
+        return raw or 0xFFFF
+    raise InvalidFieldError(
+        f"{type(layer).__name__} has no checksum field to compute"
+    )
+
+
+def verify(
+    layer: Protocol,
+    *,
+    ip: IPv4 | IPv6 | None = None,
+    payload: bytes = b"",
+) -> bool:
+    """Whether ``layer``'s checksum field matches a recomputation.
+
+    A UDP-over-IPv4 checksum of ``0`` means "no checksum in use" and
+    verifies as True (over IPv6 the checksum is mandatory and ``0`` is
+    invalid).
+    """
+    if (
+        isinstance(layer, UDP)
+        and layer.checksum == 0
+        and not isinstance(ip, IPv6)
+    ):
+        return True
+    wire: int = layer.checksum  # type: ignore[attr-defined]
+    return compute(layer, ip=ip, payload=payload) == wire

--- a/src/netprotocols/packet.py
+++ b/src/netprotocols/packet.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from typing import Self
+
 from netprotocols._base import Protocol
 from netprotocols.utils.exceptions import InvalidFieldError
 
@@ -46,3 +49,40 @@ class Packet:
     def payload(self) -> bytes:
         """The serialized form of all layers, outermost first."""
         return bytes(self)
+
+    def with_checksums(self, payload: bytes = b"") -> Self:
+        """A copy of this packet with every checksum field computed.
+
+        Layers are processed innermost-first so each transport checksum
+        covers the final bytes of everything that follows it; ``payload``
+        is whatever comes after the last layer on the wire. Instances
+        are frozen, so layers are rebuilt via :func:`dataclasses.replace`.
+        """
+        from netprotocols.checksum import compute
+        from netprotocols.layer3.icmp import ICMPv4, ICMPv6
+        from netprotocols.layer3.ip import IPv4, IPv6
+        from netprotocols.layer4.tcp import TCP
+        from netprotocols.layer4.udp import UDP
+
+        rebuilt: list[Protocol] = []
+        trailing = payload
+        for index in range(len(self.layers) - 1, -1, -1):
+            layer = self.layers[index]
+            if isinstance(layer, (TCP, UDP, ICMPv6, ICMPv4)):
+                enclosing = next(
+                    (
+                        candidate
+                        for candidate in reversed(self.layers[:index])
+                        if isinstance(candidate, (IPv4, IPv6))
+                    ),
+                    None,
+                )
+                layer = replace(
+                    layer,
+                    checksum=compute(layer, ip=enclosing, payload=trailing),
+                )
+            elif isinstance(layer, IPv4):
+                layer = replace(layer, checksum=compute(layer))
+            rebuilt.append(layer)
+            trailing = bytes(layer) + trailing
+        return type(self)(*reversed(rebuilt))

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,0 +1,239 @@
+"""Checksum computation and verification, held to the wire by the
+real-capture corpus: every checksummed inbound frame must recompute to
+its captured value."""
+
+import pytest
+
+from conftest import corpus_frames
+from netprotocols import (
+    ARP,
+    TCP,
+    UDP,
+    Ethernet,
+    ICMPv4,
+    ICMPv6,
+    InvalidFieldError,
+    IPv4,
+    IPv6,
+    IPv6Fragment,
+    Packet,
+    compute,
+    internet_checksum,
+    verify,
+)
+from test_corpus import walk
+
+CORPUS = corpus_frames()
+
+
+def transport_cases():
+    """Every corpus frame whose transport checksum is verifiable:
+    (ids, layer, enclosing ip, wire payload). Fragmented traffic is
+    excluded — those checksums span the reassembled datagram."""
+    cases = []
+    for name, index, frame in CORPUS:
+        layers, consumed = walk(frame)
+        if any(isinstance(layer, IPv6Fragment) for layer in layers):
+            continue
+        ip = next(
+            (layer for layer in layers if isinstance(layer, (IPv4, IPv6))),
+            None,
+        )
+        if ip is None:
+            continue
+        if isinstance(ip, IPv4) and (
+            ip.fragment_offset > 0 or ip.flags & 0b001
+        ):
+            continue  # any fragment: the checksum spans the reassembly
+        transport = layers[-1]
+        if not isinstance(transport, (TCP, UDP, ICMPv4, ICMPv6)):
+            continue
+        # The wire payload ends at the IP datagram's declared length.
+        if isinstance(ip, IPv4):
+            end = 14 + ip.total_length
+        else:
+            end = 14 + ip.header_len + ip.payload_length
+        cases.append((f"{name}#{index}", transport, ip, frame[consumed:end]))
+    return cases
+
+
+CASES = transport_cases()
+
+
+class TestCorpusChecksums:
+    def test_corpus_offers_all_five_checksum_cases(self):
+        kinds = {type(transport) for _, transport, _, _ in CASES}
+        assert {TCP, UDP, ICMPv4, ICMPv6} <= kinds
+        assert any(isinstance(ip, IPv4) for _, _, ip, _ in CASES)
+        assert any(isinstance(ip, IPv6) for _, _, ip, _ in CASES)
+
+    @pytest.mark.parametrize(
+        "transport,ip,payload",
+        [case[1:] for case in CASES],
+        ids=[case[0] for case in CASES],
+    )
+    def test_transport_checksums_recompute_to_wire_values(
+        self, transport, ip, payload
+    ):
+        assert compute(transport, ip=ip, payload=payload) == (
+            transport.checksum
+        )
+        assert verify(transport, ip=ip, payload=payload)
+
+    def test_ipv4_header_checksums_recompute_to_wire_values(self):
+        headers = [
+            layer
+            for _, _, frame in CORPUS
+            for layer in walk(frame)[0]
+            if isinstance(layer, IPv4)
+        ]
+        assert headers
+        for header in headers:
+            assert compute(header) == header.checksum
+            assert verify(header)
+
+    def test_corrupted_byte_is_detected(self):
+        _, transport, ip, payload = CASES[0]
+        corrupted = (
+            payload[:-1] + bytes([payload[-1] ^ 0xFF]) if payload else b"\x01"
+        )
+        assert not verify(transport, ip=ip, payload=corrupted)
+
+
+class TestChecksumRules:
+    def make_udp(self, checksum: int) -> tuple[UDP, IPv4]:
+        udp = UDP(src_port=53, dst_port=4242, length=12, checksum=checksum)
+        ip = IPv4(
+            version=4,
+            ihl=5,
+            dscp=0,
+            ecn=0,
+            total_length=32,
+            identification=1,
+            flags=2,
+            fragment_offset=0,
+            ttl=64,
+            protocol=17,
+            checksum=0,
+            src="192.0.2.1",
+            dst="192.0.2.2",
+        )
+        return udp, ip
+
+    def test_udp_zero_checksum_means_not_used_over_ipv4(self):
+        udp, ip = self.make_udp(0)
+        assert verify(udp, ip=ip, payload=b"1234")
+
+    def test_udp_never_computes_zero(self):
+        """Search for a payload whose raw sum folds to 0xFFFF: the UDP
+        arm must substitute 0xFFFF, never emit 0x0000."""
+        for word in range(0x10000):
+            udp, ip = self.make_udp(0)
+            payload = word.to_bytes(2, "big") + b"\x00\x00"
+            if compute(udp, ip=ip, payload=payload) == 0xFFFF:
+                raw_zero_found = True
+                break
+        else:
+            raw_zero_found = False
+        assert raw_zero_found
+
+    def test_tcp_legitimately_computes_zero(self):
+        """The substitution is UDP-only: for TCP a raw result of 0x0000
+        must be returned as-is (regression against misplacing the rule
+        in the shared primitive)."""
+        base = TCP(
+            src_port=1,
+            dst_port=2,
+            seq=0,
+            ack=0,
+            data_offset=5,
+            reserved=0,
+            flags=0,
+            window=0,
+            checksum=0,
+            urgent_pointer=0,
+        )
+        ip = IPv4(
+            version=4,
+            ihl=5,
+            dscp=0,
+            ecn=0,
+            total_length=44,
+            identification=1,
+            flags=2,
+            fragment_offset=0,
+            ttl=64,
+            protocol=6,
+            checksum=0,
+            src="192.0.2.1",
+            dst="192.0.2.2",
+        )
+        for word in range(0x10000):
+            payload = word.to_bytes(2, "big") + b"\x00\x00"
+            if compute(base, ip=ip, payload=payload) == 0:
+                assert internet_checksum(b"") == 0xFFFF  # sanity: raw API
+                return
+        pytest.fail("no payload drove the TCP checksum to 0x0000")
+
+    def test_pseudo_header_layers_require_ip(self):
+        udp, _ = self.make_udp(0)
+        with pytest.raises(InvalidFieldError):
+            compute(udp)
+
+    def test_layers_without_checksums_are_rejected(self):
+        eth = Ethernet(
+            dst="ff:ff:ff:ff:ff:ff",
+            src="00:07:0d:af:f4:54",
+            ethertype=0x0800,
+        )
+        with pytest.raises(InvalidFieldError):
+            compute(eth)
+
+
+class TestPacketWithChecksums:
+    def test_round_trip_matches_corpus_frame(self):
+        """Rebuild a corpus frame's stack with zeroed checksums; after
+        with_checksums() it must be byte-identical to the wire."""
+        from dataclasses import replace
+
+        name_frame = next(
+            (name, frame) for name, _, frame in CORPUS if name == "udp_dns.pcap"
+        )
+        _, frame = name_frame
+        layers, consumed = walk(frame)
+        ip = layers[1]
+        end = (
+            14 + ip.total_length
+            if isinstance(ip, IPv4)
+            else 14 + ip.header_len + ip.payload_length
+        )
+        payload = frame[consumed:end]
+        zeroed = Packet(
+            layers[0],
+            replace(layers[1], checksum=0)
+            if isinstance(layers[1], IPv4)
+            else layers[1],
+            replace(layers[2], checksum=0),
+        )
+        restored = zeroed.with_checksums(payload)
+        assert bytes(restored) + payload == frame[:end]
+
+    def test_arp_stack_passes_through_unchanged(self):
+        eth = Ethernet(
+            dst="ff:ff:ff:ff:ff:ff",
+            src="00:07:0d:af:f4:54",
+            ethertype=0x0806,
+        )
+        arp = ARP(
+            htype=1,
+            ptype=0x0800,
+            hlen=6,
+            plen=4,
+            oper=1,
+            sha="00:07:0d:af:f4:54",
+            spa="192.0.2.1",
+            tha="00:00:00:00:00:00",
+            tpa="192.0.2.2",
+        )
+        packet = Packet(eth, arp)
+        assert bytes(packet.with_checksums()) == bytes(packet)


### PR DESCRIPTION
Milestone v1.1, item L-2. RFC 1071 primitive + compute()/verify() with IPv4/IPv6 pseudo-headers and Packet.with_checksums(); corpus-verified against captured wire values; UDP-only zero substitution pinned by regression tests.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)