### PR TITLE
Add bug-report and protocol-request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: A protocol decodes, encodes, or chains incorrectly, or raises the wrong error.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. netprotocols decodes real traffic, so the most
+        useful reports come with the actual bytes that trigger the problem.
+        Please search [existing issues](https://github.com/EONRaider/NETProtocols/issues)
+        first.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: >-
+        netprotocols version
+        (`python -c "import netprotocols; print(netprotocols.__version__)"`)
+        and your Python version.
+      placeholder: "netprotocols 1.2.0, Python 3.12.3"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you decode or build, and what went wrong?
+      placeholder: "IPv4.decode(...) returned X, but the header on the wire says Y."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >-
+        A minimal snippet. Include the raw bytes as a hex string so it runs
+        standalone — that is by far the fastest path to a fix. Rendered as
+        Python; no backticks needed.
+      render: python
+      placeholder: |
+        from netprotocols import Ethernet
+
+        frame = bytes.fromhex("ffffffffffff0007...")
+        print(Ethernet.decode(frame))
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I included the raw bytes (or a pcap) needed to reproduce this.
+        - label: I searched existing issues for a duplicate.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Freeform issues stay enabled (the roadmap and design discussions don't
+# fit a form); the templates just make the common cases structured.
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/EONRaider/NETProtocols/blob/master/CONTRIBUTING.md
+    about: Dev setup, the QA ladder, and how to add a protocol.
+  - name: Protocol roadmap
+    url: https://github.com/EONRaider/NETProtocols/issues/22
+    about: Planned protocols and their ordering — check before requesting one.

--- a/.github/ISSUE_TEMPLATE/protocol_request.yml
+++ b/.github/ISSUE_TEMPLATE/protocol_request.yml
@@ -1,0 +1,66 @@
+name: Protocol request
+description: Request support for a protocol netprotocols does not decode yet.
+labels: ["enhancement", "roadmap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The roadmap ([#22](https://github.com/EONRaider/NETProtocols/issues/22))
+        tracks planned protocols and their ordering — check it and existing
+        issues first. Adding a protocol follows the cookbook in
+        [ARCHITECTURE.md](https://github.com/EONRaider/NETProtocols/blob/master/ARCHITECTURE.md);
+        contributions are welcome.
+  - type: input
+    id: protocol
+    attributes:
+      label: Protocol
+      placeholder: "e.g. DHCP, GRE, 802.1X"
+    validations:
+      required: true
+  - type: input
+    id: spec
+    attributes:
+      label: Specification
+      description: The RFC or standard number(s) that define the header.
+      placeholder: "RFC 2131"
+    validations:
+      required: true
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Layer
+      description: Roughly where it sits in the stack.
+      options:
+        - Link (2)
+        - Network (3)
+        - Transport (4)
+        - Application (7)
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: dispatch
+    attributes:
+      label: How it is reached
+      description: >-
+        What carries it — which lower layer, and which dispatch value
+        (EtherType, IP protocol number, or port)?
+      placeholder: "Behind UDP on ports 67/68."
+    validations:
+      required: false
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample traffic
+      description: >-
+        A pcap or a hex dump of a real frame makes this far easier to
+        implement and test — the fixture corpus is captured from real traffic.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I checked the roadmap (#22) and existing issues.
+        - label: I can provide a real capture (pcap or hex) of this protocol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/capture_fixtures_vlan.sh`.
 - Contributor documentation: a `CONTRIBUTING.md` (dev setup, the QA
   ladder, the decode contract, the add-a-protocol enforcement points,
-  and the fixture-capture workflow) and a pull-request template under
-  `.github/`.
+  and the fixture-capture workflow), a pull-request template, and
+  bug-report / protocol-request issue templates under `.github/`.
 
 ## [1.2.0] - 2026-08-30
 


### PR DESCRIPTION
## Summary

Rounds out `.github/` after the PR template (#41) with two GitHub **issue forms**, so the common inbound issues arrive structured instead of freeform — matching the project's rigor.

## What's included

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — pins down what a decode/encode bug report needs: version, what happened, a standalone reproduction (raw bytes as hex, rendered as Python), and expected behavior. Labeled `bug`.
- **`.github/ISSUE_TEMPLATE/protocol_request.yml`** — protocol, defining RFC/spec, layer (dropdown), how it's reached (dispatch value), and a prompt for real sample traffic (fixtures come from real captures). Labeled `enhancement` + `roadmap`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — keeps `blank_issues_enabled: true` (the roadmap and design threads don't fit a form) and links `CONTRIBUTING.md` and the roadmap (#22) from the chooser.

Both forms use only labels that already exist in the repo (`bug`, `enhancement`, `roadmap`).

## Verification

Config-only; no code changed.

- [x] All three YAML files parse and conform to the issue-forms schema (validated: valid `type`s, no `validations` on `markdown`, dropdown/checkbox option shapes, `config.yml` contact-link keys)
- [x] `uv run pytest` still green (455), `ruff` clean
- [x] `CHANGELOG.md` `### Development` note extended to cover the issue templates

## Notes

Follows #41. Separately, "Automatically delete head branches" (Settings → General) is worth enabling — it'll clean up merged branches like this one's automatically; that's a repo setting I can't toggle via the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L77CH1hWBWhWdDCkqWpExN)_