### PR TITLE
Parse ICMP message bodies (echo id/seq, error embedded packet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and MX/TXT/SOA; hexadecimal otherwise). Parsing reads the raw sections
   and never re-encodes, so the byte-exact round-trip holds; a record or
   compressed name that runs past the message raises `InvalidFieldError`.
+- **ICMP message bodies** (RFC 792 / RFC 4443): `ICMPv4`/`ICMPv6` gain a
+  raw `body` field — the message data after the 8-byte header — so a
+  decoded message is self-contained (like `IGMP`/`DNS`), `header_len`
+  consumes the whole IP payload, and the layer stays terminal with a
+  byte-exact round-trip. Echo requests/replies (v4 types 8/0, v6
+  128/129) expose `identifier` / `sequence_number` split from `rest`,
+  and the error messages (v4 Destination Unreachable / Redirect / Time
+  Exceeded / Parameter Problem; v6 types 1-4) expose `embedded_packet` —
+  the invoking datagram, decodable as `IPv4`/`IPv6`. The accessors read
+  on demand and degrade to `None` for other message types or an empty
+  body, never raising. A decoded message now carries its body in
+  `bytes(layer)`, so `checksum.compute`/`verify` need no separate
+  `payload` for it (passing one for a header-only object still works).
 - **DNS over TCP** (`DNSOverTCP`, RFC 1035 §4.2.2): `TCP.next_protocol()`
   now dispatches application protocols by well-known port
   (`layer4._ports.tcp_app_class`). DNS over TCP is length-prefixed, so

--- a/src/netprotocols/checksum.py
+++ b/src/netprotocols/checksum.py
@@ -102,7 +102,10 @@ def compute(
         ``TCP``, ``UDP``, and ``ICMPv6`` prepend the pseudo-header
         built from ``ip``.
     :param ip: The enclosing IP layer, required for TCP/UDP/ICMPv6.
-    :param payload: The bytes following ``layer`` on the wire.
+    :param payload: The bytes following ``layer`` on the wire. A decoded
+        ``ICMPv4``/``ICMPv6``/``IGMP`` message already carries its whole
+        body in ``bytes(layer)``, so pass a ``payload`` only for bytes
+        the layer object does not itself hold.
     :raises InvalidFieldError: For layers without a checksum field, or
         a missing ``ip`` where the pseudo-header needs one.
     """

--- a/src/netprotocols/layer3/icmp.py
+++ b/src/netprotocols/layer3/icmp.py
@@ -1,9 +1,17 @@
 """ICMPv4 (RFC 792) and ICMPv6 (RFC 4443) headers.
 
-Both classes model the 8-byte header common to all control messages:
+Both classes model the 8-byte header common to all control messages —
 type, code, checksum, and the message-specific final 4 bytes (the
-"rest of header" in ICMPv4, the start of the message body in ICMPv6).
-Message-specific payloads beyond those 8 bytes are left to the caller.
+"rest of header" in ICMPv4, the start of the message body in ICMPv6) —
+plus the message data that follows, kept raw as ``body`` (like
+``IGMP``/``DNS``), so a message consumes its whole IP payload and is
+self-contained. The layer stays terminal; the accessors read ``rest``
+and ``body`` on demand and never re-encode, so ``bytes(X.decode(x)) ==
+x`` holds by construction: an echo's ``identifier`` /
+``sequence_number`` split from ``rest``, and an error message's
+``embedded_packet`` exposes the invoking datagram it carries in
+``body``, decodable as :class:`~netprotocols.IPv4` /
+:class:`~netprotocols.IPv6`.
 """
 
 from __future__ import annotations
@@ -24,18 +32,28 @@ class _ICMP(Protocol):
 
     :param type: Control message type.
     :param code: Control message subtype.
-    :param checksum: Checksum, carried verbatim (this library neither
-        computes nor verifies checksums).
+    :param checksum: Checksum over the whole ICMP message, carried
+        verbatim (compute/verify via :mod:`netprotocols.checksum`).
     :param rest: The message-specific final 4 bytes of the header.
+    :param body: The message data after the 8-byte header (an echo's
+        payload, an error's embedded packet), kept raw.
     """
 
     type: int
     code: int
     checksum: int
     rest: bytes
+    body: bytes = b""
 
     _struct: ClassVar[Struct] = Struct("!BBH4s")
     type_names: ClassVar[dict[int, str]] = {}
