### PR TITLE
Parse DNS resource records (answer/authority/additional)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `protocol_type` EtherType, so a GRE-tunnelled IPv4/IPv6 packet
   keeps decoding; the round-trip stays byte-exact regardless of which
   optional fields are present.
+- **DNS resource records** (`DNSResourceRecord`, RFC 1035 §4.1.3): the
+  answer, authority, and additional sections parse on demand —
+  `DNS.answers` / `DNS.authorities` / `DNS.additionals` yield records
+  (name, type + `rtype_name`, class, TTL, raw `rdata`, and a decoded
+  `rdata_text`: IPv4/IPv6 for A/AAAA, the target name for CNAME/NS/PTR,
+  and MX/TXT/SOA; hexadecimal otherwise). Parsing reads the raw sections
+  and never re-encodes, so the byte-exact round-trip holds; a record or
+  compressed name that runs past the message raises `InvalidFieldError`.
 
 ### Development
 - The real-capture fixture corpus gained `vlan_icmp.pcap` (802.1Q

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -29,7 +29,7 @@ from netprotocols.layer3.ipv6_ext import (
 from netprotocols.layer4.tcp import TCP
 from netprotocols.layer4.udp import UDP
 from netprotocols.layer7.dhcp import DHCP
-from netprotocols.layer7.dns import DNS
+from netprotocols.layer7.dns import DNS, DNSResourceRecord
 from netprotocols.packet import Packet
 from netprotocols.utils.exceptions import (
     InvalidFieldError,
@@ -55,6 +55,7 @@ __all__ = [
     "VLAN",
     "ARPHardwareType",
     "ARPOperation",
+    "DNSResourceRecord",
     "EtherType",
     "Ethernet",
     "ICMPv4",

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -7,9 +7,8 @@ pointer to an earlier offset in the message — so re-encoding parsed
 records cannot reproduce the original byte stream, and the library's
 byte-exact round-trip guarantee is load-bearing. Keeping the sections
 raw makes ``bytes(DNS.decode(x)) == x`` hold by construction; the
-name-reading accessors below parse on demand and never re-encode.
-
-Full resource-record parsing is a roadmap follow-up.
+question and resource-record accessors below parse on demand and never
+re-encode.
 """
 
 from __future__ import annotations
@@ -18,14 +17,63 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol
+from netprotocols._base import Protocol, bytes_to_ipv4, bytes_to_ipv6
 from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["DNS"]
+__all__ = ["DNS", "DNSResourceRecord"]
 
 #: A compressed name must not follow more than this many pointers; the
 #: bound makes a maliciously looping name terminate instead of hanging.
 _MAX_NAME_POINTERS = 128
+
+#: DNS resource-record types this library names (RFC 1035 §3.2.2 and
+#: later assignments); unknown types keep their numeric value.
+_RR_TYPE_NAMES: dict[int, str] = {
+    1: "A",
+    2: "NS",
+    5: "CNAME",
+    6: "SOA",
+    12: "PTR",
+    15: "MX",
+    16: "TXT",
+    28: "AAAA",
+    33: "SRV",
+    41: "OPT",
+    65: "HTTPS",
+    257: "CAA",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DNSResourceRecord:
+    """One DNS resource record (RFC 1035 §4.1.3).
+
+    :param name: The owner name, decompressed to dotted form.
+    :param rtype: Record type — ``1`` A, ``28`` AAAA, ``5`` CNAME, ...
+        (see :attr:`rtype_name`).
+    :param rclass: Record class (``1`` = IN). For an OPT record (type
+        ``41``) this field carries the requestor's UDP payload size.
+    :param ttl: Time to live in seconds.
+    :param rdata: The record's RDATA, kept raw.
+    :param rdata_text: A decoded, human-readable view of ``rdata`` — an
+        IPv4/IPv6 address for A/AAAA, the target name for CNAME/NS/PTR,
+        ``"preference exchange"`` for MX, the concatenated strings for
+        TXT, the field tuple for SOA; the hexadecimal RDATA for types
+        this library does not special-case.
+    """
+
+    name: str
+    rtype: int
+    rclass: int
+    ttl: int
+    rdata: bytes
+    rdata_text: str
+
+    @property
+    def rtype_name(self) -> str:
+        """Display name of the record type, e.g. ``"AAAA"``; falls back
+        to the numeric type for records unknown to this library."""
+        return _RR_TYPE_NAMES.get(self.rtype, str(self.rtype))
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,13 +180,14 @@ class DNS(Protocol):
     # -- first question (parsed on demand, never re-encoded) --
 
     def _read_name(self, offset: int) -> int:
-        """Follow the (possibly compressed) name at ``offset`` in the
-        whole message; return the offset just past its in-line portion.
+        """The offset just past the name's in-line bytes at ``offset``. A
+        compression pointer ends the in-line name (this does not follow
+        it — :meth:`_labels` does), so the result advances the cursor to
+        the field after the name.
 
-        :raises InvalidFieldError: on a malformed or looping name.
+        :raises InvalidFieldError: on a malformed name.
         """
         message = bytes(self)
-        pointers = 0
         cursor = offset
         while True:
             if cursor >= len(message):
@@ -146,18 +195,13 @@ class DNS(Protocol):
             length = message[cursor]
             if length == 0:
                 return cursor + 1
-            if length & 0xC0 == 0xC0:  # compression pointer
-                pointers += 1
-                if pointers > _MAX_NAME_POINTERS:
-                    raise InvalidFieldError("DNS name compression loops")
+            if length & 0xC0 == 0xC0:  # a pointer ends the in-line name
                 if cursor + 1 >= len(message):
                     raise InvalidFieldError("truncated DNS compression pointer")
-                cursor = ((length & 0x3F) << 8) | message[cursor + 1]
-            elif length & 0xC0:
+                return cursor + 2
+            if length & 0xC0:
                 raise InvalidFieldError("reserved DNS label length bits set")
-            else:
-                cursor += 1 + length
-        # unreachable
+            cursor += 1 + length
 
     def _labels(self, offset: int) -> str:
         """Decode the dotted name beginning at ``offset``.
@@ -232,3 +276,128 @@ class DNS(Protocol):
         is no question."""
         fixed = self._question_fixed()
         return None if fixed is None else fixed[1]
+
+    # -- resource records (parsed on demand, never re-encoded) --
+
+    def _sections_start(self) -> int:
+        """Offset of the first resource record: past the questions.
+
+        :raises InvalidFieldError: if the question section is truncated.
+        """
+        message = bytes(self)
+        cursor = self._struct.size
+        for _ in range(self.qdcount):
+            cursor = self._read_name(cursor)
+            cursor += 4  # QTYPE + QCLASS
+            if cursor > len(message):
+                raise InvalidFieldError("DNS question section truncated")
+        return cursor
+
+    def _decode_txt(self, rdata: bytes) -> str:
+        """Concatenate the character-strings of a TXT record (§3.3.14)."""
+        parts: list[str] = []
+        cursor = 0
+        while cursor < len(rdata):
+            length = rdata[cursor]
+            cursor += 1
+            if cursor + length > len(rdata):
+                raise InvalidFieldError("DNS TXT character-string overruns")
+            parts.append(
+                rdata[cursor : cursor + length].decode("ascii", "replace")
+            )
+            cursor += length
+        return "".join(parts)
+
+    def _decode_rdata(self, rtype: int, offset: int, rdlength: int) -> str:
+        """A human-readable rendering of the RDATA at ``offset``; names
+        follow compression against the whole message."""
+        message = bytes(self)
+        rdata = message[offset : offset + rdlength]
+        if rtype == 1 and rdlength == 4:  # A
+            return bytes_to_ipv4(rdata)
+        if rtype == 28 and rdlength == 16:  # AAAA
+            return bytes_to_ipv6(rdata)
+        if rtype in (2, 5, 12):  # NS, CNAME, PTR — a single name
+            return self._labels(offset)
+        if rtype == 15 and rdlength >= 2:  # MX — preference + exchange
+            preference = int.from_bytes(rdata[:2], "big")
+            return f"{preference} {self._labels(offset + 2)}"
+        if rtype == 16:  # TXT
+            return self._decode_txt(rdata)
+        if rtype == 6:  # SOA — mname, rname, then five 32-bit fields
+            mname = self._labels(offset)
+            rname_at = self._read_name(offset)
+            rname = self._labels(rname_at)
+            fixed = self._read_name(rname_at)
+            if fixed + 20 > len(message):
+                raise InvalidFieldError("DNS SOA record truncated")
+            serial, refresh, retry, expire, minimum = (
+                int.from_bytes(message[fixed + i : fixed + i + 4], "big")
+                for i in range(0, 20, 4)
+            )
+            return (
+                f"{mname} {rname} {serial} {refresh} {retry} {expire} {minimum}"
+            )
+        return rdata.hex()
+
+    def _parse_rr(self, cursor: int) -> tuple[DNSResourceRecord, int]:
+        """Parse the resource record at ``cursor``; return it and the
+        offset of the next record."""
+        message = bytes(self)
+        name = self._labels(cursor)
+        cursor = self._read_name(cursor)
+        if cursor + 10 > len(message):
+            raise InvalidFieldError("DNS resource record truncated")
+        rtype = int.from_bytes(message[cursor : cursor + 2], "big")
+        rclass = int.from_bytes(message[cursor + 2 : cursor + 4], "big")
+        ttl = int.from_bytes(message[cursor + 4 : cursor + 8], "big")
+        rdlength = int.from_bytes(message[cursor + 8 : cursor + 10], "big")
+        cursor += 10
+        if cursor + rdlength > len(message):
+            raise InvalidFieldError("DNS RDATA runs past the message")
+        record = DNSResourceRecord(
+            name=name,
+            rtype=rtype,
+            rclass=rclass,
+            ttl=ttl,
+            rdata=message[cursor : cursor + rdlength],
+            rdata_text=self._decode_rdata(rtype, cursor, rdlength),
+        )
+        return record, cursor + rdlength
+
+    def _resource_records(
+        self,
+    ) -> tuple[
+        tuple[DNSResourceRecord, ...],
+        tuple[DNSResourceRecord, ...],
+        tuple[DNSResourceRecord, ...],
+    ]:
+        """Parse the answer, authority, and additional sections.
+
+        :raises InvalidFieldError: if a record, its RDATA, or a name runs
+            past the message (bounded — never hangs or over-reads).
+        """
+        cursor = self._sections_start()
+        sections: list[tuple[DNSResourceRecord, ...]] = []
+        for count in (self.ancount, self.nscount, self.arcount):
+            records: list[DNSResourceRecord] = []
+            for _ in range(count):
+                record, cursor = self._parse_rr(cursor)
+                records.append(record)
+            sections.append(tuple(records))
+        return sections[0], sections[1], sections[2]
+
+    @property
+    def answers(self) -> tuple[DNSResourceRecord, ...]:
+        """The answer-section resource records, parsed on demand."""
+        return self._resource_records()[0]
+
+    @property
+    def authorities(self) -> tuple[DNSResourceRecord, ...]:
+        """The authority-section resource records, parsed on demand."""
+        return self._resource_records()[1]
+
+    @property
+    def additionals(self) -> tuple[DNSResourceRecord, ...]:
+        """The additional-section resource records, parsed on demand."""
+        return self._resource_records()[2]

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,6 +1,7 @@
 """DNS decoding, driven by the real corpus frames in udp_dns.pcap plus
 crafted cases for the decode contract and compression safety."""
 
+import socket
 import struct
 
 import pytest
@@ -9,6 +10,7 @@ from conftest import FIXTURES, read_pcap
 from netprotocols import (
     DNS,
     UDP,
+    DNSResourceRecord,
     Ethernet,
     InvalidFieldError,
     IPv4,
@@ -30,6 +32,47 @@ def build_query(qname_labels: list[str], qtype: int = 1) -> bytes:
         + qname
         + struct.pack("!HH", qtype, 1)
     )
+
+
+def encode_name(name: str) -> bytes:
+    if name in (".", ""):
+        return b"\x00"
+    return (
+        b"".join(bytes([len(part)]) + part.encode() for part in name.split("."))
+        + b"\x00"
+    )
+
+
+def rr(
+    name: str, rtype: int, rdata: bytes, *, rclass: int = 1, ttl: int = 300
+) -> bytes:
+    return (
+        encode_name(name)
+        + struct.pack("!HHIH", rtype, rclass, ttl, len(rdata))
+        + rdata
+    )
+
+
+def build_response(
+    question: str,
+    qtype: int = 1,
+    *,
+    answers: tuple[bytes, ...] = (),
+    authorities: tuple[bytes, ...] = (),
+    additionals: tuple[bytes, ...] = (),
+) -> bytes:
+    header = struct.pack(
+        "!HHHHHH",
+        0x1234,
+        0x8180,
+        1,
+        len(answers),
+        len(authorities),
+        len(additionals),
+    )
+    body = encode_name(question) + struct.pack("!HH", qtype, 1)
+    body += b"".join(answers) + b"".join(authorities) + b"".join(additionals)
+    return header + body
 
 
 class TestCorpusDNS:
@@ -66,6 +109,33 @@ class TestCorpusDNS:
         assert "example.com" in names
         assert "accounts.youtube.com" in names
 
+    def test_answers_parse_to_real_records(self):
+        records = [
+            record
+            for frame in CORPUS_DNS
+            for record in walk(frame)[0][-1].answers
+        ]
+        assert records
+        assert {"A", "AAAA", "CNAME"} <= {r.rtype_name for r in records}
+        # An A record's RDATA decodes to the dotted IPv4 in rdata_text.
+        a = next(r for r in records if r.rtype_name == "A")
+        assert a.rdata == socket.inet_aton(a.rdata_text)
+        # A CNAME's RDATA decompresses to a real target domain.
+        cname = next(r for r in records if r.rtype_name == "CNAME")
+        assert cname.rdata_text.endswith("google.com")
+
+    def test_authority_soa_and_additional_opt(self):
+        stacks = [walk(frame)[0][-1] for frame in CORPUS_DNS]
+        soas = [
+            r for d in stacks for r in d.authorities if r.rtype_name == "SOA"
+        ]
+        assert soas  # accounts.youtube.com authority is an SOA
+        assert soas[0].rdata_text.count(" ") == 6  # mname rname + 5 fields
+        opts = [
+            r for d in stacks for r in d.additionals if r.rtype_name == "OPT"
+        ]
+        assert opts  # every response carried an EDNS OPT pseudo-record
+
 
 class TestDNSFields:
     def test_flag_bits(self):
@@ -98,6 +168,166 @@ class TestDNSFields:
         dns = DNS.decode(raw)
         assert dns.header_len == len(raw)
         assert bytes(dns) == raw
+
+
+class TestDNSResourceRecords:
+    @staticmethod
+    def _ipv6(addr: str) -> bytes:
+        return socket.inet_pton(socket.AF_INET6, addr)
+
+    def test_a_record(self):
+        raw = build_response(
+            "host.example.com",
+            1,
+            answers=(rr("host.example.com", 1, socket.inet_aton("192.0.2.1")),),
+        )
+        (record,) = DNS.decode(raw).answers
+        assert isinstance(record, DNSResourceRecord)
+        assert record.name == "host.example.com"
+        assert record.rtype == 1
+        assert record.rtype_name == "A"
+        assert record.rclass == 1
+        assert record.ttl == 300
+        assert record.rdata_text == "192.0.2.1"
+
+    def test_aaaa_record(self):
+        raw = build_response(
+            "host.example.com",
+            28,
+            answers=(rr("host.example.com", 28, self._ipv6("2001:db8::1")),),
+        )
+        (record,) = DNS.decode(raw).answers
+        assert record.rtype_name == "AAAA"
+        assert record.rdata_text == "2001:db8::1"
+
+    def test_cname_target_name(self):
+        raw = build_response(
+            "alias.example.com",
+            5,
+            answers=(
+                rr("alias.example.com", 5, encode_name("target.example.com")),
+            ),
+        )
+        (record,) = DNS.decode(raw).answers
+        assert record.rtype_name == "CNAME"
+        assert record.rdata_text == "target.example.com"
+
+    def test_mx_record(self):
+        rdata = struct.pack("!H", 10) + encode_name("mail.example.com")
+        raw = build_response(
+            "example.com", 15, answers=(rr("example.com", 15, rdata),)
+        )
+        (record,) = DNS.decode(raw).answers
+        assert record.rtype_name == "MX"
+        assert record.rdata_text == "10 mail.example.com"
+
+    def test_txt_record(self):
+        rdata = bytes([5]) + b"hello" + bytes([6]) + b"world!"
+        raw = build_response(
+            "example.com", 16, answers=(rr("example.com", 16, rdata),)
+        )
+        (record,) = DNS.decode(raw).answers
+        assert record.rtype_name == "TXT"
+        assert record.rdata_text == "helloworld!"
+
+    def test_soa_record(self):
+        rdata = (
+            encode_name("ns.example.com")
+            + encode_name("admin.example.com")
+            + struct.pack("!IIIII", 1, 2, 3, 4, 5)
+        )
+        raw = build_response(
+            "example.com", 6, authorities=(rr("example.com", 6, rdata),)
+        )
+        (record,) = DNS.decode(raw).authorities
+        assert record.rtype_name == "SOA"
+        assert record.rdata_text == "ns.example.com admin.example.com 1 2 3 4 5"
+
+    def test_unknown_type_keeps_hex_rdata(self):
+        raw = build_response(
+            "example.com",
+            1,
+            answers=(rr("example.com", 99, b"\xde\xad\xbe\xef"),),
+        )
+        (record,) = DNS.decode(raw).answers
+        assert record.rtype_name == "99"
+        assert record.rdata == b"\xde\xad\xbe\xef"
+        assert record.rdata_text == "deadbeef"
+
+    def test_sections_split_by_count(self):
+        raw = build_response(
+            "example.com",
+            1,
+            answers=(rr("example.com", 1, socket.inet_aton("192.0.2.1")),),
+            authorities=(rr("example.com", 2, encode_name("ns.example.com")),),
+            additionals=(
+                rr("ns.example.com", 1, socket.inet_aton("192.0.2.53")),
+            ),
+        )
+        dns = DNS.decode(raw)
+        assert [r.rtype_name for r in dns.answers] == ["A"]
+        assert [r.rtype_name for r in dns.authorities] == ["NS"]
+        assert [r.rtype_name for r in dns.additionals] == ["A"]
+
+    def test_no_records_is_empty(self):
+        dns = DNS.decode(build_query(["example", "com"]))
+        assert dns.answers == ()
+        assert dns.authorities == ()
+        assert dns.additionals == ()
+
+    def test_round_trip_preserved(self):
+        raw = build_response(
+            "example.com",
+            1,
+            answers=(rr("example.com", 1, socket.inet_aton("192.0.2.1")),),
+        )
+        assert bytes(DNS.decode(raw)) == raw
+
+    def test_rdata_running_past_message_raises(self):
+        raw = build_response(
+            "example.com",
+            1,
+            answers=(rr("example.com", 1, socket.inet_aton("192.0.2.1")),),
+        )
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw[:-2]).answers  # RDATA now overruns the buffer
+
+    def test_lying_answer_count_raises(self):
+        header = struct.pack("!HHHHHH", 1, 0x8180, 1, 2, 0, 0)  # ancount=2
+        body = encode_name("example.com") + struct.pack("!HH", 1, 1)
+        body += rr("example.com", 1, socket.inet_aton("192.0.2.1"))  # only 1
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(header + body).answers
+
+    def test_record_header_truncated_raises(self):
+        # An answer name present, but no room for the 10 fixed bytes.
+        header = struct.pack("!HHHHHH", 1, 0x8180, 1, 1, 0, 0)
+        body = encode_name("example.com") + struct.pack("!HH", 1, 1)
+        body += encode_name("x")  # a name, then the message ends
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(header + body).answers
+
+    def test_question_section_truncated_raises(self):
+        # qdcount=1 but the question has no room for QTYPE/QCLASS.
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 1, 0, 0) + encode_name("a")
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).answers
+
+    def test_txt_character_string_overrun_raises(self):
+        rdata = bytes([10]) + b"abc"  # declares 10 bytes, only 3 follow
+        raw = build_response(
+            "example.com", 16, answers=(rr("example.com", 16, rdata),)
+        )
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).answers
+
+    def test_soa_truncated_raises(self):
+        rdata = encode_name("ns") + encode_name("r") + b"\x00\x00"
+        raw = build_response(
+            "example.com", 6, authorities=(rr("example.com", 6, rdata),)
+        )
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).authorities
 
 
 class TestDNSContract:
