### PR TITLE
Parse TCP options (MSS, window scale, SACK, timestamps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and MX/TXT/SOA; hexadecimal otherwise). Parsing reads the raw sections
   and never re-encodes, so the byte-exact round-trip holds; a record or
   compressed name that runs past the message raises `InvalidFieldError`.
+- **TCP options** (`TCPOption`, RFC 9293 §3.1): the options TLV list
+  now parses on demand — `TCP.parsed_options` yields one `TCPOption`
+  per option in wire order (kind + `kind_name`, raw `data`, and a
+  decoded `value` where this library understands the kind: the segment
+  size for MSS, the shift count for Window Scale, a `(tsval, tsecr)`
+  pair for Timestamps, and `(left_edge, right_edge)` pairs for SACK;
+  RFC 7323/2018). EOL and NOP are single-byte (EOL ends the parse);
+  unknown kinds keep their raw `data` with `value` degrading to `None`.
+  Parsing reads the raw `options` bytes and never re-encodes, so the
+  byte-exact round-trip is preserved, and an option length below the
+  TLV minimum or one that runs past the options raises
+  `InvalidFieldError` (bounded — never hangs or over-reads).
 - **DNS over TCP** (`DNSOverTCP`, RFC 1035 §4.2.2): `TCP.next_protocol()`
   now dispatches application protocols by well-known port
   (`layer4._ports.tcp_app_class`). DNS over TCP is length-prefixed, so

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -26,7 +26,7 @@ from netprotocols.layer3.ipv6_ext import (
     IPv6HopByHopOptions,
     IPv6Routing,
 )
-from netprotocols.layer4.tcp import TCP
+from netprotocols.layer4.tcp import TCP, TCPOption
 from netprotocols.layer4.udp import UDP
 from netprotocols.layer7.dhcp import DHCP
 from netprotocols.layer7.dns import DNS, DNSOverTCP, DNSResourceRecord