+
+    #: Message types whose ``rest`` packs an echo identifier and
+    #: sequence number.
+    _echo_types: ClassVar[frozenset[int]] = frozenset()
+
+    #: Error message types whose ``body`` embeds the invoking packet.
+    _error_types: ClassVar[frozenset[int]] = frozenset()
 
     def __post_init__(self) -> None:
         if len(self.rest) != 4:
@@ -47,10 +65,25 @@ class _ICMP(Protocol):
     @classmethod
     def decode(cls, data: bytes | memoryview) -> Self:
         type_, code, checksum, rest = cls._unpack_fixed(data)
-        return cls(type=type_, code=code, checksum=checksum, rest=rest)
+        return cls(
+            type=type_,
+            code=code,
+            checksum=checksum,
+            rest=rest,
+            body=bytes(data[cls._struct.size :]),
+        )
 
     def __bytes__(self) -> bytes:
-        return self._struct.pack(self.type, self.code, self.checksum, self.rest)
+        return (
+            self._struct.pack(self.type, self.code, self.checksum, self.rest)
+            + self.body
+        )
+
+    @property
+    def header_len(self) -> int:
+        # An ICMP message is the whole IP payload: consume it all so the
+        # chain ends here with no stray payload (terminal).
+        return self._struct.size + len(self.body)
 
     @property
     def type_name(self) -> str:
@@ -64,10 +97,47 @@ class _ICMP(Protocol):
         """The checksum as a hexadecimal string, e.g. ``"0x83f7"``."""
         return f"{self.checksum:#06x}"
 
+    # -- message-specific fields (read on demand, never re-encoded) --
+
+    @property
+    def identifier(self) -> int | None:
+        """The identifier of an echo request/reply (``rest`` bytes 0-1),
+        used to match replies to requests; ``None`` for other message
+        types."""
+        if self.type not in self._echo_types:
+            return None
+        return int.from_bytes(self.rest[:2], "big")
+
+    @property
+    def sequence_number(self) -> int | None:
+        """The sequence number of an echo request/reply (``rest`` bytes
+        2-3); ``None`` for other message types."""
+        if self.type not in self._echo_types:
+            return None
+        return int.from_bytes(self.rest[2:], "big")
+
+    @property
+    def embedded_packet(self) -> bytes | None:
+        """The invoking packet an error message embeds — its ``body``,
+        starting at the original datagram's IP header, decodable as
+        :class:`~netprotocols.IPv4` / :class:`~netprotocols.IPv6`.
+        ``None`` for non-error message types and for an error whose body
+        is empty (degrades, never raises)."""
+        if self.type not in self._error_types or not self.body:
+            return None
+        return self.body
+
 
 @dataclass(frozen=True, slots=True)
 class ICMPv4(_ICMP):
