### PR TITLE
Add a pull-request template and CONTRIBUTING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for contributing to netprotocols! Fill in the sections below and
+delete this comment. CONTRIBUTING.md has the full workflow; the short
+version is: keep the QA ladder green and update the docs your change
+touches. Relative links below resolve from the repo root once this
+becomes the PR description.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? Link any related issue, e.g. "Closes #22". -->
+
+## What's included
+
+<!-- The concrete changes, one bullet each: new/edited modules, tests, docs. -->
+
+-
+
+## Verification
+
+<!-- Paste the QA-ladder output, or tick the boxes. All four gates run in CI. -->
+
+- [ ] `uv run ruff check` and `uv run ruff format --check` are clean
+- [ ] `uv run mypy` is clean (strict)
+- [ ] `uv run pytest` passes locally (CI runs it on Python 3.12 / 3.13 / 3.14)
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]`
+
+### New protocol or dispatch change — also:
+
+<!-- Delete this block if it doesn't apply. See ARCHITECTURE.md's cookbook. -->
+
+- [ ] Followed the add-a-protocol cookbook in [ARCHITECTURE.md](ARCHITECTURE.md) and the decode contract in `src/netprotocols/_base.py`
+- [ ] New `EtherType` / `IPProtocol` numbers carry display names in lockstep (a completeness test enforces it)
+- [ ] Registered the class in the fuzz suite (`tests/test_fuzz.py::ALL_PROTOCOLS`)
+- [ ] Added a fixture and updated [tests/fixtures/MANIFEST.md](tests/fixtures/MANIFEST.md) — a real capture where possible (see CONTRIBUTING.md for the capture scripts)
+- [ ] Updated the README coverage table and the ARCHITECTURE.md chain diagram
+
+## Notes
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, companion PRs. Optional. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `8021q` driver) — genuine inner checksums, byte-identical to trunk
   output; see `tests/fixtures/MANIFEST.md` and
   `scripts/capture_fixtures_vlan.sh`.
+- Contributor documentation: a `CONTRIBUTING.md` (dev setup, the QA
+  ladder, the decode contract, the add-a-protocol enforcement points,
+  and the fixture-capture workflow) and a pull-request template under
+  `.github/`.
 
 ## [1.2.0] - 2026-08-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to netprotocols
+
+Thanks for your interest in contributing. This library decodes and
+builds low-level network protocol headers; correctness against real
+traffic is the whole point, so the bar for changes is a green QA ladder
+and a fixture that proves the change against real bytes.
+
+Start with [ARCHITECTURE.md](ARCHITECTURE.md) for the design and the
+add-a-protocol cookbook; this file covers the mechanics.
+
+## Development setup
+
+Development uses [uv](https://docs.astral.sh/uv/) and targets Python
+3.12+ (CI runs 3.12, 3.13, and 3.14).
+
+```bash
+uv sync          # create the virtualenv and install dev dependencies
+```
+
+## The QA ladder
+
+These four checks are enforced by CI on every push and pull request.
+Run them locally before you push — one validated push beats three
+red ones:
+
+```bash
+uv run ruff check           # lint
+uv run ruff format --check  # formatting (drop --check to apply)
+uv run mypy                 # type checking, strict
+uv run pytest               # the full suite
+```
+
+CI additionally builds the wheel and imports it. `ruff`'s line length
+is 80; Markdown is excluded from linting.
+
+## Project layout
+
+```
+src/netprotocols/
+  _base.py        the Protocol base class and the decode contract
+  _enums.py       EtherType / IPProtocol / ARP* registries + display names
+  checksum.py     RFC 1071 internet checksum, compute()/verify()
+  packet.py       Packet: an ordered stack of headers, with_checksums()
+  layer2/         Ethernet, VLAN, ARP
+  layer3/         IPv4, IPv6, IPv6 extension headers, ICMPv4/v6, IGMP
+  layer4/         TCP, UDP (+ port-based dispatch)
+  layer7/         DNS
+  utils/          exceptions, MAC/IPv4 helpers
+tests/            unit tests, corpus invariants, fuzzing, fixtures/
+scripts/          fixture capture + validation
+```
+
+## The decode contract
+
+Every protocol is a frozen, slotted dataclass whose fields mirror the
+on-wire header. `decode(data)` receives the entire remaining buffer and
+must parse its fixed portion, tolerate trailing bytes, and raise a
+subclass of `ProtocolError` (never a bare `struct.error` or
+`ValueError`) on malformed input. The authoritative description lives in
+the module docstring of
+[`src/netprotocols/_base.py`](src/netprotocols/_base.py) — read it
+before adding a protocol.
+
+## Adding a protocol
+
+Follow the six-step cookbook in [ARCHITECTURE.md](ARCHITECTURE.md)
+("Cookbook: adding a protocol"). In short:
+
+1. Model the fixed header as a frozen, slotted dataclass with a
+   class-level `struct.Struct`; split wire bitfields into semantic
+   fields (as `IPv6` does with `version`/`traffic_class`/`flow_label`),
+   validating ranges in `__post_init__` with `InvalidFieldError`.
+2. Implement `decode()` and `__bytes__()` so `bytes(decode(x)) == x`
+   holds for well-formed input.
+3. Wire the chain: the layer below returns your class from
+   `next_protocol()`. For a new `EtherType` or IP protocol number, add
+   the value to `_enums.py` **with its display name in lockstep** — a
+   completeness test enforces this — and one mapping entry in the
+   dispatcher, using a deferred import.
+4. Add display helpers that degrade gracefully on unknown values
+   (return `"unknown (47)"`, never raise from a display property).
+5. Export the class from the package `__init__.py` and the layer
+   `__init__.py`.
+
+Two enforcement points that are easy to miss:
+
+- **Fuzz registration.** Add the class to `ALL_PROTOCOLS` in
+  [`tests/test_fuzz.py`](tests/test_fuzz.py) so the "decode never
+  escapes `ProtocolError`" property covers it.
+- **Enum lockstep.** The display-name completeness tests live in
+  `tests/test_ipv6_ext.py`; new enum members must have display names.
+
+## Tests and the fixture corpus
+
+The suite is anchored by a corpus of real captured traffic under
+[`tests/fixtures/`](tests/fixtures/), described frame by frame in
+[`tests/fixtures/MANIFEST.md`](tests/fixtures/MANIFEST.md). The
+corpus-wide invariants and the checksum recompute run over every frame
+automatically, so **dropping a `.pcap` into the corpus is often most of
+the test coverage for a new protocol.**
+
+Fixtures are captured and validated with the scripts under
+[`scripts/`](scripts/):
+
+- `capture_fixtures*.sh` — capture a scenario with `tcpdump` into
+  `tests/fixtures/staging/`, then validate it.
+- `check_fixtures.py` — a standalone (stdlib-only) checksum validator.
+  **Every committed fixture must pass it**:
+
+  ```bash
+  python3 scripts/check_fixtures.py tests/fixtures/staging
+  ```
+
+Prefer a real capture. When a protocol can't be captured directly in a
+normal environment — for example VLAN tags, which a switch strips on an
+access port and which the CI kernel can't originate without the `8021q`
+driver — a fixture may be derived from a real capture as long as the
+derivation is byte-faithful to the wire and the provenance is recorded
+in the MANIFEST. `scripts/capture_fixtures_vlan.sh` is the worked
+example (it splices tags over a real untagged capture).
+
+## Changelog
+
+This project keeps a [Keep a Changelog](https://keepachangelog.com/)
+file. Add an entry under `## [Unreleased]` in
+[`CHANGELOG.md`](CHANGELOG.md): user-facing changes under `### Added` /
+`### Changed` / `### Fixed`, test-and-tooling changes under
+`### Development`.
+
+## Pull requests
+
+- Keep changes focused; don't widen a PR beyond what it needs.
+- Fill in the pull-request template and keep the QA ladder green.
+- CI on a first-time fork PR waits for a maintainer to approve the run —
+  that's expected, not a failure on your end.
+- Commits and PRs describe the change and the reasoning; the diff shows
+  the *what*, the message explains the *why*.
+
+By contributing, you agree that your contributions are licensed under
+the project's [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ monitor built on it (formerly Packet-Sniffer).
 
 ## Roadmap
 
