### PR TITLE
Parse IGMPv3 membership-report group records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kept as the `tci` property; `VLAN` is registered in the
   property-based fuzz suite and the `EtherType` display names are
   covered by the enum completeness test.
+- **IGMPv3 group records** (`IGMPv3GroupRecord`, RFC 3376 §4.2): a v3
+  Membership Report (type `0x22`) now parses its group-record array on
+  demand. `IGMP.group_records` yields one `IGMPv3GroupRecord` per record
+  (record type + display name, multicast group, source-address list,
+  raw auxiliary data) and `IGMP.num_group_records` reads the count;
+  other message types return `None`. Parsing reads the raw body and
+  never re-encodes, so the byte-exact round-trip is preserved, and a
+  lying record/source count or a truncated record raises
+  `InvalidFieldError` (bounded — never hangs or over-reads).
 
 ### Development
 - The real-capture fixture corpus gained `vlan_icmp.pcap` (802.1Q

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -17,7 +17,7 @@ from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
 from netprotocols.layer2.vlan import VLAN
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
-from netprotocols.layer3.igmp import IGMP
+from netprotocols.layer3.igmp import IGMP, IGMPv3GroupRecord
 from netprotocols.layer3.ip import IPv4, IPv6
 from netprotocols.layer3.ipv6_ext import (
     IPv6DestinationOptions,
@@ -55,6 +55,7 @@ __all__ = [
     "Ethernet",
     "ICMPv4",
     "ICMPv6",
+    "IGMPv3GroupRecord",
     "IPProtocol",
     "IPv4",
     "IPv6",

--- a/src/netprotocols/layer3/igmp.py
+++ b/src/netprotocols/layer3/igmp.py
@@ -2,13 +2,14 @@
 
 IGMP rides directly on IPv4 (protocol 2) and never encapsulates another
 protocol. The message types do not share one fixed layout — a v3
-membership report replaces the group-address field with a record count
-— so only the common first four bytes (type, max-response code,
-checksum) are modelled as fields; the remainder is kept as raw
-``body``. The ``group_address`` accessor reads bytes 4-7 as an IPv4
-address for the message types that carry one there, and returns
-``None`` otherwise. Parsing the v3 group-record array is a roadmap
-follow-up.
+membership report replaces the group-address field with an array of
+group records — so only the common first four bytes (type,
+max-response code, checksum) are modelled as fields; the remainder is
+kept as raw ``body``. The ``group_address`` accessor reads bytes 4-7 as
+an IPv4 address for the message types that carry one there; for the v3
+report (type ``0x22``) the ``group_records`` accessor parses the record
+array. Both read the raw body on demand and never re-encode, so
+``bytes(IGMP.decode(x)) == x`` holds by construction.
 """
 
 from __future__ import annotations
@@ -18,12 +19,54 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol, bytes_to_ipv4
+from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["IGMP"]
+__all__ = ["IGMP", "IGMPv3GroupRecord"]
 
 #: Message types whose bytes 4-7 hold a group address (RFC 2236 §2;
 #: RFC 3376 §4.1 for the v3 query). The v3 report (0x22) does not.
 _GROUP_ADDRESS_TYPES = frozenset({0x11, 0x12, 0x16, 0x17})
+
+#: The IGMPv3 Membership Report message type (RFC 3376 §4.2).
+_V3_REPORT_TYPE = 0x22
+
+#: IGMPv3 group-record types (RFC 3376 §4.2.12).
+_RECORD_TYPE_NAMES: dict[int, str] = {
+    1: "MODE_IS_INCLUDE",
+    2: "MODE_IS_EXCLUDE",
+    3: "CHANGE_TO_INCLUDE_MODE",
+    4: "CHANGE_TO_EXCLUDE_MODE",
+    5: "ALLOW_NEW_SOURCES",
+    6: "BLOCK_OLD_SOURCES",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class IGMPv3GroupRecord:
+    """One group record from an IGMPv3 Membership Report (RFC 3376 §4.2.4).
+
+    :param record_type: Record type — ``1`` MODE_IS_INCLUDE, ``2``
+        MODE_IS_EXCLUDE, ``3`` CHANGE_TO_INCLUDE_MODE, ``4``
+        CHANGE_TO_EXCLUDE_MODE, ``5`` ALLOW_NEW_SOURCES, ``6``
+        BLOCK_OLD_SOURCES (see :attr:`record_type_name`).
+    :param multicast_address: The record's multicast group, dotted-decimal.
+    :param source_addresses: The source addresses (dotted-decimal); empty
+        for a record that carries none.
+    :param aux_data: Auxiliary data, kept raw (RFC 3376 defines none, so
+        this is normally empty).
+    """
+
+    record_type: int
+    multicast_address: str
+    source_addresses: tuple[str, ...] = ()
+    aux_data: bytes = b""
+
+    @property
+    def record_type_name(self) -> str:
+        """Display name of the record type, e.g. ``"MODE_IS_EXCLUDE"``."""
+        return _RECORD_TYPE_NAMES.get(
+            self.record_type, f"unknown ({self.record_type:#04x})"
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,10 +127,72 @@ class IGMP(Protocol):
     def group_address(self) -> str | None:
         """The multicast group in dotted-decimal, for the message types
         that carry it in bytes 4-7 (query, v1/v2 report, leave); ``None``
-        for the v3 report, which uses that space for a record count."""
+        for the v3 report, which uses that space for a record count (read
+        its groups via :attr:`group_records`)."""
         if self.type in _GROUP_ADDRESS_TYPES and len(self.body) >= 4:
             return bytes_to_ipv4(self.body[:4])
         return None
+
+    @property
+    def num_group_records(self) -> int | None:
+        """Number of group records in a v3 Membership Report (message
+        bytes 6-7), or ``None`` for other message types.
+
+        :raises InvalidFieldError: if the report ends before the count.
+        """
+        if self.type != _V3_REPORT_TYPE:
+            return None
+        if len(self.body) < 4:
+            raise InvalidFieldError(
+                "IGMPv3 report truncated before the record count"
+            )
+        return int.from_bytes(self.body[2:4], "big")
+
+    @property
+    def group_records(self) -> tuple[IGMPv3GroupRecord, ...] | None:
+        """The group records of a v3 Membership Report (type ``0x22``),
+        parsed on demand; ``None`` for other message types.
+
+        :raises InvalidFieldError: if a record, its source list, or its
+            auxiliary data runs past the message (bounded — never hangs
+            or over-reads).
+        """
+        count = self.num_group_records
+        if count is None:
+            return None
+        body = self.body
+        records: list[IGMPv3GroupRecord] = []
+        cursor = 4  # past the reserved word (bytes 0-1) and count (2-3)
+        for _ in range(count):
+            if cursor + 8 > len(body):
+                raise InvalidFieldError("IGMPv3 group record truncated")
+            record_type = body[cursor]
+            aux_words = body[cursor + 1]
+            num_sources = int.from_bytes(body[cursor + 2 : cursor + 4], "big")
+            multicast = bytes_to_ipv4(body[cursor + 4 : cursor + 8])
+            cursor += 8
+            sources: list[str] = []
+            for _ in range(num_sources):
+                if cursor + 4 > len(body):
+                    raise InvalidFieldError(
+                        "IGMPv3 group record source list truncated"
+                    )
+                sources.append(bytes_to_ipv4(body[cursor : cursor + 4]))
+                cursor += 4
+            aux_len = aux_words * 4
+            if cursor + aux_len > len(body):
+                raise InvalidFieldError("IGMPv3 auxiliary data truncated")
+            aux_data = body[cursor : cursor + aux_len]
+            cursor += aux_len
+            records.append(
+                IGMPv3GroupRecord(
+                    record_type=record_type,
+                    multicast_address=multicast,
+                    source_addresses=tuple(sources),
+                    aux_data=aux_data,
+                )
+            )
+        return tuple(records)
 
     @property
     def checksum_hex_str(self) -> str:

--- a/tests/test_igmp.py
+++ b/tests/test_igmp.py
@@ -13,6 +13,8 @@ import pytest
 from conftest import FIXTURES, read_pcap
 from netprotocols import (
     IGMP,
+    IGMPv3GroupRecord,
+    InvalidFieldError,
     IPv4,
     TruncatedHeaderError,
     compute,
@@ -26,6 +28,27 @@ def build_igmp(type_: int, group: str, max_resp_code: int = 0) -> bytes:
     header = struct.pack("!BBH", type_, max_resp_code, 0)
     checksum = compute(IGMP.decode(header + body))
     return struct.pack("!BBH", type_, max_resp_code, checksum) + body
+
+
+def ipv4_bytes(addr: str) -> bytes:
+    return bytes(int(octet) for octet in addr.split("."))
+
+
+def build_v3_report(
+    records: list[tuple[int, str, list[str], bytes]],
+) -> bytes:
+    """Assemble an IGMPv3 Membership Report (type 0x22) from
+    ``(record_type, multicast, sources, aux_data)`` tuples."""
+    body = struct.pack("!HH", 0, len(records))  # reserved + record count
+    for record_type, group, sources, aux in records:
+        assert len(aux) % 4 == 0, "aux data is measured in 32-bit words"
+        body += struct.pack("!BBH", record_type, len(aux) // 4, len(sources))
+        body += ipv4_bytes(group)
+        body += b"".join(ipv4_bytes(src) for src in sources)
+        body += aux
+    header = struct.pack("!BBH", 0x22, 0, 0)
+    checksum = compute(IGMP.decode(header + body))
+    return struct.pack("!BBH", 0x22, 0, checksum) + body
 
 
 class TestIGMPFields:
@@ -63,6 +86,114 @@ class TestIGMPFields:
         raw = build_igmp(0x17, "239.1.2.3")
         assert bytes(IGMP.decode(raw)) == raw
         assert IGMP.decode(bytes(IGMP.decode(raw))) == IGMP.decode(raw)
+
+
+class TestIGMPv3GroupRecords:
+    def test_single_exclude_record_no_sources(self):
+        raw = build_v3_report([(2, "239.255.42.99", [], b"")])
+        igmp = IGMP.decode(raw)
+        assert igmp.type_name == "IGMPv3 Membership Report"
+        assert igmp.group_address is None
+        assert igmp.num_group_records == 1
+        (record,) = igmp.group_records
+        assert isinstance(record, IGMPv3GroupRecord)
+        assert record.record_type == 2
+        assert record.record_type_name == "MODE_IS_EXCLUDE"
+        assert record.multicast_address == "239.255.42.99"
+        assert record.source_addresses == ()
+        assert record.aux_data == b""
+        assert verify(igmp)
+
+    def test_multiple_records_with_sources(self):
+        raw = build_v3_report(
+            [
+                (1, "232.1.1.1", ["10.0.0.1", "10.0.0.2"], b""),
+                (4, "239.0.0.5", ["192.0.2.7"], b""),
+            ]
+        )
+        igmp = IGMP.decode(raw)
+        assert igmp.num_group_records == 2
+        records = igmp.group_records
+        assert records is not None
+        assert len(records) == 2
+        assert records[0].record_type_name == "MODE_IS_INCLUDE"
+        assert records[0].multicast_address == "232.1.1.1"
+        assert records[0].source_addresses == ("10.0.0.1", "10.0.0.2")
+        assert records[1].record_type_name == "CHANGE_TO_EXCLUDE_MODE"
+        assert records[1].multicast_address == "239.0.0.5"
+        assert records[1].source_addresses == ("192.0.2.7",)
+        assert verify(igmp)
+
+    def test_auxiliary_data_is_kept_raw(self):
+        aux = b"\xde\xad\xbe\xef"  # one 32-bit word
+        raw = build_v3_report([(1, "232.0.0.9", ["203.0.113.1"], aux)])
+        (record,) = IGMP.decode(raw).group_records
+        assert record.aux_data == aux
+        assert record.source_addresses == ("203.0.113.1",)
+
+    def test_zero_records(self):
+        igmp = IGMP.decode(build_v3_report([]))
+        assert igmp.num_group_records == 0
+        assert igmp.group_records == ()
+
+    def test_unknown_record_type_degrades(self):
+        (record,) = IGMP.decode(
+            build_v3_report([(99, "224.0.0.1", [], b"")])
+        ).group_records
+        assert record.record_type == 99
+        assert record.record_type_name == "unknown (0x63)"
+
+    def test_round_trip_is_byte_exact(self):
+        raw = build_v3_report(
+            [
+                (3, "232.1.1.1", ["10.0.0.1"], b"\x00\x00\x00\x01"),
+                (6, "239.9.9.9", [], b""),
+            ]
+        )
+        assert bytes(IGMP.decode(raw)) == raw
+
+    def test_non_v3_types_have_no_records(self):
+        igmp = IGMP.decode(build_igmp(0x16, "239.1.2.3"))
+        assert igmp.group_records is None
+        assert igmp.num_group_records is None
+
+    def test_truncated_source_list_raises(self):
+        # One record claims a source, but two bytes are chopped off.
+        raw = build_v3_report([(1, "232.1.1.1", ["10.0.0.1"], b"")])
+        with pytest.raises(InvalidFieldError):
+            _ = IGMP.decode(raw[:-2]).group_records
+
+    def test_lying_source_count_raises(self):
+        # Record claims 5 sources but carries none.
+        body = struct.pack("!HH", 0, 1) + struct.pack("!BBH", 1, 0, 5)
+        body += ipv4_bytes("232.1.1.1")
+        igmp = IGMP.decode(struct.pack("!BBH", 0x22, 0, 0) + body)
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.group_records
+
+    def test_lying_record_count_raises(self):
+        # Header says 3 records; body carries one.
+        body = struct.pack("!HH", 0, 3) + struct.pack("!BBH", 2, 0, 0)
+        body += ipv4_bytes("239.1.1.1")
+        igmp = IGMP.decode(struct.pack("!BBH", 0x22, 0, 0) + body)
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.group_records
+
+    def test_count_field_truncated_raises(self):
+        # Type 0x22 but body too short to hold the reserved + count word.
+        igmp = IGMP.decode(struct.pack("!BBH", 0x22, 0, 0) + b"\x00")
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.num_group_records
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.group_records
+
+    def test_truncated_aux_data_raises(self):
+        # Record claims one 32-bit word of aux data but carries none.
+        body = struct.pack("!HH", 0, 1) + struct.pack("!BBH", 1, 1, 0)
+        body += ipv4_bytes("232.1.1.1")
+        igmp = IGMP.decode(struct.pack("!BBH", 0x22, 0, 0) + body)
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.group_records
 
 
 class TestIGMPContract:


### PR DESCRIPTION
Resolves the IGMP refinement noted under the #22 roadmap: the IGMPv3 Membership Report (type `0x22`) kept its group-record array as raw `body`. This parses it on demand.

## What changed
- **`IGMPv3GroupRecord`** — a new frozen value type: `record_type` (+ `record_type_name`), `multicast_address`, `source_addresses`, `aux_data`. Exported from the package.
- **`IGMP.group_records`** — parses the record array for type `0x22`, returning a tuple of `IGMPv3GroupRecord`; `None` for other message types.
- **`IGMP.num_group_records`** — reads the record count.

Follows the `DNS` accessor precedent: parses the raw body on demand and **never re-encodes**, so `bytes(IGMP.decode(x)) == x` still holds. Parsing is bounded — a lying record/source count, a truncated record, source list, or aux-data block raises `InvalidFieldError` (never hangs or over-reads). The module docstring drops the "roadmap follow-up" caveat.

## Verification
- `pytest` 481 passed (12 new IGMPv3 tests; `igmp.py` 100% covered) · `ruff check` · `ruff format --check` · `mypy` — all clean
- Tests cover include/exclude modes, multi-record reports, source lists, auxiliary data, zero records, unknown record types, byte-exact round-trip, and every truncation/lying-count path.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)