### PR TITLE
Gate the release workflow on the QA ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Callable so the release workflow can run this exact ladder against a
+  # tagged commit before publishing (see release.yml). Keeping one
+  # definition means the release gate cannot drift from the PR gate.
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,21 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
+  # Run the full QA ladder against the tagged commit before anything is
+  # uploaded. This is not redundant with the CI workflow's own triggers:
+  # those fire on pushes and pull requests targeting master, and a tag
+  # push matches neither, so without this job a release ran no checks at
+  # all. A tag can also point at a commit that never landed on master.
+  # A published version can only be yanked, never replaced.
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    needs: ci
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The release workflow can no longer publish untested code.** Pushing
+  a `v*` tag ran `uv build` and `uv publish` with no dependency on the
+  lint, typecheck or test jobs — and because the CI workflow triggers
+  only on pushes and pull requests targeting `master`, a tag push ran
+  **no checks at all**. A tag against broken code published to PyPI
+  unchallenged, and a published version can only be yanked, never
+  replaced. `ci.yml` is now also a reusable workflow (`workflow_call`),
+  and `release.yml` invokes it against the tagged commit with the
+  publish job gated behind it, so the release gate and the pull-request
+  gate are one definition and cannot drift apart.
+
 ### Development
+- `tests/test_workflows.py` asserts the release gate stays wired:
+  that `ci.yml` remains callable, that some release job invokes it,
+  that `publish` depends on that job, and that every local `uses: ./…`
+  reference resolves to a workflow declaring `workflow_call`. The
+  wiring is otherwise easy to remove silently — releases keep working
+  while the gate quietly stops existing — and it cannot be verified by
+  running it, since publishing is irreversible.
 - `docs/CLAIMS.md` records the positioning claims produced by the
   post-1.3.0 competitive analysis, each with its evidence, a
   reproduction path and a publication status — `VERIFIED`,

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,118 @@
+"""Tests that the release workflow cannot publish without the QA ladder.
+
+A published version can only be yanked, never replaced, so the gate that
+stops a broken tag reaching PyPI is worth asserting rather than trusting.
+The wiring is easy to break silently: drop ``needs:`` from the publish
+job, or ``workflow_call:`` from the CI workflow, and releases keep
+working while the gate quietly stops existing.
+
+These parse the workflow YAML by indentation rather than with a YAML
+library, to avoid adding a dependency for four assertions. The files are
+small and uniformly two-space indented; a parse failure here fails the
+test loudly instead of passing vacuously.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+CI = WORKFLOWS / "ci.yml"
+RELEASE = WORKFLOWS / "release.yml"
+
+
+def job_blocks(workflow: Path) -> dict[str, str]:
+    """Map each job name to its raw block text, keyed off ``jobs:``."""
+    text = workflow.read_text()
+    _, _, after = text.partition("\njobs:\n")
+    assert after, f"{workflow.name} has no jobs: mapping"
+    blocks: dict[str, str] = {}
+    current: str | None = None
+    for line in after.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        header = re.fullmatch(r"  ([A-Za-z0-9_-]+):", line)
+        if header:
+            current = header.group(1)
+            blocks[current] = ""
+        elif current is not None and line.startswith("    "):
+            blocks[current] += line + "\n"
+        elif not line.startswith(" "):
+            break  # left the jobs: mapping entirely
+    return blocks
+
+
+@pytest.fixture(scope="module")
+def release_jobs() -> dict[str, str]:
+    return job_blocks(RELEASE)
+
+
+class TestReleaseGate:
+    def test_ci_workflow_is_callable(self) -> None:
+        """The CI workflow must be reusable, or the gate cannot run it."""
+        assert re.search(r"^  workflow_call:", CI.read_text(), re.M), (
+            "ci.yml no longer declares a workflow_call trigger, so "
+            "release.yml cannot invoke it as a gate"
+        )
+
+    def test_release_calls_the_ci_workflow(
+        self, release_jobs: dict[str, str]
+    ) -> None:
+        """Some release job must invoke the real CI workflow."""
+        callers = {
+            name: block
+            for name, block in release_jobs.items()
+            if "./.github/workflows/ci.yml" in block
+        }
+        assert callers, (
+            "no job in release.yml calls ./.github/workflows/ci.yml — a "
+            "tag push runs no checks, because ci.yml's own triggers only "
+            "fire on pushes and pull requests targeting master"
+        )
+
+    def test_publish_depends_on_the_ci_gate(
+        self, release_jobs: dict[str, str]
+    ) -> None:
+        """Publishing must not start until the gate job has passed."""
+        publish = release_jobs.get("publish")
+        assert publish is not None, "release.yml has no publish job"
+
+        gates = {
+            name
+            for name, block in release_jobs.items()
+            if "./.github/workflows/ci.yml" in block
+        }
+        # Match only to end of line: a \s inside the character class
+        # would run past the newline and swallow the next key.
+        declared: set[str] = set()
+        for bracketed, bare in re.findall(
+            r"needs:[ \t]*(?:\[([^\]]*)\]|([A-Za-z0-9_-]+))[ \t]*$",
+            publish,
+            re.M,
+        ):
+            declared |= {n.strip() for n in (bracketed or bare).split(",")}
+        declared.discard("")
+
+        assert declared & gates, (
+            f"publish job needs {declared or '{}'}, none of which is the "
+            f"CI gate {gates}. Without that dependency a tag publishes to "
+            f"PyPI whether or not the checks passed"
+        )
+
+    def test_every_local_reusable_reference_resolves(self) -> None:
+        """A `uses: ./…` pointing at nothing fails the release, not CI."""
+        for workflow in sorted(WORKFLOWS.glob("*.yml")):
+            for ref in re.findall(r"uses:\s*(\./\S+)", workflow.read_text()):
+                # removeprefix, not lstrip: lstrip("./") would strip the
+                # leading dot of ".github" as well.
+                target = WORKFLOWS.parent.parent / ref.removeprefix("./")
+                assert target.is_file(), (
+                    f"{workflow.name} references {ref}, which does not exist"
+                )
+                assert re.search(
+                    r"^  workflow_call:", target.read_text(), re.M
+                ), (
+                    f"{workflow.name} calls {ref}, but that workflow does "
+                    f"not declare a workflow_call trigger"
+                )


### PR DESCRIPTION
## Summary

Closes #78.

Pushing a `v*` tag ran `uv build` and `uv publish` with no dependency on
the lint, typecheck or test jobs. The problem is worse than the issue
described: `ci.yml` triggers only on `push`/`pull_request` targeting
`master`, and **a tag push matches neither**, so a release ran *no
checks at all* — there was not even a CI run to depend on. A tag against
broken code published to PyPI unchallenged, and a published version can
only be yanked, never replaced.

Cross-workflow `needs:` does not exist, so the release workflow has to
run the checks itself. Rather than duplicating the four jobs — and
letting the release gate drift away from the pull-request gate — `ci.yml`
gains a `workflow_call` trigger and `release.yml` invokes it against the
tagged commit, with `publish` gated behind it. One definition serves both.

## What's included

- `.github/workflows/ci.yml` — adds a `workflow_call:` trigger. Existing
  push/PR triggers are unchanged.
- `.github/workflows/release.yml` — a `ci` job calling
  `./.github/workflows/ci.yml`, and `needs: ci` on `publish`. Adds a
  workflow-level `permissions: contents: read`; `publish` keeps its
  `id-token: write` for trusted publishing.
- `tests/test_workflows.py` — four assertions that the gate stays wired.
- `CHANGELOG.md` — entries under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally — 702 tests, 4 new
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

The gate cannot be verified by running it, because publishing is
irreversible. So each assertion was checked against a deliberately
broken workflow to confirm it fails when the gate is actually gone:

| Mutation | Caught by |
|---|---|
| Remove `workflow_call:` from `ci.yml` | `test_ci_workflow_is_callable`, `test_every_local_reusable_reference_resolves` |
| Delete the `ci` gate job | `test_release_calls_the_ci_workflow`, `test_publish_depends_on_the_ci_gate` |
| Remove `needs: ci` from `publish` | `test_publish_depends_on_the_ci_gate` |
| Point `uses:` at a missing workflow | all three of the above |

Worth recording: **`actionlint` passes every one of those mutations.**
It does not resolve local reusable-workflow references, so it reports a
missing target file and a missing `workflow_call` trigger as clean. Its
green result on this PR validates syntax, not wiring — which is why the
tests exist.

## Notes

Two deliberate non-changes:

- **`uv build` still runs twice** (once in the CI `build` job, once in
  `publish`). Sharing an artifact across a reusable-workflow boundary
  costs more complexity than a rebuild from the same commit is worth,
  and publishing from the checkout it just built is the safer default.
- **The gate re-runs CI for a commit already green on master.** That is
  the point — a tag can name any commit, including one that never landed
  on master.

Follow-up filed as #111: a tag whose version disagrees with
`pyproject.toml` is a separate hole this PR does not close, and one the
QA ladder structurally cannot catch, since the code is fine and only the
tag is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt
