### PR TITLE
Hoist protocol dispatch into module-level tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Protocol dispatch is a table lookup, not a table construction.**
+  `_ethertype_class()` and `_ip_protocol_class()` re-ran their deferred
+  imports and rebuilt a `dict` literal on *every* call — once per layer
+  per frame, the hottest path in the library. Both now populate a
+  module-level table on first use (the imports stay deferred, so the
+  layer modules remain acyclic) and reduce the call to a lookup.
+  Measured here: `_ip_protocol_class` 1439 → 104 ns (13.9x),
+  `_ethertype_class` 712 → 86 ns (8.3x), and a corpus walk 58,300 →
+  76,500 frames/sec (1.31x). The IPv6-only gating is unchanged: the
+  IPv4 table simply omits those numbers, so an IPv4 packet with
+  `protocol=0` still cannot decode a Hop-by-Hop layer, now asserted at
+  the table level as well as through the public API. No API change.
 - `bytes_to_mac` renders addresses with `bytes.hex(":")` instead of a
   generator over `format()`. The old form ran seven generator steps and
   six `format()` calls per address, twice per Ethernet frame, and showed

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -18,6 +18,32 @@ _VLAN_TAG_ETHERTYPES = frozenset(
 )
 
 
+#: Payload dispatch table, populated on first use. The imports it needs
+#: must stay deferred to keep the layer modules acyclic (see
+#: ARCHITECTURE.md), so the table is built once on the first call rather
+#: than at import time — every later call is a plain dict lookup.
+_ETHERTYPE_CLASSES: dict[int, type[Protocol]] = {}
+
+
+def _build_ethertype_classes() -> None:
+    """Populate :data:`_ETHERTYPE_CLASSES` (called once, on first use)."""
+    from netprotocols.layer2.arp import ARP
+    from netprotocols.layer2.vlan import VLAN
+    from netprotocols.layer3.ip import IPv4, IPv6
+
+    _ETHERTYPE_CLASSES.update(
+        {
+            EtherType.ARP: ARP,
+            EtherType.IPV4: IPv4,
+            EtherType.IPV6: IPv6,
+            # A tag type dispatches to VLAN, whose own next_protocol
+            # calls back here with the inner EtherType — so stacked tags
+            # (QinQ) decode as one VLAN layer per tag.
+            **dict.fromkeys(_VLAN_TAG_ETHERTYPES, VLAN),
+        }
+    )
+
+
 def _ethertype_class(ethertype: int) -> type[Protocol] | None:
     """The class that decodes the payload of an Ethernet/VLAN header.
 
@@ -25,18 +51,9 @@ def _ethertype_class(ethertype: int) -> type[Protocol] | None:
     ``next_protocol`` calls back here with the inner EtherType — so
     stacked tags (QinQ) decode as one VLAN layer per tag.
     """
-    from netprotocols.layer2.arp import ARP
-    from netprotocols.layer2.vlan import VLAN
-    from netprotocols.layer3.ip import IPv4, IPv6
-
-    if ethertype in _VLAN_TAG_ETHERTYPES:
-        return VLAN
-    mapping: dict[int, type[Protocol]] = {
-        EtherType.ARP: ARP,
-        EtherType.IPV4: IPv4,
-        EtherType.IPV6: IPv6,
-    }
-    return mapping.get(ethertype)
+    if not _ETHERTYPE_CLASSES:
+        _build_ethertype_classes()
+    return _ETHERTYPE_CLASSES.get(ethertype)
 
 
 def _ethertype_name(ethertype: int) -> str:

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -45,16 +45,19 @@ _IPV6_ONLY_NUMBERS = frozenset(
 )
 
 
-def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
-    """Map an IP protocol number to the class that decodes its payload.
+#: Payload dispatch tables, populated on first use. The imports they
+#: need must stay deferred to keep the layer modules acyclic (see
+#: ARCHITECTURE.md), so the tables are built once on the first call
+#: rather than at import time — every later call is a dict lookup.
+#:
+#: The IPv4 table simply omits the IPv6-only numbers, so the chain
+#: gating is baked into the table instead of being re-tested per call.
+_IPV6_PROTOCOL_CLASSES: dict[int, type[Protocol]] = {}
+_IPV4_PROTOCOL_CLASSES: dict[int, type[Protocol]] = {}
 
-    The number space is shared between IPv4 ``protocol`` and IPv6
-    ``next_header`` (the values are disjoint), so both classes dispatch
-    through this single registry — but the IPv6 extension headers are
-    handed out only when the caller is part of an IPv6 chain
-    (``ipv6=True``): a garbage IPv4 packet with ``protocol=0`` must not
-    decode a Hop-by-Hop layer.
-    """
+
+def _build_ip_protocol_classes() -> None:
+    """Populate the dispatch tables (called once, on first use)."""
     from netprotocols.layer3.gre import GRE
     from netprotocols.layer3.icmp import ICMPv4, ICMPv6
     from netprotocols.layer3.igmp import IGMP
@@ -67,21 +70,43 @@ def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
     from netprotocols.layer4.tcp import TCP
     from netprotocols.layer4.udp import UDP
 
