### PR TITLE
Refresh the README (coverage table, roadmap, corpus count)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,7 +241,7 @@ src/netprotocols/
 tests/              one file per protocol + test_contract.py
                     (truncation, lying lengths, chain walks),
                     test_corpus.py (invariants over the real-capture
-                    corpus in tests/fixtures/, 65 frames across 12
+                    corpus in tests/fixtures/, 93 frames across 16
                     scenarios — see its MANIFEST.md), test_checksum.py
                     (corpus checksums recompute to wire values), and
                     test_fuzz.py (hypothesis properties: decode never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ladder, the decode contract, the add-a-protocol enforcement points,
   and the fixture-capture workflow), a pull-request template, and
   bug-report / protocol-request issue templates under `.github/`.
+- README refresh: the Protocol coverage table gains the shipped `DHCP`
+  and `GRE` rows, the `DNS` row notes resource-record parsing and the
+  DNS-over-TCP length shim, and the `IGMP` row notes the IGMPv3 report
+  and query parsing. The Roadmap section now lists only the remaining
+  items, linking the open decoder-depth issues (#59-#66, tracked by
+  #67), and the stale corpus figure is corrected to 93 frames across 16
+  scenarios here and in `ARCHITECTURE.md`.
 
 ## [1.2.0] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Requires Python 3.12+. Fully typed (`py.typed`, mypy strict).
 | 3 | IPv6 Destination Options | `IPv6DestinationOptions` | RFC 8200 §4.6 |
 | 3 | ICMPv4 | `ICMPv4` | RFC 792, 8-byte header |
 | 3 | ICMPv6 | `ICMPv6` | RFC 4443, 8-byte header |
-| 3 | IGMP | `IGMP` | RFC 1112/2236/3376, IPv4 multicast management |
+| 3 | IGMP | `IGMP` | RFC 1112/2236/3376, IPv4 multicast management; IGMPv3 report group records + query fields |
+| 3 | GRE | `GRE` | RFC 2784/2890, IP protocol 47; payload chains onward by EtherType |
 | 4 | TCP | `TCP` | RFC 9293, data-offset/options aware |
 | 4 | UDP | `UDP` | RFC 768 |
-| 7 | DNS | `DNS` | RFC 1035, over UDP; header + on-demand name decompression |
+| 7 | DNS | `DNS` | RFC 1035, over UDP and TCP (`DNSOverTCP` length shim); on-demand name decompression + resource-record parsing |
+| 7 | DHCP | `DHCP` | RFC 2131/2132, over UDP 67/68; TLV options parsed on demand |
 
 ## Decoding a captured frame
 
@@ -133,19 +135,33 @@ monitor built on it (formerly Packet-Sniffer).
 
 ## Roadmap
 
-- More protocols: DHCP, GRE (802.1Q VLAN tags, DNS, and IGMP have shipped).
-- Full DNS resource-record parsing (the header and question are decoded today; answer/authority/additional sections are kept raw).
-- IGMPv3 group-record parsing (the common header is decoded today; v3 report records are kept raw in the body).
-- Optional richer address accessors (`ipaddress` / EUI objects
-  alongside the `str` fields).
-- TLV parsing inside IPv6 extension-header options.
+The next wave is decoder depth on already-supported layers, tracked by
+[#67](https://github.com/EONRaider/NETProtocols/issues/67):
+
+- TCP option parsing — MSS, window scale, SACK, timestamps
+  ([#59](https://github.com/EONRaider/NETProtocols/issues/59)).
+- ICMP message bodies — echo identifier/sequence, the embedded original
+  packet in error messages
+  ([#60](https://github.com/EONRaider/NETProtocols/issues/60)).
+- IPv6 Neighbor Discovery (NDP) messages and options
+  ([#61](https://github.com/EONRaider/NETProtocols/issues/61)).
+- TLV parsing inside IPv6 extension-header options
+  ([#62](https://github.com/EONRaider/NETProtocols/issues/62)).
+- A GRE arm for `netprotocols.checksum`
+  ([#63](https://github.com/EONRaider/NETProtocols/issues/63)).
+- A real-capture DNS-over-TCP corpus fixture
+  ([#64](https://github.com/EONRaider/NETProtocols/issues/64)).
+- Richer address accessors (`ipaddress` objects alongside the `str`
+  fields) ([#65](https://github.com/EONRaider/NETProtocols/issues/65)).
+- IPv4 option parsing — Router Alert, Record Route, Timestamp
+  ([#66](https://github.com/EONRaider/NETProtocols/issues/66)).
 
 ## Contributing
 
 Development uses [uv](https://docs.astral.sh/uv/): `uv sync`, then
 `uv run pytest`, `uv run mypy`, and `uv run ruff check` — all three are
 enforced by CI on Python 3.12–3.14. The test suite is anchored by a
-77-frame corpus of real captured traffic
+93-frame corpus of real captured traffic across 16 scenarios
 ([tests/fixtures/MANIFEST.md](tests/fixtures/MANIFEST.md)) plus
 property-based fuzzing of the decode path. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and


### PR DESCRIPTION
## Summary

The README drifted behind the recent roadmap work: the Roadmap section still listed shipped features (DHCP, GRE, full DNS resource-record parsing, IGMPv3 group records) as to-do, the Protocol coverage table omitted DHCP and GRE, and the Contributing section cited a 77-frame corpus that has grown to 93 frames across 16 scenarios. This brings the docs back in line with the shipped state.

## What's included

- Coverage table: new `DHCP` (RFC 2131/2132, over UDP 67/68) and `GRE` (RFC 2784/2890, IP protocol 47) rows; the `DNS` row now notes resource-record parsing and the `DNSOverTCP` length shim; the `IGMP` row notes IGMPv3 report group records + query fields.
- Roadmap section rewritten to the remaining items only, each linking its open issue (#59–#66) under the post-1.2 tracking issue #67.
- Corpus figure corrected wherever it appears: README (77 → 93 frames across 16 scenarios) and the ARCHITECTURE.md test-suite tree (65/12 → 93/16).
- `CHANGELOG.md` entry under `## [Unreleased]` (Development).

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (608 passed; CI runs it on Python 3.12 / 3.13 / 3.14)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Notes

Docs-only change. The other roadmap PRs (#59–#66) each add their own `CHANGELOG.md` entry under `## [Unreleased]`, so overlapping hunks there are expected at merge time.

Closes #58.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_