### PR TITLE
Parse IPv6 extension-header TLV options (Hop-by-Hop / Destination)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and MX/TXT/SOA; hexadecimal otherwise). Parsing reads the raw sections
   and never re-encodes, so the byte-exact round-trip holds; a record or
   compressed name that runs past the message raises `InvalidFieldError`.
+- **IPv6 extension-header options** (`IPv6Option`, RFC 8200 §4.2): the
+  Hop-by-Hop and Destination Options headers now parse their option
+  TLVs on demand — `parsed_options` yields one `IPv6Option` per option
+  in wire order, padding included (Pad1 is a lone type byte; everything
+  else is type/length/data). Each option carries its `type` +
+  `type_name` (Pad1, PadN, Router Alert per RFC 2711, Jumbo Payload per
+  RFC 2675; unknown types keep their numeric value) and raw `data`, and
+  exposes the action-on-unrecognized bits (the two high bits of the
+  type) as `unrecognized_action`. Parsing reads the raw `options` bytes
+  and never re-encodes, so the byte-exact round-trip is preserved; a
+  missing length byte or option data that runs past the header raises
+  `InvalidFieldError` (bounded — never hangs or over-reads).
 - **DNS over TCP** (`DNSOverTCP`, RFC 1035 §4.2.2): `TCP.next_protocol()`
   now dispatches application protocols by well-known port
   (`layer4._ports.tcp_app_class`). DNS over TCP is length-prefixed, so

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -24,6 +24,7 @@ from netprotocols.layer3.ipv6_ext import (
     IPv6DestinationOptions,
     IPv6Fragment,
     IPv6HopByHopOptions,
+    IPv6Option,
     IPv6Routing,
 )
 from netprotocols.layer4.tcp import TCP