-    if not ipv6 and number in _IPV6_ONLY_NUMBERS:
-        return None
-    mapping: dict[int, type[Protocol]] = {
-        IPProtocol.HOPOPT: IPv6HopByHopOptions,
-        IPProtocol.ICMP: ICMPv4,
-        IPProtocol.IGMP: IGMP,
-        IPProtocol.GRE: GRE,
-        IPProtocol.IPV6_ROUTE: IPv6Routing,
-        IPProtocol.IPV6_FRAG: IPv6Fragment,
-        IPProtocol.IPV6_ICMP: ICMPv6,
-        IPProtocol.IPV6_DSTOPTS: IPv6DestinationOptions,
-        IPProtocol.TCP: TCP,
-        IPProtocol.UDP: UDP,
-    }
-    return mapping.get(number)
+    _IPV6_PROTOCOL_CLASSES.update(
+        {
+            IPProtocol.HOPOPT: IPv6HopByHopOptions,
+            IPProtocol.ICMP: ICMPv4,
+            IPProtocol.IGMP: IGMP,
+            IPProtocol.GRE: GRE,
+            IPProtocol.IPV6_ROUTE: IPv6Routing,
+            IPProtocol.IPV6_FRAG: IPv6Fragment,
+            IPProtocol.IPV6_ICMP: ICMPv6,
+            IPProtocol.IPV6_DSTOPTS: IPv6DestinationOptions,
+            IPProtocol.TCP: TCP,
+            IPProtocol.UDP: UDP,
+        }
+    )
+    _IPV4_PROTOCOL_CLASSES.update(
+        {
+            number: protocol
+            for number, protocol in _IPV6_PROTOCOL_CLASSES.items()
+            if number not in _IPV6_ONLY_NUMBERS
+        }
+    )
+
+
+def _ip_protocol_class(number: int, *, ipv6: bool) -> type[Protocol] | None:
+    """Map an IP protocol number to the class that decodes its payload.
+
+    The number space is shared between IPv4 ``protocol`` and IPv6
+    ``next_header`` (the values are disjoint), so both classes dispatch
+    through this single registry — but the IPv6 extension headers are
+    handed out only when the caller is part of an IPv6 chain
+    (``ipv6=True``): a garbage IPv4 packet with ``protocol=0`` must not
+    decode a Hop-by-Hop layer.
+    """
+    if not _IPV6_PROTOCOL_CLASSES:
+        _build_ip_protocol_classes()
+    table = _IPV6_PROTOCOL_CLASSES if ipv6 else _IPV4_PROTOCOL_CLASSES
+    return table.get(number)
 
 
 def _ip_protocol_name(number: int) -> str:

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -249,6 +249,23 @@ class TestRegistryGating:
             frame = raw_ipv6_header[:6] + bytes([number]) + raw_ipv6_header[7:]
             assert IPv6.decode(frame).next_protocol() is cls
 
+    def test_dispatch_tables_differ_only_by_the_ipv6_only_numbers(self):
+        """The gating is baked into the tables: the IPv4 table is the
+        IPv6 one minus the extension-header numbers, and nothing else."""
+        from netprotocols.layer3.ip import (
+            _IPV4_PROTOCOL_CLASSES,
+            _IPV6_ONLY_NUMBERS,
+            _IPV6_PROTOCOL_CLASSES,
+            _ip_protocol_class,
+        )
+
+        _ip_protocol_class(6, ipv6=False)  # force the lazy build
+        assert _IPV6_PROTOCOL_CLASSES
+        missing = set(_IPV6_PROTOCOL_CLASSES) - set(_IPV4_PROTOCOL_CLASSES)
+        assert missing == set(_IPV6_ONLY_NUMBERS)
+        for number, protocol in _IPV4_PROTOCOL_CLASSES.items():
+            assert _IPV6_PROTOCOL_CLASSES[number] is protocol
+
     def test_extension_headers_chain_among_themselves(self):
         dst_opts = IPv6HopByHopOptions(
             next_header=60, hdr_ext_len=0, options=b"\x01\x04\x00\x00\x00\x00"


### PR DESCRIPTION
## Summary

`_ethertype_class()` and `_ip_protocol_class()` re-ran their deferred imports and **rebuilt a `dict` literal on every call** — once per layer per frame, the hottest path in the library. Both now build their table once, on first use, and reduce the call to a lookup. Internal only; no API change.

## What's included

- `layer2/ethernet.py`: `_ETHERTYPE_CLASSES`, populated by `_build_ethertype_classes()` on first use. The VLAN tag types fold into the same table (`dict.fromkeys`) instead of a separate membership test.
- `layer3/ip.py`: `_IPV6_PROTOCOL_CLASSES` and `_IPV4_PROTOCOL_CLASSES`. **The gating is baked into the tables** — the IPv4 table is the IPv6 one minus `_IPV6_ONLY_NUMBERS` — so it costs nothing per call and cannot drift.
- The imports stay inside the build functions, so the layer modules remain acyclic exactly as before (ARCHITECTURE.md's deferred-import rule is untouched); only the rebuilding goes away.
- New test asserting the two tables differ *only* by the IPv6-only numbers, alongside the existing public-API gating test (`test_ipv4_never_dispatches_extension_headers`).

## Measured

200k calls, best of run, CPython 3.12 on this machine:

| | before | after | |
|---|---|---|---|
| `_ip_protocol_class` | 1439 ns | 104 ns | **13.9×** |
| `_ethertype_class` | 712 ns | 86 ns | **8.3×** |
| corpus walk (97 frames) | 58,300 f/s | 76,500 f/s | **1.31×** |

A note on the issue's 91×/42×: those compare against a bare dict lookup. The figures above are measured *through the function call*, whose overhead (~90–100 ns) now dominates — the table lookup itself is a few ns. The end-to-end corpus number is the one #86 will gate on.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` — 748 passed
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

## Notes

#87 (Tier 2) generalises this into a public registry. This lands the table as a private implementation detail so the registry design isn't forced now; the shapes are deliberately compatible.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_