@@ -76,6 +76,7 @@ __all__ = [
     "Packet",
     "Protocol",
     "ProtocolError",
+    "TCPOption",
     "TruncatedHeaderError",
     "__version__",
     "compute",

--- a/src/netprotocols/layer4/tcp.py
+++ b/src/netprotocols/layer4/tcp.py
@@ -1,4 +1,13 @@
-"""TCP segment header (RFC 793 / 9293)."""
+"""TCP segment header (RFC 793 / 9293).
+
+The header is decoded in full, with the options kept as raw ``bytes``
+(data-offset aware) so ``bytes(TCP.decode(x)) == x`` holds by
+construction. The ``parsed_options`` accessor walks the option TLV list
+on demand and never re-encodes: the common kinds — MSS, window scale,
+SACK-Permitted, SACK, and timestamps (RFC 9293 §3.2, RFC 7323,
+RFC 2018) — decode to typed values, and unknown kinds keep their raw
+data.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +21,85 @@ from netprotocols.utils.exceptions import (
     TruncatedHeaderError,
 )
 
-__all__ = ["TCP"]
+__all__ = ["TCP", "TCPOption"]
+
+#: Single-byte option kinds that carry no length or value (RFC 9293
+#: §3.2): End of Option List terminates the parse, No-Operation pads.
+_OPT_EOL = 0
+_OPT_NOP = 1
+
+#: Kind/length/value option kinds this library decodes.
+_OPT_MSS = 2
+_OPT_WINDOW_SCALE = 3
+_OPT_SACK_PERMITTED = 4
+_OPT_SACK = 5
+_OPT_TIMESTAMPS = 8
+
+#: TCP option kinds this library names (RFC 9293 §3.2; RFC 7323 for
+#: Window Scale and Timestamps; RFC 2018 for SACK); unknown kinds fall
+#: back to their numeric value.
+_OPTION_KIND_NAMES: dict[int, str] = {
+    _OPT_EOL: "End of Option List",
+    _OPT_NOP: "No-Operation",
+    _OPT_MSS: "Maximum Segment Size",
+    _OPT_WINDOW_SCALE: "Window Scale",
+    _OPT_SACK_PERMITTED: "SACK Permitted",
+    _OPT_SACK: "SACK",
+    _OPT_TIMESTAMPS: "Timestamps",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TCPOption:
+    """One TCP option (RFC 9293 §3.1).
+
+    :param kind: Option kind — ``0`` End of Option List, ``1``
+        No-Operation, ``2`` MSS, ``3`` Window Scale, ``4``
+        SACK-Permitted, ``5`` SACK, ``8`` Timestamps (see
+        :attr:`kind_name`).
+    :param data: The option's value bytes, kept raw; empty for the
+        single-byte kinds (EOL, NOP) and for SACK-Permitted.
+    """
+
+    kind: int
+    data: bytes = b""
+
+    @property
+    def kind_name(self) -> str:
+        """Display name of the option kind, e.g. ``"Timestamps"``; falls
+        back to ``"unknown (n)"`` for kinds this library does not name."""
+        return _OPTION_KIND_NAMES.get(self.kind, f"unknown ({self.kind})")
+
+    @property
+    def value(
+        self,
+    ) -> int | tuple[int, int] | tuple[tuple[int, int], ...] | None:
+        """The decoded value, for the kinds this library understands:
+        the segment size for MSS, the shift count for Window Scale, a
+        ``(tsval, tsecr)`` pair for Timestamps, and a tuple of
+        ``(left_edge, right_edge)`` pairs for SACK. ``None`` — read
+        :attr:`data` raw instead — for the single-byte kinds,
+        SACK-Permitted (its presence is its meaning), kinds this
+        library does not decode, and data whose length does not match
+        its kind (degrades, never raises)."""
+        if self.kind == _OPT_MSS and len(self.data) == 2:
+            return int.from_bytes(self.data, "big")
+        if self.kind == _OPT_WINDOW_SCALE and len(self.data) == 1:
+            return self.data[0]
+        if self.kind == _OPT_TIMESTAMPS and len(self.data) == 8:
+            return (
+                int.from_bytes(self.data[:4], "big"),
+                int.from_bytes(self.data[4:], "big"),
+            )
+        if self.kind == _OPT_SACK and self.data and len(self.data) % 8 == 0:
+            return tuple(
+                (
+                    int.from_bytes(self.data[block : block + 4], "big"),
+                    int.from_bytes(self.data[block + 4 : block + 8], "big"),
+                )
+                for block in range(0, len(self.data), 8)
+            )
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,7 +119,8 @@ class TCP(Protocol):
         computes nor verifies checksums).
     :param urgent_pointer: Urgent pointer.
     :param options: Raw options bytes; length must be a multiple of 4
-        consistent with ``data_offset``.
+        consistent with ``data_offset``. Parsed on demand via
+        :attr:`parsed_options`.
     """
 
     src_port: int
@@ -161,3 +249,45 @@ class TCP(Protocol):
     def checksum_hex_str(self) -> str:
         """The checksum as a hexadecimal string, e.g. ``"0x2e5b"``."""
         return f"{self.checksum:#06x}"
+
+    # -- options TLV list (parsed on demand, never re-encoded) --
+
+    @property
+    def parsed_options(self) -> tuple[TCPOption, ...]:
+        """The options as a tuple of :class:`TCPOption`, in wire order,
+        parsed on demand (RFC 9293 §3.1). The single-byte kinds (EOL,
+        NOP) carry no data; an End of Option List option ends the parse,
+        so whatever follows it is padding and is not returned. Empty for
+        a header without options.
+
+        :raises InvalidFieldError: if an option's declared length is
+            below the 2-byte TLV minimum or runs past the options bytes
+            (bounded — never hangs or over-reads).
+        """
+        raw = self.options
+        parsed: list[TCPOption] = []
+        cursor = 0
+        while cursor < len(raw):
+            kind = raw[cursor]
+            if kind in (_OPT_EOL, _OPT_NOP):
+                parsed.append(TCPOption(kind=kind))
+                if kind == _OPT_EOL:
+                    break
+                cursor += 1
+                continue
+            if cursor + 1 >= len(raw):
+                raise InvalidFieldError("TCP option missing its length byte")
+            length = raw[cursor + 1]
+            if length < 2:
+                raise InvalidFieldError(
+                    f"TCP option length must be at least 2, got {length}"
+                )
+            if cursor + length > len(raw):
+                raise InvalidFieldError(
+                    "TCP option value runs past the options bytes"
+                )
+            parsed.append(
+                TCPOption(kind=kind, data=raw[cursor + 2 : cursor + length])
+            )
+            cursor += length
+        return tuple(parsed)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -112,6 +112,27 @@ class TestCorpusCoverage:
             if isinstance(layer, TCP)
         )
 
