### PR TITLE
Correct the stale corpus figure and layout map in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -230,19 +230,19 @@ src/netprotocols/
 ├── _enums.py       EtherType, IPProtocol, ARPOperation (imports nothing)
 ├── packet.py       Packet composition, with_checksums()
 ├── checksum.py     RFC 1071: internet_checksum, compute, verify
-├── layer2/         ethernet.py, arp.py
+├── layer2/         ethernet.py, arp.py, vlan.py (802.1Q / 802.1ad)
 ├── layer3/         ip.py (IPv4 + IPv6), icmp.py (ICMPv4 + ICMPv6),
-│                   igmp.py,
+│                   igmp.py, gre.py,
 │                   ipv6_ext.py (Hop-by-Hop, Routing, Fragment,
 │                   Destination Options)
 ├── layer4/         tcp.py, udp.py, _ports.py (well-known-port registry)
-├── layer7/         dns.py
+├── layer7/         dns.py, dhcp.py
 └── utils/          validators (mac.py, ipv4.py), exceptions.py
 tests/              one file per protocol + test_contract.py
                     (truncation, lying lengths, chain walks),
                     test_corpus.py (invariants over the real-capture
-                    corpus in tests/fixtures/, 93 frames across 16
-                    scenarios — see its MANIFEST.md), test_checksum.py
+                    corpus in tests/fixtures/ — see its MANIFEST.md for
+                    the frame and scenario counts), test_checksum.py
                     (corpus checksums recompute to wire values), and
                     test_fuzz.py (hypothesis properties: decode never
                     raises outside ProtocolError)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate are one definition and cannot drift apart.
 
 ### Fixed
+- **ARCHITECTURE.md no longer misstates the corpus or the source
+  layout.** It described "93 frames across 16 scenarios" long after the
+  corpus reached 97 across 17, and its layout map omitted `vlan.py`,
+  `gre.py` and `dhcp.py`. The counts now live in
+  `tests/fixtures/MANIFEST.md` and the README alone — ARCHITECTURE.md
+  points at the MANIFEST rather than keeping a third copy, which is
+  what drifted.
 - **Layer sub-packages now export everything their layer defines.**
   `from netprotocols.layer7 import DHCP` failed while
   `from netprotocols import DHCP` worked, because each layer's own
