### PR TITLE
Render MAC addresses with bytes.hex(":")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `bytes_to_mac` renders addresses with `bytes.hex(":")` instead of a
+  generator over `format()`. The old form ran seven generator steps and
+  six `format()` calls per address, twice per Ethernet frame, and showed
+  up in a corpus profile as 88,200 generator calls. Measured 16–29×
+  faster on the call depending on run. Output is byte-for-byte
+  identical, and `memoryview.hex` takes a separator too, so a
+  decode-time view still works. No API change.
+
 ### Fixed
 - **The release workflow can no longer publish untested code.** Pushing
   a `v*` tag ran `uv build` and `uv publish` with no dependency on the

--- a/src/netprotocols/_base.py
+++ b/src/netprotocols/_base.py
@@ -47,7 +47,11 @@ def mac_to_bytes(mac: str) -> bytes:
 
 def bytes_to_mac(data: bytes) -> str:
     """Render 6 raw bytes as a colon-separated lowercase MAC address."""
-    return ":".join(format(octet, "02x") for octet in data)
+    # bytes.hex(sep) does this in one C call; the generator-plus-format
+    # equivalent it replaces ran seven generator steps and six format()
+    # calls per address, twice per Ethernet frame. memoryview.hex takes
+    # a separator too, so this still accepts a decode-time view.
+    return data.hex(":")
 
 
 def ipv4_to_bytes(addr: str) -> bytes:


### PR DESCRIPTION
## Summary

Closes #83. First of Tier 1 (#103).

`bytes_to_mac` built each address with
`":".join(format(octet, "02x") for octet in data)` — seven generator
steps and six `format()` calls per address, twice per Ethernet frame,
plus once per ARP hardware address and NDP link-layer option. A corpus
profile attributed **88,200 generator calls and 75,600 `format()`
calls** to it.

`bytes.hex()` has taken a separator argument since Python 3.8 and does
the whole thing in one C call.

## What's included

- `src/netprotocols/_base.py` — one line, plus a comment recording why.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Changed`.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes — 749 tests, coverage 99.79%
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Output checked against the old implementation, for both input types the
decode path can produce:

```
bytes       '00:07:0d:af:f4:54'  identical=True
memoryview  '00:07:0d:af:f4:54'  identical=True
```

The `memoryview` case matters because `decode()` accepts a view and the
old generator iterated it happily. `memoryview.hex` also takes a
separator, so that path is unaffected — no `bytes()` coercion needed.

Speed, 300,000 calls:

```
old 0.418s   new 0.014s   -> 29.5x
```

#82 measured this at 16.5× on an earlier run; the direction is
unambiguous but the multiple varies, so the changelog cites the range
rather than the flattering number. Its contribution to end-to-end decode
throughput is ~0.9 µs/frame — real but small next to #82's dispatch
fix. The combined figure gets measured properly by the harness in #86.

## Notes

Taken ahead of #82 deliberately: #103 records the two as independent and
order-independent, and this one is a single line with a clean
equivalence check. #82 is the larger win (91×/42× on dispatch) and the
one that shares a design with the registry in #87, so it deserves more
room than was left in this session.

No API change; nothing outside `_base.py` moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_