### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-08-29
+
+### Added
+- **IPv6 extension headers** (RFC 8200 §4.3-4.6): `IPv6HopByHopOptions`,
+  `IPv6Routing`, `IPv6Fragment`, `IPv6DestinationOptions`. The decode
+  chain now reaches ICMPv6/TCP/UDP behind them (MLD reports decode
+  fully). Extension headers dispatch only inside an IPv6 chain, and a
+  Fragment header chains onward only from the first fragment.
+- **Checksums** (`netprotocols.checksum`): `internet_checksum()`
+  (RFC 1071), `compute()`/`verify()` covering the IPv4 header checksum,
+  ICMPv4, and TCP/UDP/ICMPv6 with IPv4/IPv6 pseudo-headers, and
+  `Packet.with_checksums()` for filling a whole stack on encode. The
+  UDP-only zero substitution is confined to the UDP arm.
+- **Property-based fuzzing** of the decode path (hypothesis, dev-only):
+  decode() raises nothing outside `ProtocolError` for any input; the
+  chain walk never consumes past the frame; constrained round trips.
+- `IPProtocol` gains `HOPOPT`, `IPV6_ROUTE`, `IPV6_FRAG`,
+  `IPV6_DSTOPTS` with display names.
+
+### Development
+- The real-capture fixture corpus grew to 65 frames across 12
+  scenarios (MLD behind hop-by-hop, IPv6 fragment pairs); checksum
+  tests recompute every verifiable corpus frame to its captured wire
+  value.
+
 ## [1.0.1] - 2026-08-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ frame = Packet(
 raw = bytes(frame)  # ready for a raw socket
 ```
 
-Checksums are carried verbatim in both directions: the library neither
-computes nor verifies them (planned — see the roadmap).
+Checksums are computed and verified on request — never silently:
+`compute()`/`verify()` in `netprotocols.checksum`, and
+`Packet.with_checksums()` to fill a whole stack before sending.
 
 ## Display helpers
 
@@ -130,8 +131,6 @@ network traffic monitor built on it.
 ## Roadmap
 
 - 802.1Q VLAN tags, DNS, DHCP, IGMP, GRE.
-- Checksum computation on encode and verification flags on decode.
-- Fuzzing of the decode path.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netprotocols"
-version = "1.0.1"
+version = "1.1.0"
 description = "Low-level implementations of common networking protocols"
 readme = "README.md"
 license = "MIT"

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -37,7 +37,7 @@ from netprotocols.utils.exceptions import (
 from netprotocols.utils.ipv4 import validate_ipv4_addr
 from netprotocols.utils.mac import random_mac, validate_mac_addr
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 __all__ = [
     "ARP",

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "netprotocols"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Milestone v1.1: IPv6 extension headers, checksum compute/verify, property-based fuzzing, and the 65-frame real-capture corpus. 372 tests, mypy strict, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)