-- More protocols: 802.1Q VLAN tags, DHCP, GRE (DNS and IGMP shipped in 1.2).
+- More protocols: DHCP, GRE (802.1Q VLAN tags, DNS, and IGMP have shipped).
 - Full DNS resource-record parsing (the header and question are decoded today; answer/authority/additional sections are kept raw).
 - IGMPv3 group-record parsing (the common header is decoded today; v3 report records are kept raw in the body).
 - Optional richer address accessors (`ipaddress` / EUI objects
@@ -145,10 +145,12 @@ monitor built on it (formerly Packet-Sniffer).
 Development uses [uv](https://docs.astral.sh/uv/): `uv sync`, then
 `uv run pytest`, `uv run mypy`, and `uv run ruff check` — all three are
 enforced by CI on Python 3.12–3.14. The test suite is anchored by a
-65-frame corpus of real captured traffic
+77-frame corpus of real captured traffic
 ([tests/fixtures/MANIFEST.md](tests/fixtures/MANIFEST.md)) plus
-property-based fuzzing of the decode path. Start with
-[ARCHITECTURE.md](ARCHITECTURE.md).
+property-based fuzzing of the decode path. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and
+[ARCHITECTURE.md](ARCHITECTURE.md) for the design and the
+add-a-protocol cookbook.
 
 ## License
 


### PR DESCRIPTION
## Summary

The project took its first external contribution (#35) with no contributor-facing process docs — the QA ladder, the add-a-protocol enforcement points, and the fixture workflow lived only in `ARCHITECTURE.md` and in reviewers' heads. This writes them down and adds the missing PR template.

## What's included

- **`.github/pull_request_template.md`** — Summary / What's included / Verification, with a checklist for the four CI gates (`ruff check`, `ruff format --check`, `mypy`, `pytest`) and an extra block for new-protocol PRs (the cookbook, enum display-name lockstep, fuzz registration, fixture + MANIFEST, README/ARCHITECTURE updates).
- **`CONTRIBUTING.md`** — dev setup, the QA ladder, project layout, the decode contract (pointing at `_base.py`), the add-a-protocol steps with their easy-to-miss enforcement points, the fixture corpus + capture/validation scripts (including when a *derived* fixture is acceptable, using the VLAN splice as the worked example), the changelog convention, and PR expectations.
- **`README.md`** — refreshes two stale facts: the roadmap listed 802.1Q VLAN as unshipped (it landed in #35) and the corpus as 65 frames (now 77); the Contributing section now points to `CONTRIBUTING.md`.

## Verification

Documentation-only; no code changed.

- [x] `uv run ruff check` / `ruff format --check` clean (Markdown is excluded from linting anyway)
- [x] `uv run pytest` still green (455 passed, unchanged)
- [x] All relative links in the new docs resolve to real files
- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Development`

## Notes

Follows up the VLAN work in #35 / #39. An issue-template pair (bug report / protocol request) is a natural next step if you'd like one — left out here to keep this focused on the PR template you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L77CH1hWBWhWdDCkqWpExN)_