### PR TITLE
Stop the README advertising shipped work as upcoming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate are one definition and cannot drift apart.
 
 ### Fixed
+- **The README no longer advertises shipped work as upcoming.** Its
+  Roadmap section listed the eight decoder-depth items tracked by #67 —
+  all of which shipped in 1.3.0, with #67 itself closed — so the front
+  page presented finished work as planned and pointed readers at a
+  closed issue. It now links the current roadmap (#107) and its five
+  release-mapped epics instead of restating individual items, which is
+  what went stale.
 - **ARCHITECTURE.md no longer misstates the corpus or the source
   layout.** It described "93 frames across 16 scenarios" long after the
   corpus reached 97 across 17, and its layout map omitted `vlan.py`,
@@ -40,7 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/test_docs.py` holds documented facts against the fixtures:
   the MANIFEST's and README's frame/scenario counts must match the real
   corpus, ARCHITECTURE.md must not reintroduce a third copy of them,
-  and the layout map must mention every shipped module.
+  and the layout map must mention every shipped module. It also
+  guards the README's Roadmap section against pointing back at the
+  superseded #67 or re-listing work that has already shipped.
 - `tests/test_exports.py` keeps the layer and top-level export sets in
   agreement, deriving the expectation from each object's `__module__`
   rather than a hand-written list, so a protocol added to the top level

--- a/README.md
+++ b/README.md
@@ -135,26 +135,24 @@ monitor built on it (formerly Packet-Sniffer).
 
 ## Roadmap
 
-The next wave is decoder depth on already-supported layers, tracked by
-[#67](https://github.com/EONRaider/NETProtocols/issues/67):
+Planned work lives in the issue tracker rather than being restated
+here, so this section cannot drift out of date the way a copied list
+does. The current plan is
+[#107](https://github.com/EONRaider/NETProtocols/issues/107) — five
+tiers, each mapped to a release:
 
-- TCP option parsing — MSS, window scale, SACK, timestamps
-  ([#59](https://github.com/EONRaider/NETProtocols/issues/59)).
-- ICMP message bodies — echo identifier/sequence, the embedded original
-  packet in error messages
-  ([#60](https://github.com/EONRaider/NETProtocols/issues/60)).
-- IPv6 Neighbor Discovery (NDP) messages and options
-  ([#61](https://github.com/EONRaider/NETProtocols/issues/61)).
-- TLV parsing inside IPv6 extension-header options
-  ([#62](https://github.com/EONRaider/NETProtocols/issues/62)).
-- A GRE arm for `netprotocols.checksum`
-  ([#63](https://github.com/EONRaider/NETProtocols/issues/63)).
-- A real-capture DNS-over-TCP corpus fixture
-  ([#64](https://github.com/EONRaider/NETProtocols/issues/64)).
-- Richer address accessors (`ipaddress` objects alongside the `str`
-  fields) ([#65](https://github.com/EONRaider/NETProtocols/issues/65)).
-- IPv4 option parsing — Router Alert, Record Route, Timestamp
-  ([#66](https://github.com/EONRaider/NETProtocols/issues/66)).
+| Version | Theme |
+|---|---|
+| [1.3.1](https://github.com/EONRaider/NETProtocols/issues/102) | Hygiene |
+| [1.4.0](https://github.com/EONRaider/NETProtocols/issues/103) | Decode performance |
+| [2.0.0](https://github.com/EONRaider/NETProtocols/issues/104) | A public protocol registry, a shipped chain walker, flow keys |
+| [2.1.0](https://github.com/EONRaider/NETProtocols/issues/105) | Typed accessors and pattern-matching ergonomics |
+| [2.2.0](https://github.com/EONRaider/NETProtocols/issues/106) | Universal round-trip properties, nightly fuzzing, a pcap reader |
+
+The previous wave — TCP and IPv4 option parsing, ICMP message bodies,
+NDP, IPv6 extension-header TLV options, the GRE checksum arm, a
+DNS-over-TCP corpus fixture and `ipaddress` accessors — shipped in
+1.3.0; see [CHANGELOG.md](CHANGELOG.md).
 
 ## Contributing
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -85,3 +85,31 @@ class TestCorpusFiguresInDocs:
             f"ARCHITECTURE.md's layout map does not mention {module}, "
             f"which ships in src/netprotocols/"
         )
+
+
+class TestReadmeRoadmap:
+    """The README's Roadmap section listed eight items tracked by #67 —
+    all of which had shipped in 1.3.0, with #67 itself closed. Presenting
+    finished work as planned is the front page's version of the drift
+    ARCHITECTURE.md had, and the cause was the same: a copied list."""
+
+    def test_does_not_point_at_the_superseded_roadmap(self) -> None:
+        assert "issues/67" not in README.read_text(), (
+            "README links to #67, the closed roadmap superseded by #107"
+        )
+
+    def test_points_at_the_current_roadmap(self) -> None:
+        assert "issues/107" in README.read_text(), (
+            "README's Roadmap section should point at the tracker (#107) "
+            "rather than restating planned work"
+        )
+
+    def test_does_not_relist_shipped_work_as_planned(self) -> None:
+        """The 1.3.0 items must not reappear as upcoming."""
+        text = README.read_text()
+        roadmap = text[text.index("## Roadmap") : text.index("## Contributing")]
+        for shipped in ("issues/59", "issues/60", "issues/61", "issues/66"):
+            assert shipped not in roadmap, (
+                f"README's Roadmap section links {shipped}, work that "
+                f"shipped in 1.3.0"
+            )


### PR DESCRIPTION
## Summary

Closes #109.

The README's Roadmap section listed the eight decoder-depth items
tracked by #67. All eight shipped in 1.3.0 and #67 is closed, so the
project's front page presented finished work as planned and sent readers
to a closed issue.

Same root cause as the ARCHITECTURE.md drift in #81: a list copied out
of the tracker, which then moved on without it.

## What's included

- `README.md` — the Roadmap section now links
  [#107](https://github.com/EONRaider/NETProtocols/issues/107) and its
  five release-mapped epics in a small table, instead of restating
  individual items. What shipped in 1.3.0 is named in one sentence
  pointing at the changelog, so the information isn't lost.
- `tests/test_docs.py` — three assertions guarding the regression.
- `CHANGELOG.md` — entries under `## [Unreleased]`.

## Why a pointer rather than a corrected list

Rewriting the list with the *new* items would set the same trap for
whoever ships 1.4.0. There is now nothing in the section that can fall
out of date: the tiers and their versions are stable, and the items live
in the epics.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes — 745 tests, 3 new; coverage 99.79%
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Checked against the regression by restoring the old section verbatim,
which fails all three new tests:

```
FAILED test_does_not_point_at_the_superseded_roadmap
FAILED test_points_at_the_current_roadmap
FAILED test_does_not_relist_shipped_work_as_planned
```

## Notes

`test_points_at_the_current_roadmap` hardcodes #107, so it will need a
deliberate update when a roadmap succeeds this one. That is the intent —
the same check is what would have caught #67 going stale.

Tier 0 (#102) is complete with this: #78, #79, #80, #81 and #109 are all
closed. #111 (a tag whose version disagrees with `pyproject.toml`)
remains open in the tier, added after the fact while working on #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_