### PR TITLE
Add GRE (RFC 2784/2890), completing the roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   well-known port (67/68); terminal, with a byte-exact round-trip and
   the same bounded-parse contract as DNS (`InvalidFieldError` on a
   missing cookie or an option that overruns the buffer).
+- **GRE** (`netprotocols.GRE`, RFC 2784/2890) — Generic Routing
+  Encapsulation, dispatched from IPv4/IPv6 protocol 47. The four-byte
+  header (flags/version + protocol type) decodes with the optional
+  checksum, key, and sequence-number fields that the flag bits announce
+  kept raw and surfaced through accessors. The payload chains onward by
+  the `protocol_type` EtherType, so a GRE-tunnelled IPv4/IPv6 packet
+  keeps decoding; the round-trip stays byte-exact regardless of which
+  optional fields are present.
 
 ### Development
 - The real-capture fixture corpus gained `vlan_icmp.pcap` (802.1Q

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -16,6 +16,7 @@ from netprotocols.checksum import compute, internet_checksum, verify
 from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
 from netprotocols.layer2.vlan import VLAN
+from netprotocols.layer3.gre import GRE
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
 from netprotocols.layer3.igmp import IGMP, IGMPv3GroupRecord
 from netprotocols.layer3.ip import IPv4, IPv6
@@ -47,6 +48,7 @@ __all__ = [
     "ARP",
     "DHCP",
     "DNS",
+    "GRE",
     "IGMP",
     "TCP",
     "UDP",

--- a/src/netprotocols/_enums.py
+++ b/src/netprotocols/_enums.py
@@ -49,6 +49,7 @@ class IPProtocol(IntEnum):
     UDP = 0x11
     IPV6_ROUTE = 0x2B
     IPV6_FRAG = 0x2C
+    GRE = 0x2F
     IPV6_ICMP = 0x3A
     IPV6_DSTOPTS = 0x3C
 
@@ -65,6 +66,7 @@ _IP_PROTOCOL_NAMES = {
     IPProtocol.UDP: "UDP",
     IPProtocol.IPV6_ROUTE: "IPv6 Routing",
     IPProtocol.IPV6_FRAG: "IPv6 Fragment",
+    IPProtocol.GRE: "GRE",
     IPProtocol.IPV6_ICMP: "IPv6-ICMP",
     IPProtocol.IPV6_DSTOPTS: "IPv6 Destination Options",
 }

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -1,0 +1,157 @@
+"""GRE — Generic Routing Encapsulation (RFC 2784, RFC 2890).
+
+GRE tunnels one protocol inside another: it rides IP as protocol 47 and
+carries a payload named by a 2-byte ``protocol_type`` that is an
+*EtherType* (``0x0800`` IPv4, ``0x86DD`` IPv6, ...), so the chain walk
+continues into the encapsulated packet exactly as it would after an
+Ethernet header.
+
+The header is four fixed bytes (a flags/version word and the protocol
+type) followed by optional fields whose presence the flag bits announce:
+a checksum (with its reserved word) when the Checksum-Present bit is set,
+a key when the Key-Present bit is set, and a sequence number when the
+Sequence-Number-Present bit is set (RFC 2890, in that order). Those
+optional bytes are kept raw and surfaced through accessors, so
+``bytes(GRE.decode(x)) == x`` holds regardless of which are present.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from struct import Struct
+from typing import ClassVar, Self
+
+from netprotocols._base import Protocol
+from netprotocols.utils.exceptions import TruncatedHeaderError
+
+__all__ = ["GRE"]
+
+_CHECKSUM_PRESENT = 0x8000  # bit 0
+_KEY_PRESENT = 0x2000  # bit 2
+_SEQUENCE_PRESENT = 0x1000  # bit 3
+
+
+@dataclass(frozen=True, slots=True)
+class GRE(Protocol):
+    """A GRE header.
+
+    :param flags: The flags/version word (bit 0 checksum-present, bit 2
+        key-present, bit 3 sequence-present, bits 13-15 version); read
+        the parts via the properties below.
+    :param protocol_type: EtherType of the encapsulated payload, e.g.
+        ``0x0800`` for IPv4 (see :class:`~netprotocols.EtherType`).
+    :param fields: The optional checksum/reserved, key, and sequence
+        fields the flags announce, kept raw and read via the accessors.
+    """
+
+    flags: int
+    protocol_type: int
+    fields: bytes = b""
+
+    _struct: ClassVar[Struct] = Struct("!HH")
+
+    @staticmethod
+    def _optional_len(flags: int) -> int:
+        """Bytes of optional fields the flags in ``flags`` announce."""
+        return (
+            (4 if flags & _CHECKSUM_PRESENT else 0)
+            + (4 if flags & _KEY_PRESENT else 0)
+            + (4 if flags & _SEQUENCE_PRESENT else 0)
+        )
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        flags, protocol_type = cls._unpack_fixed(data)
+        optional_len = cls._optional_len(flags)
+        end = cls._struct.size + optional_len
+        if len(data) < end:
+            raise TruncatedHeaderError(
+                f"GRE header declares {end} bytes, buffer holds {len(data)}"
+            )
+        return cls(
+            flags=flags,
+            protocol_type=protocol_type,
+            fields=bytes(data[cls._struct.size : end]),
+        )
+
+    def __bytes__(self) -> bytes:
+        return self._struct.pack(self.flags, self.protocol_type) + self.fields
+
+    @property
+    def header_len(self) -> int:
+        return self._struct.size + len(self.fields)
+
+    def next_protocol(self) -> type[Protocol] | None:
+        """The class that decodes the encapsulated payload, chosen by
+        ``protocol_type`` (an EtherType); ``None`` when it is not one
+        this library decodes."""
+        from netprotocols.layer2.ethernet import _ethertype_class
+
+        return _ethertype_class(self.protocol_type)
+
+    @property
+    def checksum_present(self) -> int:
+        """1 if the checksum (and its reserved word) is present."""
+        return int(bool(self.flags & _CHECKSUM_PRESENT))
+
+    @property
+    def key_present(self) -> int:
+        """1 if the key field is present (RFC 2890)."""
+        return int(bool(self.flags & _KEY_PRESENT))
+
+    @property
+    def sequence_present(self) -> int:
+        """1 if the sequence-number field is present (RFC 2890)."""
+        return int(bool(self.flags & _SEQUENCE_PRESENT))
+
+    @property
+    def version(self) -> int:
+        """The version number (bits 13-15); 0 for RFC 2784 GRE."""
+        return self.flags & 0x07
+
+    @property
+    def protocol_name(self) -> str:
+        """Display name of ``protocol_type``, e.g. ``"IPv4"``; falls back
+        to the hexadecimal value for EtherTypes unknown to this library."""
+        from netprotocols.layer2.ethernet import _ethertype_name
+
+        return _ethertype_name(self.protocol_type)
+
+    @property
+    def checksum(self) -> int | None:
+        """The header checksum, carried verbatim, or ``None`` when the
+        checksum-present bit is clear (this library neither computes nor
+        verifies it)."""
+        if not self.checksum_present or len(self.fields) < 2:
+            return None
+        return int.from_bytes(self.fields[:2], "big")
+
+    @property
+    def key(self) -> int | None:
+        """The 32-bit key (RFC 2890), or ``None`` when its bit is clear."""
+        if not self.key_present:
+            return None
+        offset = 4 if self.checksum_present else 0
+        if len(self.fields) < offset + 4:
+            return None
+        return int.from_bytes(self.fields[offset : offset + 4], "big")
+
+    @property
+    def sequence_number(self) -> int | None:
+        """The 32-bit sequence number (RFC 2890), or ``None`` when its
+        bit is clear."""
+        if not self.sequence_present:
+            return None
+        offset = (4 if self.checksum_present else 0) + (
+            4 if self.key_present else 0
+        )
+        if len(self.fields) < offset + 4:
+            return None
+        return int.from_bytes(self.fields[offset : offset + 4], "big")
+
+    @property
+    def checksum_hex_str(self) -> str | None:
+        """The checksum as a hexadecimal string, e.g. ``"0x1c2a"``, or
+        ``None`` when no checksum is present."""
+        checksum = self.checksum
+        return None if checksum is None else f"{checksum:#06x}"

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -46,6 +46,7 @@ def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
     (``ipv6=True``): a garbage IPv4 packet with ``protocol=0`` must not
     decode a Hop-by-Hop layer.
     """
+    from netprotocols.layer3.gre import GRE
     from netprotocols.layer3.icmp import ICMPv4, ICMPv6
     from netprotocols.layer3.igmp import IGMP
     from netprotocols.layer3.ipv6_ext import (
@@ -63,6 +64,7 @@ def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
         IPProtocol.HOPOPT: IPv6HopByHopOptions,
         IPProtocol.ICMP: ICMPv4,
         IPProtocol.IGMP: IGMP,
+        IPProtocol.GRE: GRE,
         IPProtocol.IPV6_ROUTE: IPv6Routing,
         IPProtocol.IPV6_FRAG: IPv6Fragment,
         IPProtocol.IPV6_ICMP: ICMPv6,

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -100,5 +100,9 @@ class TestChainWalk:
         assert IPv6.decode(icmp_ipv6).next_protocol() is ICMPv6
 
     def test_unknown_ip_protocol_ends_chain(self, raw_ipv4_header):
-        gre = b"\x45" + raw_ipv4_header[1:9] + b"\x2f" + raw_ipv4_header[10:]
-        assert IPv4.decode(gre).next_protocol() is None
+        # Protocol 253 is reserved for experimentation (RFC 3692) and is
+        # not one this library decodes, so the chain ends at IPv4.
+        unknown = (
+            b"\x45" + raw_ipv4_header[1:9] + b"\xfd" + raw_ipv4_header[10:]
+        )
+        assert IPv4.decode(unknown).next_protocol() is None

--- a/tests/test_gre.py
+++ b/tests/test_gre.py
@@ -1,0 +1,212 @@
+"""GRE decoding: the flags-driven optional fields, EtherType-based
+payload dispatch, and the IP protocol-47 wiring."""
+
+import struct
+
+import pytest
+
+from netprotocols import (
+    GRE,
+    IPProtocol,
+    IPv4,
+    IPv6,
+    TruncatedHeaderError,
+)
+
+
+def build_gre(
+    *,
+    protocol_type: int = 0x0800,
+    checksum: int | None = None,
+    key: int | None = None,
+    sequence: int | None = None,
+    version: int = 0,
+) -> bytes:
+    """Assemble a GRE header, setting each flag bit for the optional
+    fields that are supplied (RFC 2890 order: checksum, key, sequence)."""
+    flags = version & 0x07
+    fields = b""
+    if checksum is not None:
+        flags |= 0x8000
+        fields += struct.pack("!HH", checksum, 0)  # checksum + reserved1
+    if key is not None:
+        flags |= 0x2000
+        fields += struct.pack("!I", key)
+    if sequence is not None:
+        flags |= 0x1000
+        fields += struct.pack("!I", sequence)
+    return struct.pack("!HH", flags, protocol_type) + fields
+
+
+def make_ipv4(*, protocol: int, total_length: int, src: str, dst: str) -> IPv4:
+    return IPv4(
+        version=4,
+        ihl=5,
+        dscp=0,
+        ecn=0,
+        total_length=total_length,
+        identification=0,
+        flags=0,
+        fragment_offset=0,
+        ttl=64,
+        protocol=protocol,
+        checksum=0,
+        src=src,
+        dst=dst,
+    )
+
+
+class TestGREFields:
+    def test_minimal_header(self):
+        gre = GRE.decode(build_gre(protocol_type=0x0800))
+        assert gre.header_len == 4
+        assert gre.protocol_type == 0x0800
+        assert gre.protocol_name == "IPv4"
+        assert gre.version == 0
+        assert gre.checksum_present == 0
+        assert gre.key_present == 0
+        assert gre.sequence_present == 0
+        assert gre.checksum is None
+        assert gre.key is None
+        assert gre.sequence_number is None
+        assert gre.checksum_hex_str is None
+
+    def test_checksum_present(self):
+        gre = GRE.decode(build_gre(checksum=0x1C2A))
+        assert gre.checksum_present == 1
+        assert gre.checksum == 0x1C2A
+        assert gre.checksum_hex_str == "0x1c2a"
+        assert gre.header_len == 8
+
+    def test_key_present(self):
+        gre = GRE.decode(build_gre(key=0xDEADBEEF))
+        assert gre.key_present == 1
+        assert gre.key == 0xDEADBEEF
+        assert gre.checksum is None
+        assert gre.header_len == 8
+
+    def test_sequence_present(self):
+        gre = GRE.decode(build_gre(sequence=42))
+        assert gre.sequence_present == 1
+        assert gre.sequence_number == 42
+        assert gre.header_len == 8
+
+    def test_all_optional_fields_in_order(self):
+        gre = GRE.decode(
+            build_gre(checksum=0x1111, key=0x22223333, sequence=0x44445555)
+        )
+        assert gre.checksum == 0x1111
+        assert gre.key == 0x22223333
+        assert gre.sequence_number == 0x44445555
+        assert gre.header_len == 4 + 12  # checksum+reserved, key, sequence
+
+    def test_key_offset_skips_absent_checksum(self):
+        # Key present, checksum absent: the key sits right after the
+        # fixed 4 bytes, not 4 bytes further in.
+        gre = GRE.decode(build_gre(key=0xABCD1234, sequence=9))
+        assert gre.checksum is None
+        assert gre.key == 0xABCD1234
+        assert gre.sequence_number == 9
+
+    def test_version_bits(self):
+        assert GRE.decode(build_gre(version=1)).version == 1
+
+    def test_unknown_protocol_type_name(self):
+        # Transparent Ethernet Bridging (0x6558) is not decoded here.
+        assert GRE.decode(build_gre(protocol_type=0x6558)).protocol_name == (
+            "0x6558"
+        )
+
+
+class TestGREChain:
+    def test_dispatches_to_ipv4(self):
+        gre = GRE.decode(build_gre(protocol_type=0x0800))
+        assert gre.next_protocol() is IPv4
+
+    def test_dispatches_to_ipv6(self):
+        gre = GRE.decode(build_gre(protocol_type=0x86DD))
+        assert gre.next_protocol() is IPv6
+
+    def test_unknown_protocol_type_ends_chain(self):
+        gre = GRE.decode(build_gre(protocol_type=0x6558))
+        assert gre.next_protocol() is None
+
+    def test_ipv4_protocol_47_dispatches_to_gre(self):
+        ip = make_ipv4(
+            protocol=47, total_length=24, src="10.0.0.1", dst="10.0.0.2"
+        )
+        assert ip.next_protocol() is GRE
+
+    def test_ipv6_next_header_47_dispatches_to_gre(self):
+        ip = IPv6(
+            version=6,
+            traffic_class=0,
+            flow_label=0,
+            payload_length=4,
+            next_header=47,
+            hop_limit=64,
+            src="2001:db8::1",
+            dst="2001:db8::2",
+        )
+        assert ip.next_protocol() is GRE
+
+    def test_protocol_number_and_display_name(self):
+        assert IPProtocol.GRE == 47
+        assert IPProtocol.GRE.display_name == "GRE"
+
+    def test_full_ipv4_gre_ipv4_walk(self):
+        # IP-in-IP over GRE: IPv4 (proto 47) -> GRE (0x0800) -> IPv4.
+        inner = make_ipv4(
+            protocol=253,  # unknown upper protocol: the chain ends here
+            total_length=20,
+            src="192.168.0.1",
+            dst="192.168.0.2",
+        )
+        outer = make_ipv4(
+            protocol=47, total_length=44, src="10.0.0.1", dst="10.0.0.2"
+        )
+        frame = bytes(outer) + build_gre(protocol_type=0x0800) + bytes(inner)
+        layers = []
+        cursor, protocol = 0, IPv4
+        while protocol is not None:
+            header = protocol.decode(frame[cursor:])
+            layers.append(header)
+            cursor += header.header_len
+            protocol = header.next_protocol()
+        assert [type(layer) for layer in layers] == [IPv4, GRE, IPv4]
+        assert layers[2].src == "192.168.0.1"
+
+
+class TestGREContract:
+    def test_truncated_fixed_header_raises(self):
+        with pytest.raises(TruncatedHeaderError):
+            GRE.decode(b"\x00\x00\x08")  # 3 bytes, fixed header needs 4
+
+    def test_flags_declare_optional_fields_past_the_buffer(self):
+        # Checksum bit set, but the announced 4 optional bytes are absent.
+        with pytest.raises(TruncatedHeaderError):
+            GRE.decode(struct.pack("!HH", 0x8000, 0x0800))
+
+    def test_round_trip_byte_exact(self):
+        for kwargs in (
+            {"protocol_type": 0x0800},
+            {"checksum": 0x1C2A},
+            {"key": 0xDEADBEEF},
+            {"sequence": 7},
+            {"checksum": 1, "key": 2, "sequence": 3},
+        ):
+            raw = build_gre(**kwargs)
+            assert bytes(GRE.decode(raw)) == raw
+
+    def test_accessors_tolerate_flags_without_fields(self):
+        # A hand-built instance whose flags claim every optional field
+        # but whose raw `fields` are empty: the value accessors return
+        # None rather than raising past the buffer. (decode() never
+        # produces this — it validates the length up front.)
+        gre = GRE(flags=0x8000 | 0x2000 | 0x1000, protocol_type=0x0800)
+        assert gre.checksum_present == 1
+        assert gre.key_present == 1
+        assert gre.sequence_present == 1
+        assert gre.checksum is None
+        assert gre.key is None
+        assert gre.sequence_number is None


### PR DESCRIPTION
Adds GRE — the final #22 roadmap protocol. It tunnels one protocol inside another, riding IP as protocol 47 and naming its payload with a Protocol Type that is an EtherType (RFC 2890 adds the key and sequence-number fields).

## What changed
- **`netprotocols.GRE`** (`src/netprotocols/layer3/gre.py`) — the 4-byte fixed header (flags/version + protocol type) decodes; the optional checksum (+ reserved), key, and sequence-number fields the flag bits announce are kept raw and surfaced through accessors (`checksum`, `key`, `sequence_number`, `checksum_present` / `key_present` / `sequence_present`, `version`). `bytes(GRE.decode(x)) == x` holds regardless of which are present.
- **Payload dispatch** — `GRE.next_protocol()` chains by `protocol_type`, reusing the Ethernet EtherType registry, so a GRE-tunnelled IPv4/IPv6 packet keeps decoding.
- **IP wiring** — `IPProtocol.GRE` (47) added with a display name; IPv4/IPv6 protocol 47 now dispatches to `GRE`.
- **`test_contract.py`** — the unknown-IP-protocol case repoints from 47 to 253 (reserved for experimentation, RFC 3692) now that 47 decodes.

## Verification
- `pytest` 522 passed (19 new GRE tests; `gre.py` at 100%) · `ruff check` · `ruff format --check` · `mypy` — all clean
- Tests cover every optional-field combination and offset, EtherType dispatch (IPv4/IPv6/unknown), the IPv4/IPv6 protocol-47 wiring, a full IPv4→GRE→IPv4 walk, truncation, and byte-exact round-trip.

Closes #48. Closes #22 — with 802.1Q, DNS, DHCP, IGMP, and GRE all implemented, the roadmap is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)