### PR TITLE
Add a GRE checksum arm to netprotocols.checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `protocol_type` EtherType, so a GRE-tunnelled IPv4/IPv6 packet
   keeps decoding; the round-trip stays byte-exact regardless of which
   optional fields are present.
+- **GRE checksum arm** (`netprotocols.checksum`, RFC 2784 §2.5):
+  `compute`/`verify` now cover GRE — the internet checksum over the GRE
+  header plus its payload with the checksum field zeroed and no
+  pseudo-header. `compute(gre, payload=...)` requires the
+  Checksum-Present bit (and its field) and raises `InvalidFieldError`
+  otherwise; `verify` of a header whose Checksum-Present bit is clear
+  returns `True` — a frame cannot fail a checksum it does not carry —
+  mirroring the UDP-over-IPv4 zero rule.
 - **DNS resource records** (`DNSResourceRecord`, RFC 1035 §4.1.3): the
   answer, authority, and additional sections parse on demand —
   `DNS.answers` / `DNS.authorities` / `DNS.additionals` yield records

--- a/src/netprotocols/checksum.py
+++ b/src/netprotocols/checksum.py
@@ -23,6 +23,7 @@ from netprotocols._base import (
     ipv6_to_bytes,
 )
 from netprotocols._enums import IPProtocol
+from netprotocols.layer3.gre import GRE
 from netprotocols.layer3.icmp import ICMPv4, ICMPv6
 from netprotocols.layer3.igmp import IGMP
 from netprotocols.layer3.ip import IPv4, IPv6