-    """An ICMPv4 header (RFC 792)."""
+    """An ICMPv4 message (RFC 792)."""
+
+    #: Echo Reply (0) and Echo Request (8).
+    _echo_types: ClassVar[frozenset[int]] = frozenset({0, 8})
+
+    #: Destination Unreachable (3), Redirect (5), Time Exceeded (11),
+    #: and Parameter Problem (12) embed the invoking packet (RFC 792).
+    _error_types: ClassVar[frozenset[int]] = frozenset({3, 5, 11, 12})
 
     type_names: ClassVar[dict[int, str]] = {
         0: "Echo Reply",
@@ -93,7 +163,15 @@ class ICMPv4(_ICMP):
 
 @dataclass(frozen=True, slots=True)
 class ICMPv6(_ICMP):
-    """An ICMPv6 header (RFC 4443)."""
+    """An ICMPv6 message (RFC 4443)."""
+
+    #: Echo Request (128) and Echo Reply (129).
+    _echo_types: ClassVar[frozenset[int]] = frozenset({128, 129})
+
+    #: The error messages, types 1-4 (RFC 4443 §3): Destination
+    #: Unreachable, Packet Too Big, Time Exceeded, Parameter Problem —
+    #: all embed as much of the invoking packet as fits.
+    _error_types: ClassVar[frozenset[int]] = frozenset({1, 2, 3, 4})
 
     type_names: ClassVar[dict[int, str]] = {
         1: "Destination Unreachable",

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -150,11 +150,38 @@ class TestRepresentativeFrames:
         assert isinstance(icmp, ICMPv4)
         assert icmp.type == 11
         assert icmp.type_name == "Time Exceeded"
+        # The error embeds the invoking packet: its bytes must decode as
+        # the original IPv4 header, addressed like the outer datagram in
+        # reverse (the expiring probe travelled the other way).
+        outer = layers[1]
+        assert isinstance(outer, IPv4)
+        assert icmp.embedded_packet is not None
+        embedded = IPv4.decode(icmp.embedded_packet)
+        assert embedded.dst == outer.dst or embedded.src == outer.dst
 
     def test_loopback_echo_pair(self):
         frames = read_pcap(FIXTURES / "icmpv4_echo_lo.pcap")
-        types = [walk(frame)[0][2].type for frame in frames]  # type: ignore[attr-defined]
+        echoes = [walk(frame)[0][2] for frame in frames]
+        types = [icmp.type for icmp in echoes]  # type: ignore[attr-defined]
         assert 8 in types and 0 in types
+        # Every echo exposes its identifier/sequence, and each reply
+        # mirrors a request's pair.
+        pairs = {
+            (icmp.identifier, icmp.sequence_number)  # type: ignore[attr-defined]
+            for icmp in echoes
+        }
+        assert None not in {pair[0] for pair in pairs}
+        requests = {
+            (icmp.identifier, icmp.sequence_number)  # type: ignore[attr-defined]
+            for icmp in echoes
+            if icmp.type == 8  # type: ignore[attr-defined]
+        }
+        replies = {
+            (icmp.identifier, icmp.sequence_number)  # type: ignore[attr-defined]
+            for icmp in echoes
+            if icmp.type == 0  # type: ignore[attr-defined]
+        }
+        assert requests == replies
 
     def test_ndp_neighbor_discovery(self):
         frames = read_pcap(FIXTURES / "ipv6_ndp_mld.pcap")

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -1,12 +1,13 @@
 import pytest
 
-from netprotocols import ICMPv4, ICMPv6, InvalidFieldError
+from netprotocols import ICMPv4, ICMPv6, InvalidFieldError, IPv4, IPv6
 
 
 class TestICMPv4:
-    def test_decode_tolerates_trailing_payload(self, raw_icmpv4_echo_request):
+    def test_decode_captures_the_body(self, raw_icmpv4_echo_request):
         """The fixture carries a full ping payload after the 8-byte
-        header; decode must consume only the header."""
+        header; decode keeps it as the raw body, so the message consumes
+        its whole IP payload."""
         icmp = ICMPv4.decode(raw_icmpv4_echo_request)
         assert icmp.type == 8
         assert icmp.code == 0
@@ -14,12 +15,40 @@ class TestICMPv4:
         assert icmp.checksum_hex_str == "0x83f7"
         assert icmp.rest == b"\x00\x01\x00\x01"
         assert icmp.type_name == "Echo Request"
-        assert icmp.header_len == 8
+        assert icmp.body == raw_icmpv4_echo_request[8:]
+        assert icmp.header_len == len(raw_icmpv4_echo_request)
 
     def test_round_trip(self, raw_icmpv4_echo_request):
         icmp = ICMPv4.decode(raw_icmpv4_echo_request)
-        assert bytes(icmp) == raw_icmpv4_echo_request[:8]
+        assert bytes(icmp) == raw_icmpv4_echo_request
         assert ICMPv4.decode(bytes(icmp)) == icmp
+
+    def test_echo_identifier_and_sequence(self, raw_icmpv4_echo_request):
+        icmp = ICMPv4.decode(raw_icmpv4_echo_request)
+        assert icmp.identifier == 1
+        assert icmp.sequence_number == 1
+
+    def test_non_echo_types_have_no_echo_fields(self):
+        icmp = ICMPv4(type=11, code=0, checksum=0, rest=b"\x00" * 4)
+        assert icmp.identifier is None
+        assert icmp.sequence_number is None
+
+    def test_error_embeds_the_invoking_packet(self, raw_ipv4_header):
+        """A Time Exceeded body starts at the original datagram's IPv4
+        header, which must decode."""
+        original = raw_ipv4_header + b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        icmp = ICMPv4.decode(b"\x0b\x00\x00\x00\x00\x00\x00\x00" + original)
+        assert icmp.embedded_packet == original
+        embedded = IPv4.decode(icmp.embedded_packet)
+        assert embedded.src == "192.168.1.96"
+        assert embedded.dst == "192.168.1.254"
+
+    def test_echo_types_have_no_embedded_packet(self, raw_icmpv4_echo_request):
+        assert ICMPv4.decode(raw_icmpv4_echo_request).embedded_packet is None
+
+    def test_error_with_an_empty_body_degrades_to_none(self):
+        icmp = ICMPv4(type=11, code=0, checksum=0, rest=b"\x00" * 4)
+        assert icmp.embedded_packet is None
 
     def test_unknown_type_name(self):
         icmp = ICMPv4(type=200, code=0, checksum=0, rest=b"\x00" * 4)
@@ -38,11 +67,37 @@ class TestICMPv6:
         assert icmp.checksum == 0x3F69
         assert icmp.rest == b"\x76\x20\x01\x00"
         assert icmp.type_name == "Echo Request"
+        assert icmp.body == raw_icmpv6_echo_request[8:]
+        assert icmp.header_len == len(raw_icmpv6_echo_request)
 
     def test_round_trip(self, raw_icmpv6_echo_request):
         icmp = ICMPv6.decode(raw_icmpv6_echo_request)
-        assert bytes(icmp) == raw_icmpv6_echo_request[:8]
+        assert bytes(icmp) == raw_icmpv6_echo_request
         assert ICMPv6.decode(bytes(icmp)) == icmp
+
+    def test_echo_identifier_and_sequence(self, raw_icmpv6_echo_request):
+        icmp = ICMPv6.decode(raw_icmpv6_echo_request)
+        assert icmp.identifier == 0x7620
+        assert icmp.sequence_number == 0x0100
+
+    def test_error_embeds_the_invoking_packet(self, raw_ipv6_header):
+        """A Time Exceeded (v6 type 3) body starts at the original
+        datagram's IPv6 header, which must decode."""
+        icmp = ICMPv6.decode(
+            b"\x03\x00\x00\x00\x00\x00\x00\x00" + raw_ipv6_header
+        )
+        assert icmp.embedded_packet == raw_ipv6_header
+        assert icmp.identifier is None
+        embedded = IPv6.decode(icmp.embedded_packet)
+        assert embedded.src == "fe80::1"
+
+    def test_ndp_types_have_no_echo_or_error_fields(self):
+        icmp = ICMPv6(
+            type=135, code=0, checksum=0, rest=b"\x00" * 4, body=b"\x00" * 16
+        )
+        assert icmp.identifier is None
+        assert icmp.sequence_number is None
+        assert icmp.embedded_packet is None
 
     def test_v4_and_v6_type_tables_differ(self):
         assert (


### PR DESCRIPTION
## Summary

`ICMPv4`/`ICMPv6` decoded only the 8-byte common header — an echo's identifier/sequence stayed packed inside `rest`, and an error message's embedded original datagram was not captured at all. This gives both classes a raw `body: bytes` field (the `IGMP`/`DNS` pattern), so a decoded message is self-contained, `header_len` consumes the whole IP payload, the layer stays terminal, and `bytes(X.decode(x)) == x` holds by construction.

## What's included

- `body: bytes` field on `_ICMP` (default `b""`); `decode` captures everything after the 8-byte header; `__bytes__` re-emits it; `header_len` consumes the whole payload (terminal, like IGMP/DNS).
- Echo accessors — `identifier` / `sequence_number` split from `rest` for v4 types 8/0 and v6 types 128/129; `None` for other message types.
- Error accessor — `embedded_packet` exposes the invoking datagram for v4 Destination Unreachable (3) / Redirect (5) / Time Exceeded (11) / Parameter Problem (12) and v6 types 1–4, decodable as `IPv4`/`IPv6`. Non-error types and an empty body degrade to `None`, never raise.
- Checksum arms are unchanged by design: a decoded message now carries its body in `bytes(layer)`, so `compute`/`verify` cover the whole message with no separate `payload`, while passing `payload` for a header-only object still works — `compute()`'s docstring now says which.
- Tests: unit tests updated/added (body capture, round-trip, echo fields, embedded-packet decode for both versions, degradation paths); corpus asserts (loopback echo id/seq pairs match request↔reply; the Time-Exceeded frames' embedded IPv4 headers decode). `icmp.py` at 100% coverage.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (616 passed, corpus invariants + checksum recompute included)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Notes

The IPv6 NDP work (#61) builds on this `body` field — its PR is stacked on this branch and must merge after this one. The `CHANGELOG.md` hunk may overlap with the other open roadmap PRs; each adds its own entry under `## [Unreleased]`.

Closes #60.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_