@@ -137,6 +367,29 @@ class TestDNSContract:
         bad = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x09abc"
         with pytest.raises(InvalidFieldError):
             _ = DNS.decode(bad).question_type
+
+    def test_lone_pointer_byte_raises_reading_past_name(self):
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\xc0"
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_type  # via _read_name
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_name  # via _labels
+
+    def test_reserved_length_bits_raise_reading_past_name(self):
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x40\x00"
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_type  # via _read_name
+
+    def test_label_overruns_message_in_labels(self):
+        # Declares a 9-byte label but only three bytes follow.
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x09abc"
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_name  # via _labels
+
+    def test_question_without_qtype_qclass_raises(self):
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + encode_name("a")
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_type
 
 
 class TestDNSDispatch:


### PR DESCRIPTION
`DNS` decoded the 12-byte header and the first question, keeping the sections raw. This parses the answer/authority/additional resource records on demand (RFC 1035 §4.1.3) — the first of the two remaining documented follow-ups.

## What changed
- **`DNSResourceRecord`** value type: `name` (decompressed), `rtype` (+ `rtype_name`), `rclass`, `ttl`, raw `rdata`, and a decoded `rdata_text` — IPv4/IPv6 for A/AAAA, the target name for CNAME/NS/PTR, `"pref exchange"` for MX, joined strings for TXT, the field tuple for SOA; hex for types not special-cased. Exported from the package.
- **`DNS.answers` / `DNS.authorities` / `DNS.additionals`** accessors, each a tuple of records parsed on demand. Reads the raw sections and never re-encodes, so `bytes(DNS.decode(x)) == x` still holds; a record, its RDATA, or a compressed name that overruns the message raises `InvalidFieldError`.
- **Bug fix in `_read_name`**: it *followed* compression pointers instead of stopping at them (returning an offset in the pointed-to region). Dormant until now — it only ran on the never-compressed question name — but resource-record names are routinely compressed, so advancing past them needs the pointer to end the in-line name.

## Verification
- Parses the real `udp_dns.pcap` answers correctly: two AAAA for example.com, CNAME→A / CNAME→AAAA chains for accounts.youtube.com, an SOA authority, and EDNS OPT additionals
- `pytest` 603 passed; **`dns.py` at 100%** coverage · `ruff check` · `ruff format --check` · `mypy` — all clean
- Unit tests cover A/AAAA/CNAME/MX/TXT/SOA, unknown-type hex fallback, section splitting, empty sections, byte-exact round-trip, and every malformed/truncation path

Closes #54. One follow-up remains: TCP application-protocol dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)