@@ -30,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DNSResourceRecord`. Purely additive — no name changed meaning.
 
 ### Development
+- `tests/test_docs.py` holds documented facts against the fixtures:
+  the MANIFEST's and README's frame/scenario counts must match the real
+  corpus, ARCHITECTURE.md must not reintroduce a third copy of them,
+  and the layout map must mention every shipped module.
 - `tests/test_exports.py` keeps the layer and top-level export sets in
   agreement, deriving the expectation from each object's `__module__`
   rather than a hand-written list, so a protocol added to the top level

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,87 @@
+"""Tests that documented facts about the corpus match the corpus.
+
+`ARCHITECTURE.md` claimed "93 frames across 16 scenarios" long after the
+corpus reached 97 across 17, because three separate files each restated
+the figure and only one was updated. ARCHITECTURE.md now defers to the
+MANIFEST; these tests hold the two statements that remain — the
+MANIFEST's own, and the README's — against the fixtures themselves.
+
+`test_corpus.py` already gates on the corpus being large enough; what it
+cannot catch is prose drifting away from it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from conftest import FIXTURES, corpus_frames
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = FIXTURES / "MANIFEST.md"
+README = ROOT / "README.md"
+ARCHITECTURE = ROOT / "ARCHITECTURE.md"
+
+ACTUAL_FRAMES = len(corpus_frames())
+ACTUAL_SCENARIOS = len(list(FIXTURES.glob("*.pcap")))
+
+
+class TestCorpusFiguresInDocs:
+    def test_manifest_states_the_real_counts(self) -> None:
+        """MANIFEST.md is the source of truth and must be accurate."""
+        match = re.search(
+            r"(\d+) frames across (\d+)\s+scenarios", MANIFEST.read_text()
+        )
+        assert match is not None, (
+            "MANIFEST.md no longer states 'N frames across M scenarios'; "
+            "update this test if the wording changed deliberately"
+        )
+        frames, scenarios = int(match.group(1)), int(match.group(2))
+        assert (frames, scenarios) == (ACTUAL_FRAMES, ACTUAL_SCENARIOS), (
+            f"MANIFEST.md says {frames} frames across {scenarios} "
+            f"scenarios; tests/fixtures/ holds {ACTUAL_FRAMES} frames "
+            f"across {ACTUAL_SCENARIOS} pcaps"
+        )
+
+    def test_readme_states_the_real_counts(self) -> None:
+        """The README's front-page figure must match too."""
+        text = README.read_text()
+        frames = re.search(r"(\d+)-frame corpus", text)
+        scenarios = re.search(r"across (\d+) scenarios", text)
+        assert frames is not None and scenarios is not None, (
+            "README.md no longer states an 'N-frame corpus ... across M "
+            "scenarios'; update this test if the wording changed"
+        )
+        assert (int(frames.group(1)), int(scenarios.group(1))) == (
+            ACTUAL_FRAMES,
+            ACTUAL_SCENARIOS,
+        ), (
+            f"README.md says {frames.group(1)} frames across "
+            f"{scenarios.group(1)} scenarios; tests/fixtures/ holds "
+            f"{ACTUAL_FRAMES} frames across {ACTUAL_SCENARIOS} pcaps"
+        )
+
+    def test_architecture_does_not_restate_the_counts(self) -> None:
+        """Only the MANIFEST and README should carry the figures.
+
+        A third copy is what drifted last time, so this fails rather
+        than inviting someone to re-add one and keep it in sync by hand.
+        """
+        stale = re.search(
+            r"\d+ frames across \d+\s+scenarios", ARCHITECTURE.read_text()
+        )
+        assert stale is None, (
+            f"ARCHITECTURE.md restates the corpus counts "
+            f"({stale.group(0) if stale else ''}); it should point at "
+            f"tests/fixtures/MANIFEST.md instead of duplicating them"
+        )
+
+    @pytest.mark.parametrize(
+        "module", ["vlan.py", "gre.py", "dhcp.py", "ipv6_ext.py"]
+    )
+    def test_layout_map_lists_every_shipped_module(self, module: str) -> None:
+        """The layout map went stale by omission, not by wrong values."""
+        assert module in ARCHITECTURE.read_text(), (
+            f"ARCHITECTURE.md's layout map does not mention {module}, "
+            f"which ships in src/netprotocols/"
+        )


### PR DESCRIPTION
## Summary

Closes #81.

`ARCHITECTURE.md` described the corpus as "93 frames across 16
scenarios" long after it reached **97 across 17**, and its layout map
omitted `vlan.py`, `gre.py` and `dhcp.py` — three modules that ship.

The wrong number was a symptom. Three files each restated the figure and
only one got updated, so correcting the third copy would have left the
same trap set for the next fixture added.

## What's included

- `ARCHITECTURE.md` — layout map gains `vlan.py`, `gre.py` and
  `dhcp.py`; the corpus counts are removed in favour of pointing at
  `tests/fixtures/MANIFEST.md`, which sits next to the fixtures it
  counts.
- `tests/test_docs.py` — holds the two remaining statements against
  reality.
- `CHANGELOG.md` — entries under `## [Unreleased]`.

## The de-duplication

Two statements of the count remain, both now enforced:

| Where | Status |
|---|---|
| `tests/fixtures/MANIFEST.md` | source of truth, asserted against the fixtures |
| `README.md` | front-page figure, asserted against the fixtures |
| `ARCHITECTURE.md` | **must not restate it** — asserted |

The third test is the interesting one: it fails if anyone re-adds a
count to `ARCHITECTURE.md`, rather than inviting a fourth copy kept in
sync by hand. The layout map is checked by presence of each shipped
module, since it went stale by omission rather than by wrong values.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes — 742 tests, 7 new; coverage 99.79%
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Both drift modes were checked against a deliberately broken tree:

| Mutation | Caught by |
|---|---|
| MANIFEST count set back to 93/16 | `test_manifest_states_the_real_counts` |
| A count re-added to ARCHITECTURE.md | `test_architecture_does_not_restate_the_counts` |

## Notes

`test_docs.py` imports `from conftest import …` to match the existing
convention in `test_corpus.py`, `test_checksum.py` and others — my first
draft used `from tests.conftest import …`, which works locally but
relies on different import machinery than the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_