### PR TITLE
Parse IGMPv3 Membership Query fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never re-encodes, so the byte-exact round-trip is preserved, and a
   lying record/source count or a truncated record raises
   `InvalidFieldError` (bounded — never hangs or over-reads).
+- **IGMPv3 query fields** (RFC 3376 §4.1): a v3 Membership Query (type
+  `0x11`) now exposes its fields past the group address — the `s_flag`
+  (suppress router-side processing), `qrv`, `qqic`, and
+  `query_source_addresses` accessors parse the raw body on demand. A v2
+  (8-byte) query and non-query types return `None`, and a source count
+  that runs past the message raises `InvalidFieldError`.
 - **DHCP** (`netprotocols.DHCP`, RFC 2131/2132) — the fixed BOOTP header
   (op, xid, the client/your/server/gateway addresses, the 16-byte client
   hardware address, and the server-name / boot-file fields) decodes in

--- a/src/netprotocols/layer3/igmp.py
+++ b/src/netprotocols/layer3/igmp.py
@@ -8,7 +8,9 @@ max-response code, checksum) are modelled as fields; the remainder is
 kept as raw ``body``. The ``group_address`` accessor reads bytes 4-7 as
 an IPv4 address for the message types that carry one there; for the v3
 report (type ``0x22``) the ``group_records`` accessor parses the record