@@ -99,6 +100,8 @@ def compute(
     :param layer: The header to checksum. ``IPv4`` covers its own
         header only (options included; ``ip``/``payload`` ignored);
         ``ICMPv4`` covers header plus ``payload`` (no pseudo-header);
+        ``GRE`` covers header plus ``payload`` with no pseudo-header
+        (RFC 2784 §2.5) and requires the Checksum-Present bit;
         ``TCP``, ``UDP``, and ``ICMPv6`` prepend the pseudo-header
         built from ``ip``.
     :param ip: The enclosing IP layer, required for TCP/UDP/ICMPv6.
@@ -114,6 +117,16 @@ def compute(
         # Whole message, checksum field (bytes 2-3) zeroed, no
         # pseudo-header; the body is already part of bytes(layer).
         return internet_checksum(_zeroed(bytes(layer), 2))
+    if isinstance(layer, GRE):
+        # GRE header plus payload, checksum field (bytes 4-5) zeroed,
+        # no pseudo-header (RFC 2784 §2.5). Only meaningful when the
+        # Checksum-Present bit announces the field.
+        if layer.checksum is None:
+            raise InvalidFieldError(
+                "Computing a GRE checksum requires the Checksum-Present "
+                "bit and its field (RFC 2784 §2.5)"
+            )
+        return internet_checksum(_zeroed(bytes(layer), 4) + payload)
     if isinstance(layer, ICMPv6):
         enclosing = _require_ip(layer, ip)
         segment = _zeroed(bytes(layer), 2) + payload
@@ -151,13 +164,17 @@ def verify(
 
     A UDP-over-IPv4 checksum of ``0`` means "no checksum in use" and
     verifies as True (over IPv6 the checksum is mandatory and ``0`` is
-    invalid).
+    invalid). A GRE header whose Checksum-Present bit is clear carries
+    no checksum at all (RFC 2784 §2.5) and likewise verifies as True —
+    a frame cannot fail a checksum it does not have.
     """
     if (
         isinstance(layer, UDP)
         and layer.checksum == 0
         and not isinstance(ip, IPv6)
     ):
+        return True
+    if isinstance(layer, GRE) and not layer.checksum_present:
         return True
     wire: int = layer.checksum  # type: ignore[attr-defined]
     return compute(layer, ip=ip, payload=payload) == wire

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -120,8 +120,8 @@ class GRE(Protocol):
     @property
     def checksum(self) -> int | None:
         """The header checksum, carried verbatim, or ``None`` when the
-        checksum-present bit is clear (this library neither computes nor
-        verifies it)."""
+        checksum-present bit is clear (compute/verify via
+        :mod:`netprotocols.checksum`)."""
         if not self.checksum_present or len(self.fields) < 2:
             return None
         return int.from_bytes(self.fields[:2], "big")

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import corpus_frames
 from netprotocols import (
     ARP,
+    GRE,
     TCP,
     UDP,
     Ethernet,
@@ -115,6 +116,79 @@ class TestCorpusChecksums:
             payload[:-1] + bytes([payload[-1] ^ 0xFF]) if payload else b"\x01"
         )
         assert not verify(transport, ip=ip, payload=corrupted)
+
+
+class TestGREChecksum:
+    """The GRE arm (RFC 2784 §2.5): internet checksum over the GRE
+    header plus its payload, checksum field zeroed, no pseudo-header."""
+
+    def make_gre(self, *, keyed: bool = False) -> tuple[GRE, bytes]:
+        """A checksummed (optionally RFC 2890 keyed) GRE header and the
+        tunnelled payload, the checksum filled to its correct value."""
+        payload = bytes(range(64))  # stands in for the inner packet
+        flags = 0x8000 | (0x2000 if keyed else 0)
+        fields = b"\x00" * 4 + (b"\xca\xfe\xba\xbe" if keyed else b"")
+        blank = GRE(flags=flags, protocol_type=0x0800, fields=fields)
+        checksum = compute(blank, payload=payload)
+        filled = GRE(
+            flags=flags,
+            protocol_type=0x0800,
+            fields=checksum.to_bytes(2, "big") + fields[2:],
+        )
+        return filled, payload
+
+    def test_checksummed_gre_round_trips_through_verify(self):
+        gre, payload = self.make_gre()
+        assert gre.checksum is not None
+        assert compute(gre, payload=payload) == gre.checksum
+        assert verify(gre, payload=payload)
+
+    def test_keyed_and_checksummed_gre_verifies(self):
+        gre, payload = self.make_gre(keyed=True)
+        assert gre.key == 0xCAFEBABE
+        assert verify(gre, payload=payload)
+
+    def test_corrupted_payload_is_detected(self):
+        gre, payload = self.make_gre()
+        corrupted = payload[:-1] + bytes([payload[-1] ^ 0xFF])
+        assert not verify(gre, payload=corrupted)
+
+    def test_computing_without_the_checksum_bit_is_rejected(self):
+        plain = GRE(flags=0, protocol_type=0x0800)
+        with pytest.raises(InvalidFieldError):
+            compute(plain, payload=b"x")
+
+    def test_checksum_bit_without_its_field_is_rejected(self):
+        broken = GRE(flags=0x8000, protocol_type=0x0800)  # no fields
+        with pytest.raises(InvalidFieldError):
+            compute(broken)
+
+    def test_absent_checksum_verifies_vacuously(self):
+        """A header that carries no checksum cannot fail verification —
+        the GRE analogue of the UDP-over-IPv4 zero rule."""
+        assert verify(GRE(flags=0, protocol_type=0x0800), payload=b"any")
+        keyed = GRE(flags=0x2000, protocol_type=0x0800, fields=b"\x00" * 4)
+        assert verify(keyed)
+
+    def test_corpus_gre_frames_verify(self):
+        """Every corpus GRE frame — plain and keyed tunnels, none with
+        the checksum bit set — passes verify with its true payload."""
+        seen = 0
+        for name, _, frame in CORPUS:
+            if name != "gre.pcap":
+                continue
+            layers, _ = walk(frame)
+            offset = 0
+            gre = None
+            for layer in layers:
+                if isinstance(layer, GRE):
+                    gre = layer
+                    break
+                offset += layer.header_len
+            assert gre is not None
+            assert verify(gre, payload=frame[offset + gre.header_len :])
+            seen += 1
+        assert seen == 8
 
 
 class TestChecksumRules:


### PR DESCRIPTION
## Summary

`compute`/`verify` covered the IPv4 header, ICMPv4, IGMP, ICMPv6, TCP, and UDP — but not GRE, whose optional checksum (RFC 2784 §2.5) the decoder carries verbatim with no independent way to compute or verify it. This adds the arm.

## What's included

- `compute(gre, payload=...)`: the internet checksum over the **GRE header plus its payload**, checksum field (bytes 4–5) zeroed, no pseudo-header. Requires the Checksum-Present bit and its field — a header that carries no checksum has nothing to compute, so it raises `InvalidFieldError` like other checksum-less layers.
- `verify(gre, payload=...)`: compares to `gre.checksum`; a header whose Checksum-Present bit is clear verifies as `True` — a frame cannot fail a checksum it does not carry — mirroring the documented UDP-over-IPv4 zero rule.
- Docstring updates: `compute()`'s layer list gains the GRE line; `GRE.checksum`'s "this library neither computes nor verifies" note now points at `netprotocols.checksum`.
- Tests (`TestGREChecksum`): crafted plain and RFC 2890 keyed+checksummed headers ride a fill → verify → corrupt cycle; the missing-bit and bit-without-field paths raise; the vacuous-verify rule is exercised against all 8 corpus `gre.pcap` frames (real plain/keyed tunnels, none with the checksum bit — genuine checksummed GRE frames don't occur in the corpus, so the computation itself is crafted-test-driven). `checksum.py` and `gre.py` both at 100% coverage.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (615 passed)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Notes

The `CHANGELOG.md` hunk may overlap with the other open roadmap PRs; each adds its own entry under `## [Unreleased]`.

Closes #63.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_