### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-09-01
 
 ### Added
 - **IEEE 802.1Q VLAN tags** (`VLAN`, 802.1Q-2018 §9.6 / 802.1ad QinQ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netprotocols"
-version = "1.2.0"
+version = "1.3.0"
 description = "Low-level implementations of common networking protocols"
 readme = "README.md"
 license = "MIT"

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -43,7 +43,7 @@ from netprotocols.utils.exceptions import (
 from netprotocols.utils.ipv4 import validate_ipv4_addr
 from netprotocols.utils.mac import random_mac, validate_mac_addr
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = [
     "ARP",

--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "netprotocols"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Cut 1.3.0: the post-1.2 decoder-depth & polish wave (#67, issues #58–#66). Version bump only — `pyproject.toml`, `__version__`, `uv.lock`, and the `## [Unreleased]` section retitled to `## [1.3.0] - 2026-09-01`, mirroring the 1.2.0 release (#38).

Highlights (full details in the CHANGELOG):

- **TCP options** (`TCPOption`), **IPv4 options** (`IPv4Option`), and **IPv6 extension-header options** (`IPv6Option`) parse on demand.
- **ICMP message bodies**: echo `identifier`/`sequence_number`, error `embedded_packet`; **IPv6 NDP** (`NDPOption`) target + option parsing on ICMPv6.
- **GRE checksum arm** in `netprotocols.checksum`.
- **`ipaddress`-object accessors** alongside the `str` address fields (IPv4/IPv6/ARP/DHCP).
- Corpus grown to **97 frames across 17 scenarios**, including a real-capture DNS-over-TCP fixture.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run --frozen pytest` passes (698) with the regenerated lock
- [x] `uv build` + wheel import smoke test reports `1.3.0`

Merging this and pushing the `v1.3.0` tag triggers the Release workflow (PyPI trusted publishing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_