### PR TITLE
Dispatch TCP application protocols (DNS over TCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and MX/TXT/SOA; hexadecimal otherwise). Parsing reads the raw sections
   and never re-encodes, so the byte-exact round-trip holds; a record or
   compressed name that runs past the message raises `InvalidFieldError`.
+- **DNS over TCP** (`DNSOverTCP`, RFC 1035 §4.2.2): `TCP.next_protocol()`
+  now dispatches application protocols by well-known port
+  (`layer4._ports.tcp_app_class`). DNS over TCP is length-prefixed, so
+  port 53 chains through a 2-byte `DNSOverTCP` length shim — a layer
+  between `TCP` and the `DNS` message, like a VLAN tag between Ethernet
+  and its payload — and the walk reaches the DNS message (records and
+  all) at its true offset. Non-DNS ports still end the chain at TCP.
 
 ### Development
 - The real-capture fixture corpus gained `vlan_icmp.pcap` (802.1Q

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -29,7 +29,7 @@ from netprotocols.layer3.ipv6_ext import (
 from netprotocols.layer4.tcp import TCP
 from netprotocols.layer4.udp import UDP
 from netprotocols.layer7.dhcp import DHCP
-from netprotocols.layer7.dns import DNS, DNSResourceRecord
+from netprotocols.layer7.dns import DNS, DNSOverTCP, DNSResourceRecord
 from netprotocols.packet import Packet
 from netprotocols.utils.exceptions import (
     InvalidFieldError,
@@ -55,6 +55,7 @@ __all__ = [
     "VLAN",
     "ARPHardwareType",
     "ARPOperation",
+    "DNSOverTCP",
     "DNSResourceRecord",
     "EtherType",
     "Ethernet",

--- a/src/netprotocols/layer4/_ports.py
+++ b/src/netprotocols/layer4/_ports.py
@@ -10,16 +10,17 @@ request targets the server's well-known port) and then the source port
 validate strictly on decode so that a wrong guess degrades to the
 library's ordinary malformed-frame path rather than yielding garbage.
 
-Only UDP is wired this round. TCP application protocols (DNS over TCP
-carries a 2-byte length prefix, RFC 1035 §4.2.2) need their own
-handling and are left for later.
+DNS over TCP carries a 2-byte length prefix (RFC 1035 §4.2.2), so the
+TCP dispatch names a small length-prefix shim (``DNSOverTCP``) rather
+than ``DNS`` directly; the shim consumes the prefix and then chains to
+the DNS message, keeping the chain walk uniform.
 """
 
 from __future__ import annotations
 
 from netprotocols._base import Protocol
 
-__all__ = ["udp_app_class"]
+__all__ = ["tcp_app_class", "udp_app_class"]
 
 
 def udp_app_class(src_port: int, dst_port: int) -> type[Protocol] | None:
@@ -32,4 +33,19 @@ def udp_app_class(src_port: int, dst_port: int) -> type[Protocol] | None:
     from netprotocols.layer7.dns import DNS
 
     registry: dict[int, type[Protocol]] = {53: DNS, 67: DHCP, 68: DHCP}
+    return registry.get(dst_port) or registry.get(src_port)
+
+
+def tcp_app_class(src_port: int, dst_port: int) -> type[Protocol] | None:
+    """The class that decodes a TCP payload, chosen by well-known port.
+
+    DNS over TCP is length-prefixed (RFC 1035 §4.2.2), so port 53 names
+    :class:`~netprotocols.DNSOverTCP` — a 2-byte length shim that then
+    chains to the DNS message. Returns ``None`` when neither port names a
+    known application protocol (the common case, where the chain ends at
+    TCP).
+    """
+    from netprotocols.layer7.dns import DNSOverTCP
+
+    registry: dict[int, type[Protocol]] = {53: DNSOverTCP}
     return registry.get(dst_port) or registry.get(src_port)

--- a/src/netprotocols/layer4/tcp.py
+++ b/src/netprotocols/layer4/tcp.py
@@ -132,6 +132,16 @@ class TCP(Protocol):
     def header_len(self) -> int:
         return self.data_offset * 4
 
+    def next_protocol(self) -> type[Protocol] | None:
+        """The application protocol carried by this segment, chosen by
+        well-known port (best-effort — see
+        :mod:`netprotocols.layer4._ports`); ``None`` when neither port is
+        recognized. DNS over TCP is length-prefixed, so it chains through
+        a :class:`~netprotocols.DNSOverTCP` shim."""
+        from netprotocols.layer4._ports import tcp_app_class
+
+        return tcp_app_class(self.src_port, self.dst_port)
+
     @property
     def flags_str(self) -> str:
         """Space-separated names of the flags set on the segment, e.g.

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -20,7 +20,7 @@ from typing import ClassVar, Self
 from netprotocols._base import Protocol, bytes_to_ipv4, bytes_to_ipv6
 from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["DNS", "DNSResourceRecord"]
+__all__ = ["DNS", "DNSOverTCP", "DNSResourceRecord"]
 
 #: A compressed name must not follow more than this many pointers; the
 #: bound makes a maliciously looping name terminate instead of hanging.
@@ -401,3 +401,36 @@ class DNS(Protocol):
     def additionals(self) -> tuple[DNSResourceRecord, ...]:
         """The additional-section resource records, parsed on demand."""
         return self._resource_records()[2]
+
+
+@dataclass(frozen=True, slots=True)
+class DNSOverTCP(Protocol):
+    """The two-octet length prefix that frames a DNS message over TCP
+    (RFC 1035 §4.2.2).
+
+    Over TCP a DNS message is preceded by its length as a 16-bit field.
+    This models that prefix as a 2-byte shim between :class:`~netprotocols.TCP`
+    and the :class:`DNS` message — like a VLAN tag between Ethernet and
+    its payload — so the chain walk decodes ``[..., TCP, DNSOverTCP,
+    DNS]`` and the DNS message parses at its true offset. It is reached
+    only from :meth:`~netprotocols.TCP.next_protocol` on a DNS port.
+
+    :param message_length: Length in bytes of the DNS message that
+        follows this prefix.
+    """
+
+    message_length: int
+
+    _struct: ClassVar[Struct] = Struct("!H")
+
+    @classmethod
+    def decode(cls, data: bytes | memoryview) -> Self:
+        (message_length,) = cls._unpack_fixed(data)
+        return cls(message_length=message_length)
+
+    def __bytes__(self) -> bytes:
+        return self._struct.pack(self.message_length)
+
+    def next_protocol(self) -> type[Protocol] | None:
+        """The DNS message this length prefix frames."""
+        return DNS

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -9,7 +9,9 @@ import pytest
 from conftest import FIXTURES, read_pcap
 from netprotocols import (
     DNS,
+    TCP,
     UDP,
+    DNSOverTCP,
     DNSResourceRecord,
     Ethernet,
     InvalidFieldError,
@@ -73,6 +75,22 @@ def build_response(
     body = encode_name(question) + struct.pack("!HH", qtype, 1)
     body += b"".join(answers) + b"".join(authorities) + b"".join(additionals)
     return header + body
+
+
+def tcp_segment(*, src_port: int, dst_port: int, payload: bytes) -> bytes:
+    tcp = TCP(
+        src_port=src_port,
+        dst_port=dst_port,
+        seq=1,
+        ack=1,
+        data_offset=5,
+        reserved=0,
+        flags=0x018,  # PSH + ACK
+        window=0,
+        checksum=0,
+        urgent_pointer=0,
+    )
+    return bytes(tcp) + payload
 
 
 class TestCorpusDNS:
@@ -419,3 +437,53 @@ class TestDNSDispatch:
 
     def test_dns_ends_the_chain(self):
         assert DNS.decode(build_query(["x"])).next_protocol() is None
+
+
+class TestDNSOverTCP:
+    def test_shim_decodes_length_and_chains(self):
+        shim = DNSOverTCP.decode(struct.pack("!H", 56) + b"x" * 56)
+        assert shim.message_length == 56
+        assert shim.header_len == 2
+        assert shim.next_protocol() is DNS
+        assert bytes(shim) == struct.pack("!H", 56)
+
+    def test_truncated_prefix_raises(self):
+        with pytest.raises(TruncatedHeaderError):
+            DNSOverTCP.decode(b"\x00")
+
+    def test_tcp_port_53_dispatches_to_shim(self):
+        to_server = TCP.decode(
+            tcp_segment(src_port=40000, dst_port=53, payload=b"")
+        )
+        assert to_server.next_protocol() is DNSOverTCP
+        from_server = TCP.decode(
+            tcp_segment(src_port=53, dst_port=40000, payload=b"")
+        )
+        assert from_server.next_protocol() is DNSOverTCP
+
+    def test_non_dns_tcp_port_ends_chain(self):
+        https = TCP.decode(tcp_segment(src_port=443, dst_port=443, payload=b""))
+        assert https.next_protocol() is None
+
+    def test_full_tcp_dns_walk_with_records(self):
+        message = build_response(
+            "example.com",
+            1,
+            answers=(rr("example.com", 1, socket.inet_aton("93.184.216.34")),),
+        )
+        payload = struct.pack("!H", len(message)) + message
+        frame = tcp_segment(src_port=40000, dst_port=53, payload=payload)
+        layers = []
+        cursor, protocol = 0, TCP
+        while protocol is not None:
+            header = protocol.decode(frame[cursor:])
+            layers.append(header)
+            cursor += header.header_len
+            protocol = header.next_protocol()
+        assert [type(layer) for layer in layers] == [TCP, DNSOverTCP, DNS]
+        assert layers[1].message_length == len(message)
+        dns = layers[2]
+        assert dns.question_name == "example.com"
+        (a,) = dns.answers
+        assert (a.rtype_name, a.rdata_text) == ("A", "93.184.216.34")
+        assert b"".join(bytes(layer) for layer in layers) == frame


### PR DESCRIPTION
The last documented follow-up. `TCP.next_protocol()` ended the chain; this adds TCP application-protocol dispatch by well-known port, alongside the existing UDP dispatch.

## The DNS-over-TCP length prefix
DNS over TCP is length-prefixed — a 2-byte length precedes the message (RFC 1035 §4.2.2), which is why TCP dispatch was left for later. Rather than special-case it, this models the prefix as a small **`DNSOverTCP`** shim layer — a 2-byte length between `TCP` and the `DNS` message, exactly like a VLAN tag between Ethernet and its payload. The chain walk stays uniform:

```
Ethernet → IPv4 → TCP → DNSOverTCP → DNS  (records and all)
```

## What changed
- **`DNSOverTCP`** (`layer7/dns.py`) — the 2-byte length shim; `header_len` is 2, `next_protocol()` is `DNS`, so the DNS message parses at its true offset. Exported from the package.
- **`tcp_app_class`** (`layer4/_ports.py`) — the TCP port registry (`{53: DNSOverTCP}`), destination-then-source like the UDP one.
- **`TCP.next_protocol()`** — dispatches through it.

## Verification
- `pytest` 608 passed; **`dns.py` and `_ports.py` at 100%** coverage · `ruff check` · `ruff format --check` · `mypy` — all clean
- Tests: the shim decodes/round-trips, port 53 (dst and src) dispatches, non-DNS ports end the chain at TCP, and a full `TCP → DNSOverTCP → DNS` walk decodes an A record and round-trips the whole frame layer by layer
- Corpus HTTP/HTTPS (ports 80/443) frames are unaffected — they still end at TCP

Closes #56. This clears the last documented roadmap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)