### PR TITLE
Enforce the coverage level already achieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate are one definition and cannot drift apart.
 
 ### Development
+- Coverage is now enforced, not merely reported: `fail_under = 98` in
+  `[tool.coverage.report]`. The suite covers 99% of 1441 statements —
+  the only misses are `Packet.__repr__` and its `__eq__`
+  `NotImplemented` branch — so the gate is set below the current figure
+  to leave room for a legitimately unreachable branch, and well above
+  the level at which the bar would stop meaning anything.
 - `tests/test_workflows.py` asserts the release gate stays wired:
   that `ci.yml` remains callable, that some release job invokes it,
   that `publish` depends on that job, and that every local `uses: ./…`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,8 @@ source = ["netprotocols"]
 
 [tool.coverage.report]
 show_missing = true
+# The suite covers 99% of 1441 statements; the only misses are Packet's
+# __repr__ and its __eq__ NotImplemented branch. Gate at 98 rather than
+# at the current figure so a legitimately unreachable branch does not
+# fail CI, and well above it so the bar is actually held.
+fail_under = 98


### PR DESCRIPTION
## Summary

Closes #79.

Coverage ran on every CI build and failed on nothing.
`[tool.coverage.report]` set only `show_missing`, so a drop was reported
and then ignored. The bar had already been cleared — **1441 statements,
3 missed, 99.79%** — it just was not held.

## What's included

- `pyproject.toml` — `fail_under = 98` under `[tool.coverage.report]`,
  with a comment recording what the current figure is and why the gate
  sits below it.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Development`.

## Why 98 and not 100

The only three uncovered statements are `Packet.__repr__` and the
`__eq__` `NotImplemented` branch. Both are trivially coverable, so 100
was tempting — but a gate at 100 turns every legitimately unreachable
branch into a CI failure and invites `# pragma: no cover` scattered
through the source to keep it green. 98 leaves roughly 26 statements of
slack against 1441: enough for a defensive branch, far too little for
coverage to erode quietly.

95, the other value the issue floated, allows ~72 uncovered statements.
That is more slack than this suite has ever needed.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally — 702 tests
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Checked in both directions, so the setting is demonstrably read and
enforced rather than silently ignored:

```
fail_under = 98   →  Required test coverage of 98.0% reached.
                     Total coverage: 99.79%          exit 0

fail_under = 100  →  FAIL Required test coverage of 100.0% not reached.
                     Total coverage: 99.79%          exit 1
```

## Notes

No source or test changes — the coverage figure is unchanged, only
enforced. CI already invokes `pytest --cov=netprotocols`, so the gate
applies to the existing command with no workflow edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_