### PR TITLE
Add IEEE 802.1Q VLAN tag support (single tag + QinQ stacking)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,11 @@ flowchart LR
   E[Ethernet] -->|0x0806| A[ARP]
   E -->|0x0800| I4[IPv4]
   E -->|0x86DD| I6[IPv6]
+  E -->|0x8100, 0x88A8, 0x9100| V[VLAN tag]
+  V -->|0x8100, 0x88A8, 0x9100| V
+  V -->|0x0806| A
+  V -->|0x0800| I4
+  V -->|0x86DD| I6
   I4 -->|1| IC4[ICMPv4]
   I4 -->|6| T[TCP]
   I4 -->|17| U[UDP]
@@ -131,6 +136,16 @@ Fragment header chains onward only when `fragment_offset == 0` — a
 non-first fragment carries a slice from the middle of the original
 payload, so no upper-layer header exists at its start. The same
 offset rule applies to fragmented IPv4.
+
+VLAN tags chain the same way: a tag's `next_protocol` dispatches the
+inner EtherType through the same registry Ethernet uses, so a QinQ
+(`0x88A8`) or legacy double-tagged (`0x9100`) frame decodes as one
+`VLAN` layer per tag and the innermost payload (IPv4/IPv6/ARP) chains
+normally. The Tag Control Information word is split into its semantic
+bitfields — `pcp`, `dei`, `vid` — as dataclass fields validated in
+`__post_init__`, with the packed 16-bit view kept as the `tci`
+property (the same pattern `IPv6` uses for `version` /
+`traffic_class` / `flow_label`).
 
 The numbers on the arrows are the wire values — EtherTypes out of
 Ethernet, IP protocol numbers out of IPv4/IPv6 — and they live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **IEEE 802.1Q VLAN tags** (`VLAN`, 802.1Q-2018 §9.6 / 802.1ad QinQ):
+  single and stacked (QinQ `0x88A8`, legacy double-tagged `0x9100`)
+  tags decode as one layer per tag; the Tag Control Information word is
+  split into `pcp`/`dei`/`vid` dataclass fields validated in
+  `__post_init__` (`InvalidFieldError`), with the packed 16-bit view
+  kept as the `tci` property; `VLAN` is registered in the
+  property-based fuzz suite and the `EtherType` display names are
+  covered by the enum completeness test.
+
 ## [1.1.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Requires Python 3.12+. Fully typed (`py.typed`, mypy strict).
 | Layer | Protocol | Class | Notes |
 |---|---|---|---|
 | 2 | Ethernet II | `Ethernet` | IEEE 802.3 |
+| 2 | IEEE 802.1Q VLAN tag (802.1ad QinQ) | `VLAN` | 802.1Q-2018 §9.6, PCP/DEI/VID, tag stacking |
 | 2 | ARP | `ARP` | RFC 826, IPv4-over-Ethernet binding |
 | 3 | IPv4 | `IPv4` | RFC 791, IHL/options aware |
 | 3 | IPv6 | `IPv6` | RFC 8200 |

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -15,6 +15,7 @@ from netprotocols._enums import (
 from netprotocols.checksum import compute, internet_checksum, verify
 from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
+from netprotocols.layer2.vlan import VLAN
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
 from netprotocols.layer3.ip import IPv4, IPv6
 from netprotocols.layer3.ipv6_ext import (
@@ -43,6 +44,7 @@ __all__ = [
     "ARP",
     "TCP",
     "UDP",
+    "VLAN",
     "ARPHardwareType",
     "ARPOperation",
     "EtherType",

--- a/src/netprotocols/_enums.py
+++ b/src/netprotocols/_enums.py
@@ -15,6 +15,9 @@ class EtherType(IntEnum):
 
     IPV4 = 0x0800
     ARP = 0x0806
+    VLAN_TAG = 0x8100
+    VLAN_TAG_QINQ = 0x88A8
+    VLAN_TAG_9100 = 0x9100
     IPV6 = 0x86DD
 
     @property
@@ -25,6 +28,9 @@ class EtherType(IntEnum):
 _ETHERTYPE_NAMES = {
     EtherType.IPV4: "IPv4",
     EtherType.ARP: "ARP",
+    EtherType.VLAN_TAG: "802.1Q VLAN tag",
+    EtherType.VLAN_TAG_QINQ: "802.1ad S-TAG (QinQ)",
+    EtherType.VLAN_TAG_9100: "VLAN double tag (legacy)",
     EtherType.IPV6: "IPv6",
 }
 

--- a/src/netprotocols/layer2/__init__.py
+++ b/src/netprotocols/layer2/__init__.py
@@ -1,4 +1,5 @@
 from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
+from netprotocols.layer2.vlan import VLAN
 
-__all__ = ["ARP", "Ethernet"]
+__all__ = ["ARP", "VLAN", "Ethernet"]

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -10,7 +10,7 @@ from netprotocols._base import Protocol, bytes_to_mac, mac_to_bytes
 from netprotocols._enums import EtherType
 from netprotocols.utils.mac import validate_mac_addr
 
-__all__ = ["Ethernet", "_ethertype_class", "_ethertype_name"]
+__all__ = ["Ethernet"]
 
 #: EtherType values that mark a VLAN tag shim rather than a payload.
 _VLAN_TAG_ETHERTYPES = frozenset(

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -10,7 +10,42 @@ from netprotocols._base import Protocol, bytes_to_mac, mac_to_bytes
 from netprotocols._enums import EtherType
 from netprotocols.utils.mac import validate_mac_addr
 
-__all__ = ["Ethernet"]
+__all__ = ["Ethernet", "_ethertype_class", "_ethertype_name"]
+
+#: EtherType values that mark a VLAN tag shim rather than a payload.
+_VLAN_TAG_ETHERTYPES = frozenset(
+    {EtherType.VLAN_TAG, EtherType.VLAN_TAG_QINQ, EtherType.VLAN_TAG_9100}
+)
+
+
+def _ethertype_class(ethertype: int) -> type[Protocol] | None:
+    """The class that decodes the payload of an Ethernet/VLAN header.
+
+    VLAN tag types dispatch to :class:`~netprotocols.VLAN`, whose own
+    ``next_protocol`` calls back here with the inner EtherType — so
+    stacked tags (QinQ) decode as one VLAN layer per tag.
+    """
+    from netprotocols.layer2.arp import ARP
+    from netprotocols.layer2.vlan import VLAN
+    from netprotocols.layer3.ip import IPv4, IPv6
+
+    if ethertype in _VLAN_TAG_ETHERTYPES:
+        return VLAN
+    mapping: dict[int, type[Protocol]] = {
+        EtherType.ARP: ARP,
+        EtherType.IPV4: IPv4,
+        EtherType.IPV6: IPv6,
+    }
+    return mapping.get(ethertype)
+
+
+def _ethertype_name(ethertype: int) -> str:
+    """Display name of an EtherType, e.g. ``"IPv4"``; falls back to the
+    hexadecimal value for types unknown to this library."""
+    try:
+        return EtherType(ethertype).display_name
+    except ValueError:
+        return f"{ethertype:#06x}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,21 +81,10 @@ class Ethernet(Protocol):
         )
 
     def next_protocol(self) -> type[Protocol] | None:
-        from netprotocols.layer2.arp import ARP
-        from netprotocols.layer3.ip import IPv4, IPv6
-
-        mapping: dict[int, type[Protocol]] = {
-            EtherType.ARP: ARP,
-            EtherType.IPV4: IPv4,
-            EtherType.IPV6: IPv6,
-        }
-        return mapping.get(self.ethertype)
+        return _ethertype_class(self.ethertype)
 
     @property
     def ethertype_name(self) -> str:
         """Display name of the EtherType, e.g. ``"IPv4"``; falls back to
         the hexadecimal value for types unknown to this library."""
-        try:
-            return EtherType(self.ethertype).display_name
-        except ValueError:
-            return f"{self.ethertype:#06x}"
+        return _ethertype_name(self.ethertype)

--- a/src/netprotocols/layer2/vlan.py
+++ b/src/netprotocols/layer2/vlan.py
@@ -1,0 +1,70 @@
+"""IEEE 802.1Q VLAN tag header (802.1Q-2018 §9.6, 802.1ad for QinQ).
+
+A VLAN tag is a 4-byte shim between the Ethernet header and the
+encapsulated frame: a 2-byte Tag Control Information field (PCP + DEI +
+VID) followed by the 2-byte EtherType of the tagged payload. Tags
+chain: a QinQ (0x88A8) or legacy double-tagged (0x9100) frame carries
+an inner tag whose EtherType is again a tag type, so
+``next_protocol`` dispatches recursively and the chain walker sees one
+``VLAN`` layer per tag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from struct import Struct
+from typing import ClassVar, Self
+
+from netprotocols._base import Protocol
+
+__all__ = ["VLAN"]
+
+
+@dataclass(frozen=True, slots=True)
+class VLAN(Protocol):
+    """One 802.1Q / 802.1ad VLAN tag.
+
+    :param tci: Tag Control Information — PCP (3 bits), DEI (1 bit)
+        and VID (12 bits) — carried as the raw 16-bit field.
+    :param ethertype: EtherType of the payload that follows this tag.
+    """
+
+    tci: int
+    ethertype: int
+
+    _struct: ClassVar[Struct] = Struct("!HH")
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        tci, ethertype = cls._unpack_fixed(data)
+        return cls(tci=tci, ethertype=ethertype)
+
+    def __bytes__(self) -> bytes:
+        return self._struct.pack(self.tci, self.ethertype)
+
+    def next_protocol(self) -> type[Protocol] | None:
+        from netprotocols.layer2.ethernet import _ethertype_class
+
+        return _ethertype_class(self.ethertype)
+
+    @property
+    def pcp(self) -> int:
+        """Priority code point (802.1p), 0-7."""
+        return self.tci >> 13
+
+    @property
+    def dei(self) -> int:
+        """Drop eligible indicator, 0-1."""
+        return (self.tci >> 12) & 1
+
+    @property
+    def vid(self) -> int:
+        """VLAN identifier, 0-4094 (0 = priority tag, 0xFFF = wildcard)."""
+        return self.tci & 0xFFF
+
+    @property
+    def ethertype_name(self) -> str:
+        """Display name of the tagged payload's EtherType, e.g. ``"IPv4"``."""
+        from netprotocols.layer2.ethernet import _ethertype_name
+
+        return _ethertype_name(self.ethertype)

--- a/src/netprotocols/layer2/vlan.py
+++ b/src/netprotocols/layer2/vlan.py
@@ -7,6 +7,13 @@ chain: a QinQ (0x88A8) or legacy double-tagged (0x9100) frame carries
 an inner tag whose EtherType is again a tag type, so
 ``next_protocol`` dispatches recursively and the chain walker sees one
 ``VLAN`` layer per tag.
+
+Following the house pattern (``IPv6`` stores ``version`` /
+``traffic_class`` / ``flow_label``, not the raw first word), the TCI
+bitfields are materialized as dataclass fields — ``pcp``, ``dei``,
+``vid`` — so serialization surfaces the semantic parts instead of an
+opaque integer. The packed 16-bit view remains available as the
+``tci`` property.
 """
 
 from __future__ import annotations
@@ -16,6 +23,7 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol
+from netprotocols.utils.exceptions import InvalidFieldError
 
 __all__ = ["VLAN"]
 
@@ -24,43 +32,54 @@ __all__ = ["VLAN"]
 class VLAN(Protocol):
     """One 802.1Q / 802.1ad VLAN tag.
 
-    :param tci: Tag Control Information — PCP (3 bits), DEI (1 bit)
-        and VID (12 bits) — carried as the raw 16-bit field.
+    :param pcp: Priority code point (802.1p), ``0``-``7``.
+    :param dei: Drop eligible indicator, ``0`` or ``1``.
+    :param vid: VLAN identifier, ``0``-``4095`` (``0`` = priority tag,
+        ``0xFFF`` = wildcard).
     :param ethertype: EtherType of the payload that follows this tag.
     """
 
-    tci: int
+    pcp: int
+    dei: int
+    vid: int
     ethertype: int
 
     _struct: ClassVar[Struct] = Struct("!HH")
 
+    def __post_init__(self) -> None:
+        if not 0 <= self.pcp <= 7:
+            raise InvalidFieldError(
+                f"VLAN PCP must be within 0-7, got {self.pcp}"
+            )
+        if self.dei not in (0, 1):
+            raise InvalidFieldError(f"VLAN DEI must be 0 or 1, got {self.dei}")
+        if not 0 <= self.vid <= 0xFFF:
+            raise InvalidFieldError(
+                f"VLAN VID must be within 0-4095, got {self.vid}"
+            )
+
     @classmethod
     def decode(cls, data: bytes | memoryview) -> Self:
         tci, ethertype = cls._unpack_fixed(data)
-        return cls(tci=tci, ethertype=ethertype)
+        return cls(
+            pcp=tci >> 13,
+            dei=(tci >> 12) & 1,
+            vid=tci & 0xFFF,
+            ethertype=ethertype,
+        )
 
     def __bytes__(self) -> bytes:
         return self._struct.pack(self.tci, self.ethertype)
+
+    @property
+    def tci(self) -> int:
+        """The raw Tag Control Information word (PCP | DEI | VID)."""
+        return (self.pcp << 13) | (self.dei << 12) | self.vid
 
     def next_protocol(self) -> type[Protocol] | None:
         from netprotocols.layer2.ethernet import _ethertype_class
 
         return _ethertype_class(self.ethertype)
-
-    @property
-    def pcp(self) -> int:
-        """Priority code point (802.1p), 0-7."""
-        return self.tci >> 13
-
-    @property
-    def dei(self) -> int:
-        """Drop eligible indicator, 0-1."""
-        return (self.tci >> 12) & 1
-
-    @property
-    def vid(self) -> int:
-        """VLAN identifier, 0-4094 (0 = priority tag, 0xFFF = wildcard)."""
-        return self.tci & 0xFFF
 
     @property
     def ethertype_name(self) -> str:

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -21,6 +21,7 @@ from netprotocols import (
     ARP,
     TCP,
     UDP,
+    VLAN,
     Ethernet,
     ICMPv4,
     ICMPv6,
@@ -42,6 +43,7 @@ settings.load_profile("netprotocols")
 
 ALL_PROTOCOLS = (
     Ethernet,
+    VLAN,
     ARP,
     IPv4,
     IPv6,

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -5,6 +5,7 @@ import pytest
 from conftest import FIXTURES, read_pcap
 from netprotocols import (
     Ethernet,
+    EtherType,
     ICMPv6,
     InvalidFieldError,
     IPProtocol,
@@ -170,6 +171,10 @@ class TestRegistryGating:
 class TestEnumCompleteness:
     def test_every_ip_protocol_member_has_a_display_name(self):
         for member in IPProtocol:
+            assert member.display_name
+
+    def test_every_ethertype_member_has_a_display_name(self):
+        for member in EtherType:
             assert member.display_name
 
     def test_extension_header_display_names(self):

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,0 +1,88 @@
+"""VLAN tag decoding: fields, single tag, QinQ stacking, round-trip,
+and the decode contract (short buffers raise, never escape)."""
+
+import struct
+
+import pytest
+
+from netprotocols import (
+    VLAN,
+    Ethernet,
+    IPv4,
+    Protocol,
+    TruncatedHeaderError,
+)
+
+ETH = struct.Struct("!6s6sH")
+TAG = struct.Struct("!HH")
+
+DST = b"\xaa" * 6
+SRC = b"\xbb" * 6
+
+
+def tagged(inner_ethertype: int, payload: bytes, tci: int = 0x002A) -> bytes:
+    return ETH.pack(DST, SRC, 0x8100) + TAG.pack(tci, inner_ethertype) + payload
+
+
+class TestVLANFields:
+    def test_decode_and_fields(self) -> None:
+        tag = VLAN.decode(TAG.pack(0xE02A, 0x0800))
+        assert tag.tci == 0xE02A
+        assert tag.pcp == 7
+        assert tag.dei == 0
+        assert tag.vid == 42
+        assert tag.ethertype == 0x0800
+        assert tag.ethertype_name == "IPv4"
+        assert tag.header_len == 4
+
+    def test_roundtrip(self) -> None:
+        tag = VLAN(tci=0x0123, ethertype=0x86DD)
+        assert VLAN.decode(bytes(tag)) == tag
+
+    def test_unknown_ethertype_name_falls_back(self) -> None:
+        assert VLAN(tci=0, ethertype=0xCAFE).ethertype_name == "0xcafe"
+
+
+class TestVLANChain:
+    def test_single_tag_dispatch(self) -> None:
+        ipv4_bytes = b"\x45" + b"\x00" * 19
+        eth_header = Ethernet.decode(tagged(0x0800, ipv4_bytes))
+        assert eth_header.ethertype_name == "802.1Q VLAN tag"
+        tag_cls: type[Protocol] | None = eth_header.next_protocol()
+        assert tag_cls is VLAN
+        assert tag_cls is not None
+        tag = tag_cls.decode(TAG.pack(0x002A, 0x0800) + ipv4_bytes)
+        assert tag.next_protocol() is IPv4
+
+    def test_qinq_stacks_one_layer_per_tag(self) -> None:
+        ipv4_bytes = b"\x45" + b"\x00" * 19
+        frame = (
+            ETH.pack(DST, SRC, 0x88A8)
+            + TAG.pack(0, 0x8100)
+            + TAG.pack(0x002A, 0x0800)
+            + ipv4_bytes
+        )
+        eth_header = Ethernet.decode(frame)
+        first = eth_header.next_protocol()
+        assert first is VLAN
+        assert first is not None
+        tag1 = first.decode(frame[ETH.size :])
+        assert tag1.next_protocol() is VLAN
+        tag2_cls = tag1.next_protocol()
+        assert tag2_cls is not None
+        tag2 = tag2_cls.decode(frame[ETH.size + VLAN._struct.size :])
+        assert tag2.next_protocol() is IPv4
+
+
+class TestVLANContract:
+    def test_short_buffers_raise_truncated(self) -> None:
+        with pytest.raises(TruncatedHeaderError):
+            VLAN.decode(b"")
+        with pytest.raises(TruncatedHeaderError):
+            VLAN.decode(b"\x00")
+        with pytest.raises(TruncatedHeaderError):
+            VLAN.decode(b"\x00\x00\x00")
+
+    def test_unknown_inner_ethertype_ends_chain(self) -> None:
+        tag = VLAN(tci=0, ethertype=0xCAFE)
+        assert tag.next_protocol() is None

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -8,6 +8,7 @@ import pytest
 from netprotocols import (
     VLAN,
     Ethernet,
+    InvalidFieldError,
     IPv4,
     Protocol,
     TruncatedHeaderError,
@@ -36,11 +37,15 @@ class TestVLANFields:
         assert tag.header_len == 4
 
     def test_roundtrip(self) -> None:
-        tag = VLAN(tci=0x0123, ethertype=0x86DD)
+        tag = VLAN(pcp=0, dei=0, vid=0x123, ethertype=0x86DD)
         assert VLAN.decode(bytes(tag)) == tag
 
     def test_unknown_ethertype_name_falls_back(self) -> None:
-        assert VLAN(tci=0, ethertype=0xCAFE).ethertype_name == "0xcafe"
+        tag = VLAN(pcp=0, dei=0, vid=0, ethertype=0xCAFE)
+        assert tag.ethertype_name == "0xcafe"
+
+    def test_tci_packs_the_bitfields(self) -> None:
+        assert VLAN(pcp=7, dei=1, vid=42, ethertype=0).tci == 0xE02A + 0x1000
 
 
 class TestVLANChain:
@@ -84,5 +89,19 @@ class TestVLANContract:
             VLAN.decode(b"\x00\x00\x00")
 
     def test_unknown_inner_ethertype_ends_chain(self) -> None:
-        tag = VLAN(tci=0, ethertype=0xCAFE)
+        tag = VLAN(pcp=0, dei=0, vid=0, ethertype=0xCAFE)
         assert tag.next_protocol() is None
+
+
+class TestVLANValidation:
+    def test_out_of_range_pcp_rejected(self) -> None:
+        with pytest.raises(InvalidFieldError):
+            VLAN(pcp=8, dei=0, vid=0, ethertype=0)
+
+    def test_out_of_range_dei_rejected(self) -> None:
+        with pytest.raises(InvalidFieldError):
+            VLAN(pcp=0, dei=2, vid=0, ethertype=0)
+
+    def test_out_of_range_vid_rejected(self) -> None:
+        with pytest.raises(InvalidFieldError):
+            VLAN(pcp=0, dei=0, vid=0x1000, ethertype=0)


### PR DESCRIPTION
## Summary

802.1Q VLAN-tagged frames were invisible to the decoder: `Ethernet.next_protocol()` dispatched only ARP/IPv4/IPv6, so any tagged frame ended its chain at Ethernet and the entire tagged IP payload rendered as opaque bytes. On trunk ports that is the majority of traffic — a network monitor that can't see VLANs is flying blind on most real LANs.

This PR adds a `VLAN` layer (IEEE 802.1Q-2018 §9.6, incl. 802.1ad QinQ) and routes tag EtherTypes (0x8100, 0x88A8, legacy 0x9100) to it. The tag carries the inner EtherType, so `next_protocol` re-dispatches recursively and stacked tags decode as **one VLAN layer per tag** — no recursion risk, the walker's layer cap still applies.

## What's included

- `layer2/vlan.py` — new `VLAN` layer: TCI decoded with `pcp`/`dei`/`vid` properties, round-trip serialization, contract-faithful decode (short buffers raise `TruncatedHeaderError`, unknown inner EtherType ends the chain).
- `layer2/ethernet.py` — dispatch mapping extracted to module-level `_ethertype_class()` / `_ethertype_name()` (shared with `VLAN`); tag EtherTypes → `VLAN`.
- `_enums.py` — three new `EtherType` members + display names.
- Exports (both `__init__` files) + `tests/test_vlan.py`.

## Verification (two-corner audit — Oracle + Windy)

- **Dispatch differential:** all 65,536 EtherTypes swept master-vs-patch → exactly 3 new dispatches (the tag types), zero changed elsewhere.
- **Adversarial battery:** 19/19 — 16 stacked tags hit the layer cap cleanly, truncated tags (1-4 bytes), tag-on-empty-payload, unknown inner EtherType, VID 0 priority tag, legacy 0x9100 path.
- **Fuzz:** 7,000 frames (5k random + 2k corpus-mutated) through the full decode pipeline — zero escapes of the `ProtocolError` contract, pre- and post-patch.
- **QA ladder:** pytest green, ruff format/check clean, mypy strict clean.

## Notes

- Pairs with the RootWire renderer PR (screen output for the new layer).
- The protocol-number registry was deliberately left untouched — the tag EtherTypes belong to the L2 dispatch path, and the existing `ipv6=` gating still separates IPv6 extension headers correctly.


Companion triage issue: https://github.com/EONRaider/RootWire/issues/49