### PR TITLE
Add DHCP (RFC 2131/2132) over UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never re-encodes, so the byte-exact round-trip is preserved, and a
   lying record/source count or a truncated record raises
   `InvalidFieldError` (bounded — never hangs or over-reads).
+- **DHCP** (`netprotocols.DHCP`, RFC 2131/2132) — the fixed BOOTP header
+  (op, xid, the client/your/server/gateway addresses, the 16-byte client
+  hardware address, and the server-name / boot-file fields) decodes in
+  full; the magic cookie and TLV options are kept raw and parsed on
+  demand. `option_map` walks the options (concatenating a value split
+  across appearances, RFC 3396) and `message_type` / `message_type_name`
+  read the DHCP message type (option 53). Dispatched from UDP by
+  well-known port (67/68); terminal, with a byte-exact round-trip and
+  the same bounded-parse contract as DNS (`InvalidFieldError` on a
+  missing cookie or an option that overruns the buffer).
 
 ### Development
 - The real-capture fixture corpus gained `vlan_icmp.pcap` (802.1Q

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -27,6 +27,7 @@ from netprotocols.layer3.ipv6_ext import (
 )
 from netprotocols.layer4.tcp import TCP
 from netprotocols.layer4.udp import UDP
+from netprotocols.layer7.dhcp import DHCP
 from netprotocols.layer7.dns import DNS
 from netprotocols.packet import Packet
 from netprotocols.utils.exceptions import (
@@ -44,6 +45,7 @@ __version__ = "1.2.0"
 
 __all__ = [
     "ARP",
+    "DHCP",
     "DNS",
     "IGMP",
     "TCP",

--- a/src/netprotocols/layer4/_ports.py
+++ b/src/netprotocols/layer4/_ports.py
@@ -28,7 +28,8 @@ def udp_app_class(src_port: int, dst_port: int) -> type[Protocol] | None:
     Returns ``None`` when neither port names a known application
     protocol — the common case, where the chain ends at UDP.
     """
+    from netprotocols.layer7.dhcp import DHCP
     from netprotocols.layer7.dns import DNS
 
-    registry: dict[int, type[Protocol]] = {53: DNS}
+    registry: dict[int, type[Protocol]] = {53: DNS, 67: DHCP, 68: DHCP}
     return registry.get(dst_port) or registry.get(src_port)

--- a/src/netprotocols/layer7/dhcp.py
+++ b/src/netprotocols/layer7/dhcp.py
@@ -1,0 +1,259 @@
+"""DHCP message (RFC 2131/2132), carried in a UDP datagram.
+
+DHCP extends the fixed BOOTP frame: a 236-byte header (op through the
+128-byte boot-file name) followed by a 4-byte magic cookie and a
+variable list of TLV options. The fixed header is decoded in full; the
+options are kept raw and parsed on demand, so ``bytes(DHCP.decode(x))
+== x`` holds by construction and a message with unusual or vendor
+options still round-trips exactly. ``option_map`` walks the TLV list,
+and ``message_type`` reads the DHCP message type (option 53) that
+distinguishes a DISCOVER from an ACK.
+
+DHCP rides UDP between the server port (67) and the client port (68);
+it is terminal — it never encapsulates another protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from struct import Struct
+from typing import ClassVar, Self
+
+from netprotocols._base import (
+    Protocol,
+    bytes_to_ipv4,
+    bytes_to_mac,
+    ipv4_to_bytes,
+)
+from netprotocols.utils.exceptions import InvalidFieldError
+
+__all__ = ["DHCP"]
+
+#: The four-byte value that begins the options field (RFC 2131 §3;
+#: the dotted form 99.130.83.99).
+_MAGIC_COOKIE = b"\x63\x82\x53\x63"
+
+#: Single-byte options that carry no length or value (RFC 2132 §3.1-3.2).
+_OPT_PAD = 0
+_OPT_END = 255
+
+#: The DHCP Message Type option (RFC 2132 §9.6).
+_OPT_MESSAGE_TYPE = 53
+
+_OP_NAMES: dict[int, str] = {1: "BOOTREQUEST", 2: "BOOTREPLY"}
+
+_MESSAGE_TYPE_NAMES: dict[int, str] = {
+    1: "DISCOVER",
+    2: "OFFER",
+    3: "REQUEST",
+    4: "DECLINE",
+    5: "ACK",
+    6: "NAK",
+    7: "RELEASE",
+    8: "INFORM",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DHCP(Protocol):
+    """A DHCP/BOOTP message.
+
+    :param op: Message op code — ``1`` request (client→server), ``2``
+        reply (server→client).
+    :param htype: Hardware address type (``1`` = Ethernet).
+    :param hlen: Hardware address length (``6`` for Ethernet).
+    :param hops: Relay hop count.
+    :param xid: Transaction identifier correlating a request and reply.
+    :param secs: Seconds since the client began address acquisition.
+    :param flags: Flags word; bit 15 is the broadcast flag.
+    :param ciaddr: Client IP address (dotted-decimal), set when the
+        client already holds a lease.
+    :param yiaddr: "Your" IP address — the address the server assigns.
+    :param siaddr: Next-server IP address (dotted-decimal).
+    :param giaddr: Relay-agent (gateway) IP address (dotted-decimal).
+    :param chaddr: Client hardware address, 16 raw bytes (the first
+        ``hlen`` are significant); read via :attr:`client_mac`.
+    :param sname: Optional server host name, 64 raw bytes; read via
+        :attr:`server_name`.
+    :param file: Optional boot-file name, 128 raw bytes; read via
+        :attr:`boot_file`.
+    :param options: The magic cookie and TLV options, kept raw; read via
+        :attr:`option_map` and :attr:`message_type`.
+    """
+
+    op: int
+    htype: int
+    hlen: int
+    hops: int
+    xid: int
+    secs: int
+    flags: int
+    ciaddr: str
+    yiaddr: str
+    siaddr: str
+    giaddr: str
+    chaddr: bytes = b"\x00" * 16
+    sname: bytes = b"\x00" * 64
+    file: bytes = b"\x00" * 128
+    options: bytes = b""
+
+    _struct: ClassVar[Struct] = Struct("!4BIHH4s4s4s4s16s64s128s")
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        (
+            op,
+            htype,
+            hlen,
+            hops,
+            xid,
+            secs,
+            flags,
+            ciaddr,
+            yiaddr,
+            siaddr,
+            giaddr,
+            chaddr,
+            sname,
+            file,
+        ) = cls._unpack_fixed(data)
+        return cls(
+            op=op,
+            htype=htype,
+            hlen=hlen,
+            hops=hops,
+            xid=xid,
+            secs=secs,
+            flags=flags,
+            ciaddr=bytes_to_ipv4(ciaddr),
+            yiaddr=bytes_to_ipv4(yiaddr),
+            siaddr=bytes_to_ipv4(siaddr),
+            giaddr=bytes_to_ipv4(giaddr),
+            chaddr=bytes(chaddr),
+            sname=bytes(sname),
+            file=bytes(file),
+            options=bytes(data[cls._struct.size :]),
+        )
+
+    def __bytes__(self) -> bytes:
+        return (
+            self._struct.pack(
+                self.op,
+                self.htype,
+                self.hlen,
+                self.hops,
+                self.xid,
+                self.secs,
+                self.flags,
+                ipv4_to_bytes(self.ciaddr),
+                ipv4_to_bytes(self.yiaddr),
+                ipv4_to_bytes(self.siaddr),
+                ipv4_to_bytes(self.giaddr),
+                self.chaddr,
+                self.sname,
+                self.file,
+            )
+            + self.options
+        )
+
+    @property
+    def header_len(self) -> int:
+        # A DHCP message is the whole UDP payload: consume it all so the
+        # chain ends here with no stray payload.
+        return self._struct.size + len(self.options)
+
+    @property
+    def op_name(self) -> str:
+        """Display name of the op code, e.g. ``"BOOTREQUEST"``."""
+        return _OP_NAMES.get(self.op, f"unknown ({self.op:#04x})")
+
+    @property
+    def is_broadcast(self) -> bool:
+        """Whether the broadcast flag (bit 15 of ``flags``) is set."""
+        return bool(self.flags & 0x8000)
+
+    @property
+    def client_mac(self) -> str | None:
+        """The client hardware address as a MAC string, for Ethernet
+        (``htype`` 1, ``hlen`` 6); ``None`` for other link types."""
+        if self.htype == 1 and self.hlen == 6:
+            return bytes_to_mac(self.chaddr[:6])
+        return None
+
+    @property
+    def server_name(self) -> str:
+        """The optional server host name (``sname``), NUL-trimmed."""
+        return self.sname.split(b"\x00", 1)[0].decode("ascii", "replace")
+
+    @property
+    def boot_file(self) -> str:
+        """The optional boot-file name (``file``), NUL-trimmed."""
+        return self.file.split(b"\x00", 1)[0].decode("ascii", "replace")
+
+    @property
+    def has_magic_cookie(self) -> bool:
+        """Whether the options begin with the DHCP magic cookie — false
+        for a plain BOOTP message that carries none."""
+        return self.options[:4] == _MAGIC_COOKIE
+
+    @property
+    def option_map(self) -> dict[int, bytes]:
+        """The TLV options after the magic cookie as a ``{code: value}``
+        map. An option split across several appearances is concatenated
+        (RFC 3396); ``pad`` (0) and ``end`` (255) are consumed, not
+        returned. Empty when the message carries no options.
+
+        :raises InvalidFieldError: if the options are present but do not
+            begin with the magic cookie, or an option's length runs past
+            the buffer (bounded — never hangs or over-reads).
+        """
+        raw = self.options
+        if not raw:
+            return {}
+        if raw[:4] != _MAGIC_COOKIE:
+            raise InvalidFieldError("DHCP options missing the magic cookie")
+        parsed: dict[int, bytes] = {}
+        cursor = 4
+        while cursor < len(raw):
+            code = raw[cursor]
+            cursor += 1
+            if code == _OPT_PAD:
+                continue
+            if code == _OPT_END:
+                break
+            if cursor >= len(raw):
+                raise InvalidFieldError("DHCP option missing its length byte")
+            length = raw[cursor]
+            cursor += 1
+            if cursor + length > len(raw):
+                raise InvalidFieldError(
+                    "DHCP option value runs past the buffer"
+                )
+            parsed[code] = parsed.get(code, b"") + raw[cursor : cursor + length]
+            cursor += length
+        return parsed
+
+    @property
+    def message_type(self) -> int | None:
+        """The DHCP message type (option 53) — ``1`` DISCOVER, ``2``
+        OFFER, ``3`` REQUEST, ``5`` ACK, ... — or ``None`` for a plain
+        BOOTP message that carries no such option.
+
+        :raises InvalidFieldError: if the options are malformed (see
+            :attr:`option_map`).
+        """
+        value = self.option_map.get(_OPT_MESSAGE_TYPE)
+        if value is None or len(value) != 1:
+            return None
+        return value[0]
+
+    @property
+    def message_type_name(self) -> str | None:
+        """Display name of the DHCP message type, e.g. ``"DISCOVER"``;
+        ``None`` when no message-type option is present."""
+        message_type = self.message_type
+        if message_type is None:
+            return None
+        return _MESSAGE_TYPE_NAMES.get(
+            message_type, f"unknown ({message_type:#04x})"
+        )

--- a/tests/test_dhcp.py
+++ b/tests/test_dhcp.py
@@ -1,0 +1,209 @@
+"""DHCP decoding, driven by crafted messages for the decode contract,
+option parsing, and UDP port dispatch."""
+
+import struct
+
+import pytest
+
+from netprotocols import (
+    DHCP,
+    UDP,
+    InvalidFieldError,
+    TruncatedHeaderError,
+)
+
+MAGIC = b"\x63\x82\x53\x63"
+
+
+def ipv4_bytes(addr: str) -> bytes:
+    return bytes(int(octet) for octet in addr.split("."))
+
+
+def mac_bytes(mac: str) -> bytes:
+    return bytes.fromhex(mac.replace(":", ""))
+
+
+def build_options(
+    entries: list[tuple[int, bytes]], *, cookie: bytes = MAGIC
+) -> bytes:
+    body = cookie
+    for code, value in entries:
+        body += bytes([code, len(value)]) + value
+    return body + bytes([255])  # END
+
+
+def build_dhcp(
+    *,
+    op: int = 2,
+    flags: int = 0,
+    xid: int = 0x3903F326,
+    ciaddr: str = "0.0.0.0",
+    yiaddr: str = "0.0.0.0",
+    siaddr: str = "0.0.0.0",
+    giaddr: str = "0.0.0.0",
+    chaddr_mac: str = "00:0c:29:ab:cd:ef",
+    sname: bytes = b"",
+    file: bytes = b"",
+    options: bytes = MAGIC + bytes([255]),
+) -> bytes:
+    fixed = struct.pack("!4BIHH", op, 1, 6, 0, xid, 0, flags)
+    fixed += ipv4_bytes(ciaddr) + ipv4_bytes(yiaddr)
+    fixed += ipv4_bytes(siaddr) + ipv4_bytes(giaddr)
+    fixed += mac_bytes(chaddr_mac).ljust(16, b"\x00")
+    fixed += sname.ljust(64, b"\x00")
+    fixed += file.ljust(128, b"\x00")
+    return fixed + options
+
+
+class TestDHCPFields:
+    def test_offer_fixed_header(self):
+        raw = build_dhcp(
+            op=2,
+            flags=0x8000,
+            yiaddr="192.168.1.100",
+            siaddr="192.168.1.1",
+            chaddr_mac="00:0c:29:ab:cd:ef",
+        )
+        dhcp = DHCP.decode(raw)
+        assert dhcp.op == 2
+        assert dhcp.op_name == "BOOTREPLY"
+        assert dhcp.htype == 1
+        assert dhcp.hlen == 6
+        assert dhcp.xid == 0x3903F326
+        assert dhcp.yiaddr == "192.168.1.100"
+        assert dhcp.siaddr == "192.168.1.1"
+        assert dhcp.ciaddr == "0.0.0.0"
+        assert dhcp.is_broadcast is True
+        assert dhcp.client_mac == "00:0c:29:ab:cd:ef"
+
+    def test_request_op_name(self):
+        dhcp = DHCP.decode(build_dhcp(op=1))
+        assert dhcp.op_name == "BOOTREQUEST"
+        assert dhcp.is_broadcast is False
+
+    def test_unknown_op_degrades(self):
+        dhcp = DHCP.decode(build_dhcp(op=7))
+        assert dhcp.op_name == "unknown (0x07)"
+
+    def test_client_mac_none_for_non_ethernet(self):
+        raw = bytearray(build_dhcp())
+        raw[1] = 0  # htype = 0 (not Ethernet)
+        assert DHCP.decode(bytes(raw)).client_mac is None
+
+    def test_server_name_and_boot_file(self):
+        dhcp = DHCP.decode(build_dhcp(sname=b"dhcp-server", file=b"pxelinux.0"))
+        assert dhcp.server_name == "dhcp-server"
+        assert dhcp.boot_file == "pxelinux.0"
+
+    def test_header_len_consumes_whole_message(self):
+        raw = build_dhcp(options=build_options([(53, b"\x05")]))
+        dhcp = DHCP.decode(raw)
+        assert dhcp.header_len == len(raw)
+        assert bytes(dhcp) == raw
+
+
+class TestDHCPOptions:
+    def test_message_type_and_name(self):
+        raw = build_dhcp(options=build_options([(53, b"\x01")]))  # DISCOVER
+        dhcp = DHCP.decode(raw)
+        assert dhcp.has_magic_cookie is True
+        assert dhcp.message_type == 1
+        assert dhcp.message_type_name == "DISCOVER"
+
+    def test_option_map_parses_tlvs(self):
+        raw = build_dhcp(
+            options=build_options(
+                [
+                    (53, b"\x02"),  # OFFER
+                    (1, ipv4_bytes("255.255.255.0")),  # subnet mask
+                    (54, ipv4_bytes("192.168.1.1")),  # server identifier
+                ]
+            )
+        )
+        options = DHCP.decode(raw).option_map
+        assert options[53] == b"\x02"
+        assert options[1] == ipv4_bytes("255.255.255.0")
+        assert options[54] == ipv4_bytes("192.168.1.1")
+
+    def test_pad_options_are_skipped(self):
+        # Two PAD bytes (0x00) between the cookie and the message type.
+        raw = build_dhcp(options=MAGIC + b"\x00\x00" + bytes([53, 1, 3, 255]))
+        dhcp = DHCP.decode(raw)
+        assert dhcp.message_type == 3  # REQUEST
+        assert dhcp.message_type_name == "REQUEST"
+
+    def test_split_option_is_concatenated(self):
+        # RFC 3396: option 43 appearing twice concatenates in order.
+        raw = build_dhcp(
+            options=build_options([(43, b"\xaa\xbb"), (43, b"\xcc\xdd")])
+        )
+        assert DHCP.decode(raw).option_map[43] == b"\xaa\xbb\xcc\xdd"
+
+    def test_unknown_message_type_degrades(self):
+        raw = build_dhcp(options=build_options([(53, b"\x63")]))  # 99
+        assert DHCP.decode(raw).message_type_name == "unknown (0x63)"
+
+    def test_plain_bootp_without_options(self):
+        # A BOOTP message whose options field is empty: no cookie, no
+        # message type, but still a valid, round-tripping frame.
+        raw = build_dhcp(options=b"")
+        dhcp = DHCP.decode(raw)
+        assert dhcp.has_magic_cookie is False
+        assert dhcp.option_map == {}
+        assert dhcp.message_type is None
+        assert dhcp.message_type_name is None
+        assert bytes(dhcp) == raw
+
+    def test_message_type_wrong_length_is_none(self):
+        raw = build_dhcp(options=build_options([(53, b"\x05\x05")]))
+        assert DHCP.decode(raw).message_type is None
+
+
+class TestDHCPContract:
+    def test_truncated_fixed_header_raises(self):
+        with pytest.raises(TruncatedHeaderError):
+            DHCP.decode(build_dhcp()[:235])
+
+    def test_missing_magic_cookie_raises(self):
+        raw = build_dhcp(options=b"\x00\x00\x00\x00" + bytes([53, 1, 1, 255]))
+        with pytest.raises(InvalidFieldError):
+            _ = DHCP.decode(raw).option_map
+
+    def test_option_running_past_buffer_raises(self):
+        # Option 53 declares length 4 but only one value byte follows.
+        raw = build_dhcp(options=MAGIC + bytes([53, 4, 1]))
+        with pytest.raises(InvalidFieldError):
+            _ = DHCP.decode(raw).option_map
+
+    def test_option_missing_length_byte_raises(self):
+        raw = build_dhcp(options=MAGIC + bytes([53]))  # code, no length
+        with pytest.raises(InvalidFieldError):
+            _ = DHCP.decode(raw).option_map
+
+    def test_round_trip_is_byte_exact(self):
+        raw = build_dhcp(
+            op=2,
+            flags=0x8000,
+            yiaddr="10.0.0.55",
+            sname=b"srv",
+            file=b"boot.img",
+            options=build_options([(53, b"\x05"), (51, b"\x00\x00\x0e\x10")]),
+        )
+        assert bytes(DHCP.decode(raw)) == raw
+
+    def test_dhcp_ends_the_chain(self):
+        assert DHCP.decode(build_dhcp()).next_protocol() is None
+
+
+class TestDHCPDispatch:
+    def test_udp_dst_67_dispatches(self):
+        udp = UDP(src_port=68, dst_port=67, length=8, checksum=0)
+        assert udp.next_protocol() is DHCP
+
+    def test_udp_dst_68_dispatches(self):
+        udp = UDP(src_port=67, dst_port=68, length=8, checksum=0)
+        assert udp.next_protocol() is DHCP
+
+    def test_non_dhcp_ports_do_not_dispatch(self):
+        udp = UDP(src_port=12345, dst_port=80, length=8, checksum=0)
+        assert udp.next_protocol() is None


### PR DESCRIPTION
Adds the DHCP roadmap protocol (#22). It rides UDP between the server (67) and client (68) ports and extends the fixed BOOTP frame with a magic cookie + TLV options.

## What changed
- **`netprotocols.DHCP`** (`src/netprotocols/layer7/dhcp.py`) — the 236-byte BOOTP header (op, xid, the client/your/server/gateway addresses, `chaddr`, `sname`, `file`) decodes in full; the magic cookie and TLV options are kept raw and parsed on demand, so `bytes(DHCP.decode(x)) == x` holds and vendor/unknown options round-trip exactly.
  - `option_map` walks the TLV list, concatenating an option split across appearances (RFC 3396); `message_type` / `message_type_name` read option 53.
  - Convenience accessors: `op_name`, `is_broadcast`, `client_mac`, `server_name`, `boot_file`, `has_magic_cookie`.
- **UDP dispatch** — `layer4/_ports.py` now maps ports 67/68 → `DHCP`. Terminal (`next_protocol()` is `None`).
- Follows the `DNS` bounded-parse contract: a missing magic cookie or an option overrunning the buffer raises `InvalidFieldError` (never hangs or over-reads).

## Verification
- `pytest` 503 passed (22 new DHCP tests; `dhcp.py` and `_ports.py` at 100%) · `ruff check` · `ruff format --check` · `mypy` — all clean
- Tests cover the fixed header, DISCOVER/OFFER/REQUEST/ACK, options (pad/end/split/unknown), plain BOOTP without options, byte-exact round-trip, UDP port dispatch, and every malformed path.

Closes #46. Advances the #22 roadmap (GRE remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)