-array. Both read the raw body on demand and never re-encode, so
+array; and for a v3 query (type ``0x11``) the ``s_flag`` / ``qrv`` /
+``qqic`` / ``query_source_addresses`` accessors parse the query's extra
+fields. All read the raw body on demand and never re-encode, so
 ``bytes(IGMP.decode(x)) == x`` holds by construction.
 """
 
@@ -29,6 +31,13 @@ _GROUP_ADDRESS_TYPES = frozenset({0x11, 0x12, 0x16, 0x17})
 
 #: The IGMPv3 Membership Report message type (RFC 3376 §4.2).
 _V3_REPORT_TYPE = 0x22
+
+#: The Membership Query message type. A v3 query (RFC 3376 §4.1) extends
+#: the group address with S/QRV (1 byte), QQIC (1 byte), and a source
+#: count (2 bytes) before the sources — so its body is at least 8 bytes,
+#: where a v2 query (RFC 2236) carries only the 4-byte group address.
+_QUERY_TYPE = 0x11
+_V3_QUERY_MIN_BODY = 8
 
 #: IGMPv3 group-record types (RFC 3376 §4.2.12).
 _RECORD_TYPE_NAMES: dict[int, str] = {
@@ -193,6 +202,66 @@ class IGMP(Protocol):
                 )
             )
         return tuple(records)
+
+    @property
+    def _is_v3_query(self) -> bool:
+        """Whether this is an IGMPv3 Membership Query — a query whose body
+        is long enough to carry the v3 fields past the group address."""
+        return self.type == _QUERY_TYPE and len(self.body) >= _V3_QUERY_MIN_BODY
+
+    @property
+    def s_flag(self) -> int | None:
+        """Suppress Router-Side Processing (S) flag of a v3 Membership
+        Query (RFC 3376 §4.1.5); ``None`` for other messages and for a
+        v2 query, which carries no such field."""
+        if not self._is_v3_query:
+            return None
+        return (self.body[4] >> 3) & 1
+
+    @property
+    def qrv(self) -> int | None:
+        """Querier's Robustness Variable (QRV) of a v3 query (RFC 3376
+        §4.1.6); ``None`` otherwise."""
+        if not self._is_v3_query:
+            return None
+        return self.body[4] & 0x07
+
+    @property
+    def qqic(self) -> int | None:
+        """Querier's Query Interval Code (QQIC) of a v3 query (RFC 3376
+        §4.1.7); ``None`` otherwise."""
+        if not self._is_v3_query:
+            return None
+        return self.body[5]
+
+    @property
+    def num_query_sources(self) -> int | None:
+        """Number of source addresses in a v3 query (RFC 3376 §4.1.8),
+        or ``None`` for other messages and a v2 query."""
+        if not self._is_v3_query:
+            return None
+        return int.from_bytes(self.body[6:8], "big")
+
+    @property
+    def query_source_addresses(self) -> tuple[str, ...] | None:
+        """The source addresses of a v3 Membership Query (RFC 3376
+        §4.1.10), parsed on demand; ``None`` for other messages and a v2
+        query (empty for a General or Group-Specific query).
+
+        :raises InvalidFieldError: if the source count runs past the
+            message (bounded — never hangs or over-reads).
+        """
+        count = self.num_query_sources
+        if count is None:
+            return None
+        sources: list[str] = []
+        cursor = 8
+        for _ in range(count):
+            if cursor + 4 > len(self.body):
+                raise InvalidFieldError("IGMPv3 query source list truncated")
+            sources.append(bytes_to_ipv4(self.body[cursor : cursor + 4]))
+            cursor += 4
+        return tuple(sources)
 
     @property
     def checksum_hex_str(self) -> str:

--- a/tests/test_igmp.py
+++ b/tests/test_igmp.py
@@ -51,6 +51,26 @@ def build_v3_report(
     return struct.pack("!BBH", 0x22, 0, checksum) + body
 
 
+def build_v3_query(
+    *,
+    group: str = "0.0.0.0",
+    s: int = 0,
+    qrv: int = 2,
+    qqic: int = 125,
+    sources: list[str] | None = None,
+    max_resp_code: int = 100,
+) -> bytes:
+    """Assemble an IGMPv3 Membership Query (type 0x11, RFC 3376 §4.1)."""
+    sources = sources or []
+    body = ipv4_bytes(group)
+    body += bytes([((s & 1) << 3) | (qrv & 0x07), qqic])
+    body += struct.pack("!H", len(sources))
+    body += b"".join(ipv4_bytes(src) for src in sources)
+    header = struct.pack("!BBH", 0x11, max_resp_code, 0)
+    checksum = compute(IGMP.decode(header + body))
+    return struct.pack("!BBH", 0x11, max_resp_code, checksum) + body
+
+
 class TestIGMPFields:
     def test_v2_membership_report(self):
         raw = build_igmp(0x16, "239.255.42.99")
@@ -194,6 +214,71 @@ class TestIGMPv3GroupRecords:
         igmp = IGMP.decode(struct.pack("!BBH", 0x22, 0, 0) + body)
         with pytest.raises(InvalidFieldError):
             _ = igmp.group_records
+
+
+class TestIGMPv3Query:
+    def test_general_query_fields(self):
+        raw = build_v3_query(group="0.0.0.0", s=0, qrv=2, qqic=125)
+        igmp = IGMP.decode(raw)
+        assert igmp.type_name == "Membership Query"
+        assert igmp.group_address == "0.0.0.0"
+        assert igmp.s_flag == 0
+        assert igmp.qrv == 2
+        assert igmp.qqic == 125
+        assert igmp.num_query_sources == 0
+        assert igmp.query_source_addresses == ()
+        assert verify(igmp)
+
+    def test_group_and_source_specific_query(self):
+        raw = build_v3_query(
+            group="239.1.1.1",
+            s=1,
+            qrv=3,
+            qqic=10,
+            sources=["10.0.0.1", "10.0.0.2"],
+        )
+        igmp = IGMP.decode(raw)
+        assert igmp.group_address == "239.1.1.1"
+        assert igmp.s_flag == 1
+        assert igmp.qrv == 3
+        assert igmp.qqic == 10
+        assert igmp.num_query_sources == 2
+        assert igmp.query_source_addresses == ("10.0.0.1", "10.0.0.2")
+        assert verify(igmp)
+
+    def test_v2_query_has_no_v3_fields(self):
+        # An 8-byte v2 query: its body is only the 4-byte group address.
+        igmp = IGMP.decode(build_igmp(0x11, "224.0.0.1", max_resp_code=100))
+        assert igmp.group_address == "224.0.0.1"
+        assert igmp.s_flag is None
+        assert igmp.qrv is None
+        assert igmp.qqic is None
+        assert igmp.num_query_sources is None
+        assert igmp.query_source_addresses is None
+
+    def test_non_query_types_have_no_query_fields(self):
+        igmp = IGMP.decode(build_igmp(0x16, "239.1.2.3"))  # v2 report
+        assert igmp.s_flag is None
+        assert igmp.query_source_addresses is None
+
+    def test_round_trip_is_byte_exact(self):
+        raw = build_v3_query(
+            group="239.9.9.9", s=1, qrv=7, qqic=200, sources=["192.0.2.1"]
+        )
+        assert bytes(IGMP.decode(raw)) == raw
+
+    def test_truncated_source_list_raises(self):
+        raw = build_v3_query(sources=["10.0.0.1"])
+        with pytest.raises(InvalidFieldError):
+            _ = IGMP.decode(raw[:-2]).query_source_addresses
+
+    def test_lying_source_count_raises(self):
+        # Query claims 4 sources but carries none.
+        body = ipv4_bytes("0.0.0.0") + bytes([0x02, 100])
+        body += struct.pack("!H", 4)
+        igmp = IGMP.decode(struct.pack("!BBH", 0x11, 100, 0) + body)
+        with pytest.raises(InvalidFieldError):
+            _ = igmp.query_source_addresses
 
 
 class TestIGMPContract:


### PR DESCRIPTION
`IGMP.group_records` (#45) parsed the IGMPv3 Membership **Report**; the v3 Membership **Query** (type `0x11`, RFC 3376 §4.1) still kept its fields past the group address raw in `body`. This adds the query side.

## What changed
On-demand accessors on `IGMP`, mirroring the report-record accessors:
- `s_flag` (Suppress Router-Side Processing), `qrv` (Querier's Robustness Variable), `qqic` (Querier's Query Interval Code)
- `num_query_sources` and `query_source_addresses` (tuple of dotted-decimal)

They parse the raw body on demand and never re-encode, so `bytes(IGMP.decode(x)) == x` still holds. A **v2** (8-byte) query and **non-query** message types return `None`; a source count that runs past the message raises `InvalidFieldError` (bounded). `IGMP.group_address` already read the query's Group Address.

## Verification
- `pytest` — IGMP suite 28 tests, `igmp.py` at **100%** coverage; full suite green
- `ruff check` · `ruff format --check` · `mypy` — all clean
- Tests cover a General Query, a Group-and-Source-Specific Query, a v2 query (no v3 fields), non-query types, byte-exact round-trip, and the truncation / lying-count paths

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)