### PR TITLE
Parse IPv6 Neighbor Discovery messages and options (RFC 4861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   body, never raising. A decoded message now carries its body in
   `bytes(layer)`, so `checksum.compute`/`verify` need no separate
   `payload` for it (passing one for a header-only object still works).
+- **IPv6 Neighbor Discovery** (`NDPOption`, RFC 4861): `ICMPv6` now
+  parses NDP messages on demand — `ndp_target_address` reads the
+  16-byte target of a Neighbor Solicitation/Advertisement (135/136),
+  and `ndp_options` walks the option TLVs of Router
+  Solicitation/Advertisement, Neighbor Solicitation/Advertisement, and
+  Redirect at each message's own options offset. Each `NDPOption`
+  carries its `type` + `type_name` and raw `data`; a Source/Target
+  Link-Layer Address option (1/2) reads back as a MAC string via
+  `link_layer_address`, and Prefix Information (3) / MTU (5) stay raw.
+  Non-NDP message types return `None`. Option lengths count in 8-octet
+  units: a zero length (which must not loop), a length past the
+  message, or a body shorter than the message's fixed fields raises
+  `InvalidFieldError` (bounded — never hangs or over-reads).
 - **DNS over TCP** (`DNSOverTCP`, RFC 1035 §4.2.2): `TCP.next_protocol()`
   now dispatches application protocols by well-known port
   (`layer4._ports.tcp_app_class`). DNS over TCP is length-prefixed, so

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -17,7 +17,7 @@ from netprotocols.layer2.arp import ARP
 from netprotocols.layer2.ethernet import Ethernet
 from netprotocols.layer2.vlan import VLAN
 from netprotocols.layer3.gre import GRE
-from netprotocols.layer3.icmp import ICMPv4, ICMPv6
+from netprotocols.layer3.icmp import ICMPv4, ICMPv6, NDPOption
 from netprotocols.layer3.igmp import IGMP, IGMPv3GroupRecord
 from netprotocols.layer3.ip import IPv4, IPv6
 from netprotocols.layer3.ipv6_ext import (
@@ -73,6 +73,7 @@ __all__ = [
     "InvalidIPv4AddressError",
     "InvalidMACAddressError",
     "InvalidManufacturerCodeError",
+    "NDPOption",
     "Packet",
     "Protocol",
     "ProtocolError",

--- a/src/netprotocols/layer3/icmp.py
+++ b/src/netprotocols/layer3/icmp.py
@@ -8,10 +8,13 @@ plus the message data that follows, kept raw as ``body`` (like
 self-contained. The layer stays terminal; the accessors read ``rest``
 and ``body`` on demand and never re-encode, so ``bytes(X.decode(x)) ==
 x`` holds by construction: an echo's ``identifier`` /
-``sequence_number`` split from ``rest``, and an error message's
+``sequence_number`` split from ``rest``, an error message's
 ``embedded_packet`` exposes the invoking datagram it carries in
 ``body``, decodable as :class:`~netprotocols.IPv4` /
-:class:`~netprotocols.IPv6`.
+:class:`~netprotocols.IPv6`, and an ICMPv6 Neighbor Discovery
+message's ``ndp_target_address`` / ``ndp_options`` parse the RFC 4861
+target and option TLVs (a source/target link-layer address reads back
+as a MAC string).
 """
 
 from __future__ import annotations
@@ -20,10 +23,56 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol
+from netprotocols._base import Protocol, bytes_to_ipv6, bytes_to_mac
 from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["ICMPv4", "ICMPv6"]
+__all__ = ["ICMPv4", "ICMPv6", "NDPOption"]
+
+#: Neighbor Discovery option types this library names (RFC 4861 §4.6);
+#: unknown types fall back to their numeric value.
+_NDP_OPTION_TYPE_NAMES: dict[int, str] = {
+    1: "Source Link-Layer Address",
+    2: "Target Link-Layer Address",
+    3: "Prefix Information",
+    4: "Redirected Header",
+    5: "MTU",
+}
+
+#: Option types that carry a link-layer address (RFC 4861 §4.6.1).
+_NDP_LLA_TYPES = frozenset({1, 2})
+
+
+@dataclass(frozen=True, slots=True)
+class NDPOption:
+    """One Neighbor Discovery option TLV (RFC 4861 §4.6).
+
+    :param type: Option type — ``1`` Source Link-Layer Address, ``2``
+        Target Link-Layer Address, ``3`` Prefix Information, ``4``
+        Redirected Header, ``5`` MTU (see :attr:`type_name`).
+    :param data: The option's payload after the two type/length bytes,
+        kept raw (the wire length counts in 8-octet units, so this is
+        ``length * 8 - 2`` bytes).
+    """
+
+    type: int
+    data: bytes = b""
+
+    @property
+    def type_name(self) -> str:
+        """Display name of the option type, e.g. ``"Source Link-Layer
+        Address"``; falls back to ``"unknown (n)"`` for types this
+        library does not name."""
+        return _NDP_OPTION_TYPE_NAMES.get(self.type, f"unknown ({self.type})")
+
+    @property
+    def link_layer_address(self) -> str | None:
+        """The MAC of a Source/Target Link-Layer Address option (types
+        1/2) over Ethernet, e.g. ``"84:01:12:be:7e:d9"``; ``None`` for
+        other option types and for a payload that is not the 6-byte
+        Ethernet form (degrades, never raises)."""
+        if self.type in _NDP_LLA_TYPES and len(self.data) == 6:
+            return bytes_to_mac(self.data)
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -211,3 +260,69 @@ class ICMPv6(_ICMP):
         201: "Private Experimentation",
         255: "Reserved for Expansion of ICMPv6 Informational Messages",
     }
+
+    #: Neighbor Discovery message types (RFC 4861 §4.1-4.5) mapped to
+    #: the offset into ``body`` where the option list starts — past the
+    #: fixed fields each message puts there: none for a Router
+    #: Solicitation, the reachable-time/retrans timers for a Router
+    #: Advertisement, the target address for a Neighbor
+    #: Solicitation/Advertisement, target + destination for a Redirect.
+    _NDP_OPTIONS_OFFSET: ClassVar[dict[int, int]] = {
+        133: 0,
+        134: 8,
+        135: 16,
+        136: 16,
+        137: 32,
+    }
+
+    # -- Neighbor Discovery (read on demand, never re-encoded) --
+
+    @property
+    def ndp_target_address(self) -> str | None:
+        """The target address of a Neighbor Solicitation/Advertisement
+        (types 135/136) — the 16 bytes after the reserved word, e.g.
+        ``"fe80::f6d7:8b9a:993e:5efa"``; ``None`` for other message
+        types and for a body too short to hold it (degrades, never
+        raises)."""
+        if self.type not in (135, 136) or len(self.body) < 16:
+            return None
+        return bytes_to_ipv6(self.body[:16])
+
+    @property
+    def ndp_options(self) -> tuple[NDPOption, ...] | None:
+        """The option TLVs of a Neighbor Discovery message (Router
+        Solicitation/Advertisement, Neighbor Solicitation/Advertisement,
+        Redirect), parsed on demand — one :class:`NDPOption` per option,
+        in wire order; ``None`` for non-NDP message types and empty for
+        an NDP message carrying no options.
+
+        :raises InvalidFieldError: if the body ends before the message's
+            fixed fields, an option's length is zero (lengths count in
+            8-octet units and zero must not loop), or an option runs
+            past the message (bounded — never hangs or over-reads).
+        """
+        offset = self._NDP_OPTIONS_OFFSET.get(self.type)
+        if offset is None:
+            return None
+        body = self.body
+        if len(body) < offset:
+            raise InvalidFieldError(
+                f"{self.type_name} body ends before its fixed fields"
+            )
+        options: list[NDPOption] = []
+        cursor = offset
+        while cursor < len(body):
+            if cursor + 2 > len(body):
+                raise InvalidFieldError("NDP option missing its length byte")
+            length = body[cursor + 1] * 8
+            if length == 0:
+                raise InvalidFieldError("NDP option length must not be zero")
+            if cursor + length > len(body):
+                raise InvalidFieldError("NDP option runs past the message")
+            options.append(
+                NDPOption(
+                    type=body[cursor], data=body[cursor + 2 : cursor + length]
+                )
+            )
+            cursor += length
+        return tuple(options)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -185,14 +185,27 @@ class TestRepresentativeFrames:
 
     def test_ndp_neighbor_discovery(self):
         frames = read_pcap(FIXTURES / "ipv6_ndp_mld.pcap")
-        types = {
-            layer.type
+        ndp = [
+            layer
             for frame in frames
             for layer in walk(frame)[0]
-            if isinstance(layer, ICMPv6)
-        }
+            if isinstance(layer, ICMPv6) and layer.type in (135, 136)
+        ]
+        types = {icmp.type for icmp in ndp}
         assert 135 in types  # Neighbor Solicitation
         assert 136 in types  # Neighbor Advertisement
+        # Every NS/NA exposes its target address, and the captured
+        # source/target link-layer-address options read back as MACs.
+        lla_types = set()
+        for icmp in ndp:
+            assert icmp.ndp_target_address is not None
+            for option in icmp.ndp_options or ():
+                if option.type in (1, 2):
+                    lla_types.add(option.type)
+                    mac = option.link_layer_address
+                    assert mac is not None
+                    assert len(mac.split(":")) == 6
+        assert {1, 2} <= lla_types
 
     def test_dns_responses_over_both_ip_versions(self):
         frames = read_pcap(FIXTURES / "udp_dns.pcap")

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -189,6 +189,22 @@ class TestPacketProperties:
                 assert bytes(Packet(*layers)) == bytes(data[:consumed])
 
 
+class TestNDPAccessorSafety:
+    @given(data=fuzz_input)
+    def test_ndp_accessors_never_hang_or_escape(self, data: bytes) -> None:
+        """The NDP accessors parse untrusted TLV bytes (and a zero
+        option length must not loop): a tuple/None or InvalidFieldError,
+        never anything else — and the target/display helpers never raise
+        at all."""
+        with contextlib.suppress(ProtocolError):
+            icmp = ICMPv6.decode(data)
+            _ = icmp.ndp_target_address
+            with contextlib.suppress(InvalidFieldError):
+                for option in icmp.ndp_options or ():
+                    assert option.type_name
+                    _ = option.link_layer_address
+
+
 class TestDNSNameAccessorSafety:
     @given(data=fuzz_input)
     def test_question_name_never_hangs_or_escapes(self, data: bytes) -> None:

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -1,6 +1,20 @@
 import pytest
 
-from netprotocols import ICMPv4, ICMPv6, InvalidFieldError, IPv4, IPv6
+from netprotocols import (
+    ICMPv4,
+    ICMPv6,
+    InvalidFieldError,
+    IPv4,
+    IPv6,
+    NDPOption,
+)
+
+#: The target of the corpus Neighbor Solicitation/Advertisement pair.
+NDP_TARGET = bytes.fromhex("fe80000000000000f6d78b9a993e5efa")
+
+
+def make_ndp(type_: int, body: bytes) -> ICMPv6:
+    return ICMPv6(type=type_, code=0, checksum=0, rest=b"\x00" * 4, body=body)
 
 
 class TestICMPv4:
@@ -108,3 +122,96 @@ class TestICMPv6:
             ICMPv6(type=129, code=0, checksum=0, rest=b"\x00" * 4).type_name
             == "Echo Reply"
         )
+
+
+class TestNDP:
+    def test_neighbor_solicitation_target_and_slla(self):
+        """The wire layout of the corpus NS: 16-byte target, then a
+        Source Link-Layer Address option."""
+        icmp = make_ndp(135, NDP_TARGET + b"\x01\x01\x84\x01\x12\xbe\x7e\xd9")
+        assert icmp.ndp_target_address == "fe80::f6d7:8b9a:993e:5efa"
+        assert icmp.ndp_options is not None
+        (option,) = icmp.ndp_options
+        assert option.type == 1
+        assert option.type_name == "Source Link-Layer Address"
+        assert option.link_layer_address == "84:01:12:be:7e:d9"
+
+    def test_neighbor_advertisement_without_options(self):
+        icmp = make_ndp(136, NDP_TARGET)
+        assert icmp.ndp_target_address == "fe80::f6d7:8b9a:993e:5efa"
+        assert icmp.ndp_options == ()
+
+    def test_router_advertisement_mtu_and_prefix_information(self):
+        """RA options follow the 8 bytes of timers; MTU and Prefix
+        Information are exposed raw."""
+        mtu = b"\x05\x01\x00\x00\x00\x00\x05\xdc"
+        prefix = b"\x03\x04\x40\xc0" + b"\x00" * 12 + NDP_TARGET
+        icmp = make_ndp(134, b"\x00" * 8 + mtu + prefix)
+        options = icmp.ndp_options
+        assert options is not None
+        assert [option.type for option in options] == [5, 3]
+        assert options[0].type_name == "MTU"
+        assert options[0].data == b"\x00\x00\x00\x00\x05\xdc"
+        assert options[0].link_layer_address is None
+        assert options[1].type_name == "Prefix Information"
+        assert options[1].data == b"\x40\xc0" + b"\x00" * 12 + NDP_TARGET
+        assert icmp.ndp_target_address is None  # targets are NS/NA-only
+
+    def test_router_solicitation_options_start_at_the_body(self):
+        icmp = make_ndp(133, b"\x01\x01\x84\x01\x12\xbe\x7e\xd9")
+        assert icmp.ndp_options is not None
+        (option,) = icmp.ndp_options
+        assert option.type == 1
+
+    def test_redirect_options_follow_target_and_destination(self):
+        icmp = make_ndp(
+            137, NDP_TARGET * 2 + b"\x02\x01\xa8\x3b\x76\xda\xa6\x9d"
+        )
+        assert icmp.ndp_options is not None
+        (option,) = icmp.ndp_options
+        assert option.type == 2
+        assert option.type_name == "Target Link-Layer Address"
+        assert option.link_layer_address == "a8:3b:76:da:a6:9d"
+
+    def test_non_ndp_types_return_none(self):
+        echo = make_ndp(128, b"payload")
+        assert echo.ndp_target_address is None
+        assert echo.ndp_options is None
+
+    def test_short_ns_body_degrades_the_target_to_none(self):
+        assert make_ndp(135, NDP_TARGET[:8]).ndp_target_address is None
+
+    def test_body_ending_before_the_fixed_fields_raises(self):
+        with pytest.raises(InvalidFieldError):
+            _ = make_ndp(135, NDP_TARGET[:8]).ndp_options
+
+    def test_zero_option_length_must_not_loop(self):
+        with pytest.raises(InvalidFieldError):
+            _ = make_ndp(133, b"\x01\x00\x84\x01\x12\xbe\x7e\xd9").ndp_options
+
+    def test_option_running_past_the_message_raises(self):
+        with pytest.raises(InvalidFieldError):
+            _ = make_ndp(133, b"\x01\x02\x84\x01\x12\xbe\x7e\xd9").ndp_options
+
+    def test_option_missing_its_length_byte_raises(self):
+        with pytest.raises(InvalidFieldError):
+            _ = make_ndp(136, NDP_TARGET + b"\x01").ndp_options
+
+    def test_unknown_option_type_keeps_raw_data(self):
+        icmp = make_ndp(133, b"\x19\x01\x00\x00\x0e\x10\x00\x00")
+        assert icmp.ndp_options is not None
+        (option,) = icmp.ndp_options
+        assert option.type == 25
+        assert option.type_name == "unknown (25)"
+        assert option.data == b"\x00\x00\x0e\x10\x00\x00"
+        assert option.link_layer_address is None
+
+    def test_lla_of_a_non_ethernet_length_degrades_to_none(self):
+        assert NDPOption(type=1, data=b"\x00" * 14).link_layer_address is None
+
+    def test_round_trip_unchanged_by_parsing(self):
+        raw = b"\x87\x00\x1c\x2a\x00\x00\x00\x00" + NDP_TARGET
+        icmp = ICMPv6.decode(raw)
+        _ = icmp.ndp_target_address
+        _ = icmp.ndp_options
+        assert bytes(icmp) == raw


### PR DESCRIPTION
## Summary

IPv6 Neighbor Discovery messages ride ICMPv6, but none of their structure was parsed. Building on the ICMP `body` field from #70, this adds on-demand NDP parsing: the NS/NA target address and the RFC 4861 option TLVs, with link-layer-address options reading back as MAC strings.

> **Stacked PR — base is `claude/icmp-body` (#70), which must merge first.** This PR depends on the `ICMPv6.body` field introduced there; once #70 merges, this can be retargeted to `master` (GitHub does that automatically on branch deletion).
>
> **CI note:** the CI workflow triggers only on PRs targeting `master`, so no checks run while this PR is based on `claude/icmp-body`. The full QA ladder (pytest incl. corpus + fuzz, ruff check/format, mypy strict) was run green on this branch locally; CI will run normally once the PR retargets to `master` after #70 merges.

## What's included

- `ICMPv6.ndp_target_address` — the 16-byte target after the reserved word for Neighbor Solicitation (135) / Advertisement (136); `None` for other types or a body too short to hold it (degrades, never raises).
- `ICMPv6.ndp_options` — a tuple of `NDPOption` for RS (133) / RA (134) / NS / NA / Redirect (137), each parsed at its message's own options offset past the fixed fields (0 / 8 / 16 / 16 / 32). `None` for non-NDP message types.
- `NDPOption` value type: `type` + `type_name` display property, raw `data`, and `link_layer_address` decoding Source/Target Link-Layer Address (1/2) to a MAC string on the 6-byte Ethernet form; Prefix Information (3) / MTU (5) exposed raw; unknown types degrade to `"unknown (n)"`.
- Bounded parsing: option lengths count in 8-octet units — a zero length (must not loop), a length past the message, or a body shorter than the fixed fields raises `InvalidFieldError`.
- Exported `NDPOption`; tests: `TestNDP` unit suite (all five message types, degradation and malformed paths, round-trip), corpus asserts on `ipv6_ndp_mld.pcap` (every NS/NA exposes its target; captured SLLA/TLLA options read back as MACs), and a hypothesis accessor-safety property.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (631 passed; `icmp.py` at 100% coverage)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Closes #61.