+    def test_tcp_options_parse_across_the_corpus(self):
+        """Every options-bearing captured segment parses; the corpus
+        rides established connections, so the options are the classic
+        NOP, NOP, Timestamps layout (no SYN was captured — see the
+        MANIFEST — so MSS and friends are exercised by crafted tests)."""
+        options = [
+            option
+            for _, _, frame in CORPUS
+            for layer in walk(frame)[0]
+            if isinstance(layer, TCP)
+            for option in layer.parsed_options
+        ]
+        kinds = {option.kind for option in options}
+        assert kinds == {1, 8}  # No-Operation + Timestamps
+        for option in options:
+            if option.kind == 8:
+                assert option.kind_name == "Timestamps"
+                tsval_tsecr = option.value
+                assert isinstance(tsval_tsecr, tuple)
+                assert len(tsval_tsecr) == 2
+
 
 class TestFragmentHandling:
     """Regression: real fragmented traffic exposed that IPv4 chained

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -200,3 +200,18 @@ class TestDNSNameAccessorSafety:
             with contextlib.suppress(InvalidFieldError):
                 name = dns.question_name
                 assert name is None or isinstance(name, str)
+
+
+class TestTCPOptionAccessorSafety:
+    @given(data=fuzz_input)
+    def test_parsed_options_never_hang_or_escape(self, data: bytes) -> None:
+        """The options accessor parses untrusted TLV bytes: it must
+        return a tuple or raise InvalidFieldError, never hang and never
+        raise anything else — and the per-option display helpers and
+        decoded values must never raise at all."""
+        with contextlib.suppress(ProtocolError):
+            tcp = TCP.decode(data)
+            with contextlib.suppress(InvalidFieldError):
+                for option in tcp.parsed_options:
+                    assert option.kind_name
+                    _ = option.value

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -1,6 +1,25 @@
 import pytest
 
-from netprotocols import TCP, InvalidFieldError
+from netprotocols import TCP, InvalidFieldError, TCPOption
+
+
+def tcp_with_options(options: bytes) -> TCP:
+    """A minimal segment carrying ``options`` (padded to whole words)."""
+    if len(options) % 4:
+        options += b"\x00" * (4 - len(options) % 4)
+    return TCP(
+        src_port=1022,
+        dst_port=22,
+        seq=1,
+        ack=1,
+        data_offset=5 + len(options) // 4,
+        reserved=0,
+        flags=0x012,
+        window=64,
+        checksum=0,
+        urgent_pointer=0,
+        options=options,
+    )
 
 
 class TestTCP:
@@ -64,6 +83,22 @@ class TestTCP:
                 options=b"\x01\x01\x01\x01",
             )
 
+    def test_data_offset_out_of_range_rejected(self):
+        with pytest.raises(InvalidFieldError):
+            TCP(
+                src_port=1022,
+                dst_port=22,
+                seq=1,
+                ack=1,
+                data_offset=16,
+                reserved=0,
+                flags=0x010,
+                window=64,
+                checksum=0,
+                urgent_pointer=0,
+                options=b"\x00" * 44,
+            )
+
     def test_flag_names_cover_all_nine_bits(self):
         tcp = TCP(
             src_port=1,
@@ -78,3 +113,92 @@ class TestTCP:
             urgent_pointer=0,
         )
         assert tcp.flags_str == "FIN SYN RST PSH ACK URG ECE CWR NS"
+
+
+class TestTCPOptions:
+    def test_timestamps_from_captured_segment(
+        self, raw_tcp_header_with_options
+    ):
+        """The conftest header carries the classic NOP, NOP, Timestamps
+        layout of an established connection."""
+        options = TCP.decode(raw_tcp_header_with_options).parsed_options
+        assert [option.kind for option in options] == [1, 1, 8]
+        assert [option.kind_name for option in options] == [
+            "No-Operation",
+            "No-Operation",
+            "Timestamps",
+        ]
+        assert options[2].data == b"\x00\x08\xca\x61\x00\x01\x69\x2e"
+        assert options[2].value == (0x0008CA61, 0x0001692E)
+
+    def test_syn_style_options(self):
+        """The typical SYN block: MSS, NOP, Window Scale, SACK-Permitted
+        (padded to a whole word with End of Option List)."""
+        tcp = tcp_with_options(b"\x02\x04\x05\xb4\x01\x03\x03\x07\x04\x02")
+        options = tcp.parsed_options
+        assert [option.kind for option in options] == [2, 1, 3, 4, 0]
+        mss, _, window_scale, sack_permitted, eol = options
+        assert mss.value == 1460
+        assert mss.kind_name == "Maximum Segment Size"
+        assert window_scale.value == 7
+        assert sack_permitted.value is None  # presence is its meaning
+        assert sack_permitted.data == b""
+        assert eol.kind_name == "End of Option List"
+
+    def test_sack_blocks(self):
+        blocks = (
+            b"\x00\x00\x10\x00\x00\x00\x14\x00\x00\x00\x20\x00\x00\x00\x24\x00"
+        )
+        tcp = tcp_with_options(b"\x01\x01\x05\x12" + blocks)
+        sack = tcp.parsed_options[2]
+        assert sack.kind == 5
+        assert sack.value == ((0x1000, 0x1400), (0x2000, 0x2400))
+
+    def test_eol_ends_the_parse(self):
+        """Padding after an End of Option List is not returned as more
+        options."""
+        tcp = tcp_with_options(b"\x02\x04\x05\xb4\x00\x00\x00\x00")
+        options = tcp.parsed_options
+        assert [option.kind for option in options] == [2, 0]
+
+    def test_unknown_kind_keeps_raw_data(self):
+        tcp = tcp_with_options(b"\xfe\x04\xca\xfe")
+        (option,) = tcp.parsed_options
+        assert option.kind == 254
+        assert option.kind_name == "unknown (254)"
+        assert option.data == b"\xca\xfe"
+        assert option.value is None
+
+    def test_no_options_parses_empty(self):
+        tcp = tcp_with_options(b"")
+        assert tcp.data_offset == 5
+        assert tcp.parsed_options == ()
+
+    def test_missing_length_byte_raises(self):
+        tcp = tcp_with_options(b"\x01\x01\x01\x08")
+        with pytest.raises(InvalidFieldError):
+            _ = tcp.parsed_options
+
+    def test_length_below_tlv_minimum_raises(self):
+        tcp = tcp_with_options(b"\x08\x01\x01\x01")
+        with pytest.raises(InvalidFieldError):
+            _ = tcp.parsed_options
+
+    def test_length_past_the_options_raises(self):
+        tcp = tcp_with_options(b"\x08\x0a\x00\x00")
+        with pytest.raises(InvalidFieldError):
+            _ = tcp.parsed_options
+
+    def test_value_degrades_on_a_length_wrong_for_the_kind(self):
+        """A known kind whose data does not have the expected shape
+        yields no decoded value — the raw data stays readable."""
+        assert TCPOption(kind=2, data=b"\x05").value is None
+        assert TCPOption(kind=3, data=b"\x01\x02").value is None
+        assert TCPOption(kind=8, data=b"\x00" * 6).value is None
+        assert TCPOption(kind=5, data=b"\x00" * 12).value is None
+        assert TCPOption(kind=5).value is None
+
+    def test_round_trip_unchanged_by_parsing(self, raw_tcp_header_with_options):
+        tcp = TCP.decode(raw_tcp_header_with_options)
+        _ = tcp.parsed_options
+        assert bytes(tcp) == raw_tcp_header_with_options


### PR DESCRIPTION
## Summary

`TCP` kept its options as raw bytes and never parsed them. This parses the options TLV list on demand, following the house pattern (DNS resource records): the raw `options` field is preserved and the accessor never re-encodes, so `bytes(TCP.decode(x)) == x` still holds by construction.

## What's included

- `TCPOption` value type: `kind` + `kind_name` display property, raw `data`, and a decoded `value` property for the kinds this library understands — segment size for MSS (2), shift count for Window Scale (3), a `(tsval, tsecr)` pair for Timestamps (8), `(left_edge, right_edge)` pairs for SACK (5). SACK-Permitted (4) and the single-byte kinds decode to `None` (presence is the meaning); unknown kinds keep raw `data`; a value whose length doesn't match its kind degrades to `None`, never raises.
- `TCP.parsed_options`: the options as a tuple of `TCPOption` in wire order. EOL ends the parse (what follows is padding); an option length below the 2-byte TLV minimum or past the options bytes raises `InvalidFieldError` (bounded — never hangs or over-reads).
- Exported `TCPOption` from `netprotocols` (`__all__` kept consistent).
- Tests: unit tests for the SYN-style block, SACK blocks, EOL termination, unknown kinds, malformed lengths, and value degradation; a corpus test asserting every options-bearing captured segment parses (NOP/NOP/Timestamps — no SYN was captured, per the MANIFEST, so MSS and friends ride crafted tests); a hypothesis accessor-safety property alongside the DNS one.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (622 passed; `tcp.py` at 100% coverage)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Notes

The `CHANGELOG.md` hunk may overlap with the other open roadmap PRs (#58, #60–#66) — each adds its own entry under `## [Unreleased]`; trivial to resolve at merge time.

Closes #59.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_