### PR TITLE
Refuse to publish a release whose tag and version disagree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,34 @@ jobs:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
       - run: uv build
+      # The QA ladder cannot catch a mistagged release: every check
+      # passes because the code is fine and only the tag is wrong. Read
+      # the version back out of the artifact that is about to be
+      # uploaded, rather than re-parsing pyproject.toml, so this
+      # compares against what PyPI will actually receive.
+      - name: Verify the tag matches the version being published
+        run: |
+          set -euo pipefail
+          # Only the "v*" trigger keeps a bare "1.3.0" tag from reaching
+          # this step, where it would compare equal and pass. Check the
+          # prefix here too, so the contract survives a wider trigger.
+          case "${GITHUB_REF_NAME}" in
+            v*) tag="${GITHUB_REF_NAME#v}" ;;
+            *)
+              echo "::error::Tag ${GITHUB_REF_NAME} does not start with 'v'."
+              echo "Release tags must be of the form v<version>." >&2
+              exit 1
+              ;;
+          esac
+          built=$(uv run --isolated --no-project --with dist/*.whl \
+            python -c \
+            "from importlib.metadata import version; print(version('netprotocols'))")
+          if [ "$tag" != "$built" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} would publish version ${built}."
+            echo "The tag and the packaged version must agree." >&2
+            echo "Either retag as v${built}, or set the version in" >&2
+            echo "pyproject.toml (and __version__) to ${tag} and retag." >&2
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} matches packaged version ${built}."
       - run: uv publish --trusted-publishing always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate are one definition and cannot drift apart.
 
 ### Fixed
+- **A mistagged release can no longer publish the wrong version.**
+  `release.yml` built from `pyproject.toml` and never consulted the tag,
+  so pushing `v1.4.0` while the project still read `1.3.0` would either
+  fail at upload against an existing version or, if that version was
+  never released, silently publish the wrong one. The QA ladder cannot
+  catch this — every check passes, because the code is fine and only the
+  tag is wrong. The release now reads the version back out of the built
+  artifact and refuses to publish unless it matches the tag.
 - **The README no longer advertises shipped work as upcoming.** Its
   Roadmap section listed the eight decoder-depth items tracked by #67 —
   all of which shipped in 1.3.0, with #67 itself closed — so the front
@@ -44,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DNSResourceRecord`. Purely additive — no name changed meaning.
 
 ### Development
+- `tests/test_version.py` holds `netprotocols.__version__` against the
+  version in `pyproject.toml`. The two were kept in step by hand and
+  nothing checked them, so a bump that missed one would ship a package
+  whose metadata and `__version__` disagree.
 - `tests/test_docs.py` holds documented facts against the fixtures:
   the MANIFEST's and README's frame/scenario counts must match the real
   corpus, ARCHITECTURE.md must not reintroduce a third copy of them,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,54 @@
+"""Tests that the package's two in-tree version statements agree.
+
+The version is written in three places: ``pyproject.toml`` (what PyPI
+publishes as), ``netprotocols.__version__`` (what a user reads at
+runtime), and the ``v*`` release tag. Nothing kept any pair of them in
+step, so a bump that missed one would ship a package whose metadata and
+``__version__`` disagree.
+
+The two in-tree copies are checked here, on every pull request. The tag
+cannot be checked here because it does not exist until release time —
+``.github/workflows/release.yml`` compares it against the built artifact
+immediately before publishing.
+"""
+
+import tomllib
+from pathlib import Path
+
+import netprotocols
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def packaged_version() -> str:
+    with PYPROJECT.open("rb") as handle:
+        version: str = tomllib.load(handle)["project"]["version"]
+    return version
+
+
+class TestVersionAgreement:
+    def test_dunder_version_matches_pyproject(self) -> None:
+        """A bump must land in both files or neither."""
+        declared = packaged_version()
+        assert netprotocols.__version__ == declared, (
+            f"netprotocols.__version__ is "
+            f"{netprotocols.__version__!r} but pyproject.toml publishes "
+            f"{declared!r}; a release would ship a package whose metadata "
+            f"and __version__ disagree"
+        )
+
+    def test_version_is_a_plausible_release(self) -> None:
+        """Guards the comparison itself: two empty strings would agree.
+
+        Also rejects the placeholder values that make a bad tag easy to
+        push by accident.
+        """
+        declared = packaged_version()
+        assert declared not in ("", "0.0.0"), (
+            f"pyproject.toml declares a placeholder version {declared!r}"
+        )
+        parts = declared.split(".")
+        assert len(parts) >= 2 and all(part.isdigit() for part in parts[:2]), (
+            f"pyproject.toml version {declared!r} does not start with "
+            f"numeric major.minor components"
+        )


### PR DESCRIPTION
## Summary

Closes #111. Completes Tier 0 / 1.3.1 (#102).

`release.yml` built from `pyproject.toml` and never consulted the tag.
Pushing `v1.4.0` while the project still read `1.3.0` would either fail
at upload against an existing version, or — if that version was never
released — **silently publish the wrong one**. The gate added in #78
cannot catch this: every check passes, because the code is fine and only
the tag is wrong.

## The version lives in three places

Nothing kept any pair of them in step; they agreed by manual discipline
alone. Each check now sits where it can fire earliest:

| Pair | Checked by | When |
|---|---|---|
| `pyproject.toml` ↔ `__version__` | `tests/test_version.py` | every pull request |
| tag ↔ published artifact | `release.yml` | immediately before `uv publish` |

The release step reads the version back out of the **built wheel**
rather than re-parsing `pyproject.toml`, so it compares against what
PyPI will actually receive.

## What's included

- `.github/workflows/release.yml` — a verification step between
  `uv build` and `uv publish`.
- `tests/test_version.py` — `__version__` must equal the packaged
  version, plus a guard that the comparison isn't vacuous (two empty
  strings would agree).
- `CHANGELOG.md` — entries under `## [Unreleased]`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes — 747 tests, 2 new; coverage 99.79%
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Unlike #78, this one is executable, so I ran the shipped step — extracted
from the workflow YAML rather than retyped — against a real `uv build`:

| `GITHUB_REF_NAME` | Exit | |
|---|---|---|
| `v1.3.0` | 0 | publishes |
| `v1.4.0` | 1 | *"would publish version 1.3.0… retag as v1.3.0"* |
| `v1.3.0-rc1` | 1 | see note below |
| `1.3.0` | 1 | *"does not start with 'v'"* |
| `varnish-1.3.0` | 1 | matches the `v*` trigger, correctly rejected |
| `v` | 1 | |

`tests/test_version.py` was checked against drift by setting
`__version__` to `1.4.0`, which fails with `assert '1.4.0' == '1.3.0'`.

## One thing running it turned up

**A tag without the `v` prefix passed.** `${GITHUB_REF_NAME#v}` leaves
`1.3.0` untouched, which compares equal to the built version. Only the
`tags: ["v*"]` trigger kept it from reaching the step — an implicit
assumption doing load-bearing work. The prefix is now checked
explicitly, so the contract survives anyone widening that trigger.

## Note on prerelease tags

The comparison is exact, so a prerelease must use the PEP 440 form:
`v1.3.0rc1`, not `v1.3.0-rc1`. The latter fails rather than publishing
something unexpected, and the message names the exact tag expected. I
left it strict rather than pulling `packaging` into the release path to
normalise an edge case that already fails safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_