@@ -68,6 +69,7 @@ __all__ = [
     "IPv6DestinationOptions",
     "IPv6Fragment",
     "IPv6HopByHopOptions",
+    "IPv6Option",
     "IPv6Routing",
     "InvalidFieldError",
     "InvalidIPv4AddressError",

--- a/src/netprotocols/layer3/ipv6_ext.py
+++ b/src/netprotocols/layer3/ipv6_ext.py
@@ -10,8 +10,10 @@ header (see ``_ip_protocol_class``).
 The TLV-shaped headers (Hop-by-Hop Options, Routing, Destination
 Options) declare their own length in ``hdr_ext_len``, counted in
 8-octet units *excluding* the first 8; the Fragment header is a fixed
-8 bytes. Option/data contents are kept as raw ``bytes`` — TLV parsing
-inside options is deliberately out of scope for now.
+8 bytes. Option/data contents are kept as raw ``bytes``; on the two
+options headers the ``parsed_options`` accessor walks the option TLVs
+(RFC 8200 §4.2) on demand and never re-encodes, so the byte-exact
+round-trip holds by construction.
 """
 
 from __future__ import annotations
@@ -30,8 +32,56 @@ __all__ = [
     "IPv6DestinationOptions",
     "IPv6Fragment",
     "IPv6HopByHopOptions",
+    "IPv6Option",
     "IPv6Routing",
 ]
+
+#: The one option type that is a lone byte with no length or data
+#: (RFC 8200 §4.2): Pad1, one byte of padding.
+_OPT_PAD1 = 0
+
+#: Option types this library names (RFC 8200 §4.2; RFC 2711 for Router
+#: Alert; RFC 2675 for Jumbo Payload); unknown types fall back to their
+#: numeric value.
+_OPTION_TYPE_NAMES: dict[int, str] = {
+    _OPT_PAD1: "Pad1",
+    1: "PadN",
+    5: "Router Alert",
+    194: "Jumbo Payload",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class IPv6Option:
+    """One option TLV from a Hop-by-Hop / Destination Options extension
+    header (RFC 8200 §4.2).
+
+    :param type: Option type — ``0`` Pad1, ``1`` PadN, ``5`` Router
+        Alert, ``194`` Jumbo Payload (see :attr:`type_name`). The two
+        high bits encode the action on an unrecognized option
+        (:attr:`unrecognized_action`).
+    :param data: The option data after the two type/length bytes, kept
+        raw; always empty for Pad1, which is a lone type byte.
+    """
+
+    type: int
+    data: bytes = b""
+
+    @property
+    def type_name(self) -> str:
+        """Display name of the option type, e.g. ``"Router Alert"``;
+        falls back to ``"unknown (n)"`` for types this library does not
+        name."""
+        return _OPTION_TYPE_NAMES.get(self.type, f"unknown ({self.type})")
+
+    @property
+    def unrecognized_action(self) -> int:
+        """What a node must do with an option it does not recognize —
+        the two high bits of the type (RFC 8200 §4.2): ``0`` skip it,
+        ``1`` discard the packet, ``2`` discard and send an ICMP
+        Parameter Problem, ``3`` discard and send the Parameter Problem
+        only to a non-multicast destination."""
+        return self.type >> 6
 
 
 def _next_in_ipv6_chain(number: int) -> type[Protocol] | None:
@@ -103,6 +153,45 @@ class _IPv6OptionsHeader(Protocol):
     def next_header_name(self) -> str:
         """Display name of what follows, e.g. ``"IPv6-ICMP"``."""
         return _next_header_name(self.next_header)
+
+    @property
+    def parsed_options(self) -> tuple[IPv6Option, ...]:
+        """The option TLVs as a tuple of :class:`IPv6Option`, in wire
+        order, parsed on demand (RFC 8200 §4.2) — padding included:
+        Pad1 is a lone type byte, every other option is
+        type/length/data.
+
+        :raises InvalidFieldError: if an option's length byte is
+            missing or its data runs past the header (bounded — never
+            hangs or over-reads).
+        """
+        raw = self.options
+        parsed: list[IPv6Option] = []
+        cursor = 0
+        while cursor < len(raw):
+            option_type = raw[cursor]
+            if option_type == _OPT_PAD1:
+                parsed.append(IPv6Option(type=option_type))
+                cursor += 1
+                continue
+            if cursor + 1 >= len(raw):
+                raise InvalidFieldError(
+                    f"{self.__class__.__name__} option missing its length byte"
+                )
+            length = raw[cursor + 1]
+            if cursor + 2 + length > len(raw):
+                raise InvalidFieldError(
+                    f"{self.__class__.__name__} option data runs past the "
+                    f"header"
+                )
+            parsed.append(
+                IPv6Option(
+                    type=option_type,
+                    data=raw[cursor + 2 : cursor + 2 + length],
+                )
+            )
+            cursor += 2 + length
+        return tuple(parsed)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -189,6 +189,21 @@ class TestPacketProperties:
                 assert bytes(Packet(*layers)) == bytes(data[:consumed])
 
 
+class TestIPv6OptionAccessorSafety:
+    @given(data=fuzz_input)
+    def test_parsed_options_never_hang_or_escape(self, data: bytes) -> None:
+        """The ext-header options accessor parses untrusted TLV bytes:
+        it must return a tuple or raise InvalidFieldError, never hang
+        and never raise anything else — and the per-option display
+        helpers must never raise at all."""
+        with contextlib.suppress(ProtocolError):
+            header = IPv6HopByHopOptions.decode(data)
+            with contextlib.suppress(InvalidFieldError):
+                for option in header.parsed_options:
+                    assert option.type_name
+                    _ = option.unrecognized_action
+
+
 class TestDNSNameAccessorSafety:
     @given(data=fuzz_input)
     def test_question_name_never_hangs_or_escapes(self, data: bytes) -> None:

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -14,6 +14,7 @@ from netprotocols import (
     IPv6DestinationOptions,
     IPv6Fragment,
     IPv6HopByHopOptions,
+    IPv6Option,
     IPv6Routing,
     TruncatedHeaderError,
 )
@@ -53,6 +54,18 @@ class TestMLDBehindHopByHop:
         # MLDv2 Listener Report (143) and/or v1 report/done (131/132).
         assert types <= {130, 131, 132, 143}
         assert types
+
+    def test_router_alert_option_parses(self):
+        """The captured hop-by-hop options are a Router Alert (value 0:
+        an MLD message is present) padded out with a PadN."""
+        for frame in self.frames():
+            hbh = walk(frame)[0][2]
+            assert isinstance(hbh, IPv6HopByHopOptions)
+            alert = hbh.parsed_options[0]
+            assert alert.type == 5
+            assert alert.type_name == "Router Alert"
+            assert alert.data == b"\x00\x00"
+            assert alert.unrecognized_action == 0
 
 
 class TestFragmentHeader:
@@ -101,6 +114,9 @@ class TestDecodeContract:
         assert routing.routing_type == 3
         assert routing.segments_left == 1
         assert bytes(routing) == raw
+        assert routing.header_len == 8
+        assert routing.next_protocol() is ICMPv6
+        assert routing.next_header_name == "IPv6-ICMP"
 
     def test_fragment_round_trip_preserves_reserved_bits(self):
         raw = b"\x3a\xa5\x01\x5b\xde\xad\xbe\xef"
@@ -110,6 +126,7 @@ class TestDecodeContract:
         assert fragment.res == 0b01
         assert fragment.m_flag == 1
         assert bytes(fragment) == raw
+        assert fragment.next_header_name == "IPv6-ICMP"
 
     def test_trailing_bytes_tolerated(self):
         header = IPv6HopByHopOptions.decode(self.RAW_HBH + b"payload")
@@ -137,6 +154,77 @@ class TestDecodeContract:
                 segments_left=0,
                 data=b"\x00" * 12,
             )
+
+
+class TestOptionTLVs:
+    """Option TLV parsing on the two options headers (RFC 8200 §4.2)."""
+
+    def make_hbh(self, options: bytes) -> IPv6HopByHopOptions:
+        """A hop-by-hop header carrying ``options`` (whole 8-octet
+        units, the 2 fixed bytes included)."""
+        return IPv6HopByHopOptions(
+            next_header=58,
+            hdr_ext_len=(len(options) - 6) // 8,
+            options=options,
+        )
+
+    def test_router_alert_and_padn(self):
+        hbh = self.make_hbh(b"\x05\x02\x00\x00\x01\x00")
+        alert, padn = hbh.parsed_options
+        assert alert.type == 5
+        assert alert.type_name == "Router Alert"
+        assert alert.data == b"\x00\x00"
+        assert padn.type == 1
+        assert padn.type_name == "PadN"
+        assert padn.data == b""
+
+    def test_pad1_is_a_lone_byte(self):
+        hbh = self.make_hbh(b"\x00" * 6)
+        options = hbh.parsed_options
+        assert [option.type_name for option in options] == ["Pad1"] * 6
+        assert all(option.data == b"" for option in options)
+
+    def test_jumbo_payload(self):
+        hbh = self.make_hbh(b"\xc2\x04\x00\x10\x00\x00")
+        (jumbo,) = hbh.parsed_options
+        assert jumbo.type == 194
+        assert jumbo.type_name == "Jumbo Payload"
+        assert jumbo.data == b"\x00\x10\x00\x00"
+        assert jumbo.unrecognized_action == 3
+
+    def test_destination_options_share_the_parser(self):
+        dst = IPv6DestinationOptions(
+            next_header=58, hdr_ext_len=0, options=b"\x05\x02\x00\x00\x01\x00"
+        )
+        assert [option.type for option in dst.parsed_options] == [5, 1]
+
+    def test_unknown_type_keeps_raw_data_and_action_bits(self):
+        hbh = self.make_hbh(b"\x8a\x02\xca\xfe\x01\x00")
+        unknown = hbh.parsed_options[0]
+        assert unknown.type == 138
+        assert unknown.type_name == "unknown (138)"
+        assert unknown.data == b"\xca\xfe"
+        assert unknown.unrecognized_action == 2
+
+    def test_action_bits_on_a_direct_construction(self):
+        assert IPv6Option(type=0x40).unrecognized_action == 1
+        assert IPv6Option(type=0x05).unrecognized_action == 0
+
+    def test_missing_length_byte_raises(self):
+        hbh = self.make_hbh(b"\x00\x00\x00\x00\x00\x05")
+        with pytest.raises(InvalidFieldError):
+            _ = hbh.parsed_options
+
+    def test_length_past_the_header_raises(self):
+        hbh = self.make_hbh(b"\x05\x08\x00\x00\x00\x00")
+        with pytest.raises(InvalidFieldError):
+            _ = hbh.parsed_options
+
+    def test_round_trip_unchanged_by_parsing(self):
+        raw = b"\x3a\x00\x05\x02\x00\x00\x01\x00"
+        hbh = IPv6HopByHopOptions.decode(raw)
+        _ = hbh.parsed_options
+        assert bytes(hbh) == raw
 
 
 class TestRegistryGating:


### PR DESCRIPTION
## Summary

*(README roadmap item.)* `IPv6HopByHopOptions` / `IPv6DestinationOptions` decoded as a layer but kept their option TLVs raw. This parses them on demand, following the house pattern: the raw `options` field is preserved, the accessor never re-encodes, and the byte-exact round-trip holds by construction.

## What's included

- `IPv6Option` value type: `type` + `type_name` display property and raw `data`; `unrecognized_action` exposes the action-on-unrecognized bits (the two high bits of the type, RFC 8200 §4.2: skip / discard / discard + Parameter Problem / …).
- `parsed_options` on the shared `_IPv6OptionsHeader` (so both options headers get it): one `IPv6Option` per option in wire order, padding included — Pad1 (0) is a lone type byte with no length; PadN (1), Router Alert (5, RFC 2711), Jumbo Payload (194, RFC 2675) are named; unknown types keep raw `data` with a numeric fallback.
- Bounded parsing: a missing length byte or option data that runs past the header raises `InvalidFieldError`.
- Exported `IPv6Option`; tests: `TestOptionTLVs` unit suite (Router Alert + PadN, Pad1 runs, Jumbo Payload, action bits, unknown types, malformed paths, round-trip), a corpus assert (every `ipv6_mld.pcap` frame's hop-by-hop Router Alert parses to value 0 + PadN), and a hypothesis accessor-safety property. `ipv6_ext.py` at 100% coverage (the previously uncovered `IPv6Routing`/`IPv6Fragment` accessors picked up asserts in existing tests).
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (619 passed; `ipv6_ext.py` at 100% coverage)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Notes

The `CHANGELOG.md` hunk may overlap with the other open roadmap PRs (#68–#71 and the ones that follow); each adds its own entry under `## [Unreleased]`.

Closes #62.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_