### PR TITLE
Cache DNS section parsing instead of re-serializing per access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **DNS section parsing happens once, and no longer re-serializes the
+  message to read it.** Six helpers called `bytes(self)` — a full
+  re-serialization of the whole message — so a single `.answers` access
+  rebuilt the message 14 times; and `answers`, `authorities` and
+  `additionals` each re-parsed *all three* sections, so reading all
+  three parsed the message three times. The parsers are now module-level
+  functions working directly from the `sections` bytes the instance
+  already holds, in section-relative offsets (a compression pointer,
+  which counts from the start of the message, is translated once), and
+  the three accessors share a single parse cached on those immutable
+  bytes. Measured here on a corpus response: `.answers` 16.84 → 0.20 us,
+  all three sections 52.08 → 0.54 us, and one uncached parse 17.03 →
+  12.17 us from dropping the re-serializations alone. Nothing is stored
+  on the frozen instance — the cache is a bounded module-level memo
+  keyed by value, so equal messages share a parse and records (frozen
+  dataclasses) are shared rather than copied. The byte-exact round-trip
+  is unchanged. A compression pointer that addresses the fixed header
+  now raises `InvalidFieldError` instead of decoding header bytes as
+  labels. No API change.
 - **The decoder no longer re-validates the addresses it just
   generated.** Every header's `__post_init__` ran the address
   validators, including for instances built by `decode()` — so a MAC

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -14,6 +14,7 @@ re-encode.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from struct import Struct
 from typing import ClassVar, Self
 
@@ -25,6 +26,20 @@ __all__ = ["DNS", "DNSOverTCP", "DNSResourceRecord"]
 #: A compressed name must not follow more than this many pointers; the
 #: bound makes a maliciously looping name terminate instead of hanging.
 _MAX_NAME_POINTERS = 128
+
+#: Length of the fixed header. The parser works from the ``sections``
+#: bytes that follow it, so every internal offset below is relative to
+#: the start of ``sections``; only a compression pointer, which counts
+#: from the start of the *message*, needs translating (by subtracting
+#: this) — a pointer into the header lands below zero and is rejected.
+_HEADER_LEN = 12
+
+#: How many parsed messages the record cache keeps. The cache is keyed
+#: by the raw section bytes and the counts, so it is shared by equal
+#: messages and bounded: reading all three sections of one message
+#: parses it once instead of three times, without storing anything on
+#: the (frozen) instance.
+_RECORD_CACHE_SIZE = 128
 
 #: DNS resource-record types this library names (RFC 1035 §3.2.2 and
 #: later assignments); unknown types keep their numeric value.
@@ -74,6 +89,180 @@ class DNSResourceRecord:
         """Display name of the record type, e.g. ``"AAAA"``; falls back
         to the numeric type for records unknown to this library."""
         return _RR_TYPE_NAMES.get(self.rtype, str(self.rtype))
+
+
+def _read_name(sections: bytes, at: int) -> int:
+    """The offset just past the name's in-line bytes at ``at``.
+
+    A compression pointer ends the in-line name (this does not follow
+    it — :func:`_labels` does), so the result advances the cursor to the
+    field after the name.
+
+    :raises InvalidFieldError: on a malformed name.
+    """
+    cursor = at
+    while True:
+        if not 0 <= cursor < len(sections):
+            raise InvalidFieldError("DNS name runs past the message")
+        length = sections[cursor]
+        if length == 0:
+            return cursor + 1
+        if length & 0xC0 == 0xC0:  # a pointer ends the in-line name
+            if cursor + 1 >= len(sections):
+                raise InvalidFieldError("truncated DNS compression pointer")
+            return cursor + 2
+        if length & 0xC0:
+            raise InvalidFieldError("reserved DNS label length bits set")
+        cursor += 1 + length
+
+
+def _labels(sections: bytes, at: int) -> str:
+    """Decode the dotted name beginning at ``at``.
+
+    :raises InvalidFieldError: on a label that overruns the message, a
+        reserved length prefix, a pointer into the header, or looping
+        compression pointers (bounded — never hangs).
+    """
+    labels: list[str] = []
+    pointers = 0
+    cursor = at
+    while True:
+        if not 0 <= cursor < len(sections):
+            raise InvalidFieldError("DNS name runs past the message")
+        length = sections[cursor]
+        if length == 0:
+            break
+        if length & 0xC0 == 0xC0:  # compression pointer
+            pointers += 1
+            if pointers > _MAX_NAME_POINTERS:
+                raise InvalidFieldError("DNS name compression loops")
+            if cursor + 1 >= len(sections):
+                raise InvalidFieldError("truncated DNS compression pointer")
+            target = ((length & 0x3F) << 8) | sections[cursor + 1]
+            cursor = target - _HEADER_LEN  # pointers count from the message
+            continue
+        if length & 0xC0:
+            raise InvalidFieldError("reserved DNS label length bits set")
+        if cursor + 1 + length > len(sections):
+            raise InvalidFieldError("DNS label runs past the message")
+        labels.append(
+            sections[cursor + 1 : cursor + 1 + length].decode(
+                "ascii", "replace"
+            )
+        )
+        cursor += 1 + length
+    return ".".join(labels) if labels else "."
+
+
+def _decode_txt(rdata: bytes) -> str:
+    """Concatenate the character-strings of a TXT record (§3.3.14)."""
+    parts: list[str] = []
+    cursor = 0
+    while cursor < len(rdata):
+        length = rdata[cursor]
+        cursor += 1
+        if cursor + length > len(rdata):
+            raise InvalidFieldError("DNS TXT character-string overruns")
+        parts.append(rdata[cursor : cursor + length].decode("ascii", "replace"))
+        cursor += length
+    return "".join(parts)
+
+
+def _decode_rdata(sections: bytes, rtype: int, at: int, rdlength: int) -> str:
+    """A human-readable rendering of the RDATA at ``at``; names follow
+    compression against the whole message."""
+    rdata = sections[at : at + rdlength]
+    if rtype == 1 and rdlength == 4:  # A
+        return bytes_to_ipv4(rdata)
+    if rtype == 28 and rdlength == 16:  # AAAA
+        return bytes_to_ipv6(rdata)
+    if rtype in (2, 5, 12):  # NS, CNAME, PTR — a single name
+        return _labels(sections, at)
+    if rtype == 15 and rdlength >= 2:  # MX — preference + exchange
+        preference = int.from_bytes(rdata[:2], "big")
+        return f"{preference} {_labels(sections, at + 2)}"
+    if rtype == 16:  # TXT
+        return _decode_txt(rdata)
+    if rtype == 6:  # SOA — mname, rname, then five 32-bit fields
+        mname = _labels(sections, at)
+        rname_at = _read_name(sections, at)
+        rname = _labels(sections, rname_at)
+        fixed = _read_name(sections, rname_at)
+        if fixed + 20 > len(sections):
+            raise InvalidFieldError("DNS SOA record truncated")
+        serial, refresh, retry, expire, minimum = (
+            int.from_bytes(sections[fixed + i : fixed + i + 4], "big")
+            for i in range(0, 20, 4)
+        )
+        return f"{mname} {rname} {serial} {refresh} {retry} {expire} {minimum}"
+    return rdata.hex()
+
+
+def _parse_rr(sections: bytes, at: int) -> tuple[DNSResourceRecord, int]:
+    """Parse the resource record at ``at``; return it and the offset of
+    the next record."""
+    name = _labels(sections, at)
+    cursor = _read_name(sections, at)
+    if cursor + 10 > len(sections):
+        raise InvalidFieldError("DNS resource record truncated")
+    rtype = int.from_bytes(sections[cursor : cursor + 2], "big")
+    rclass = int.from_bytes(sections[cursor + 2 : cursor + 4], "big")
+    ttl = int.from_bytes(sections[cursor + 4 : cursor + 8], "big")
+    rdlength = int.from_bytes(sections[cursor + 8 : cursor + 10], "big")
+    cursor += 10
+    if cursor + rdlength > len(sections):
+        raise InvalidFieldError("DNS RDATA runs past the message")
+    record = DNSResourceRecord(
+        name=name,
+        rtype=rtype,
+        rclass=rclass,
+        ttl=ttl,
+        rdata=sections[cursor : cursor + rdlength],
+        rdata_text=_decode_rdata(sections, rtype, cursor, rdlength),
+    )
+    return record, cursor + rdlength
+
+
+def _first_record(sections: bytes, qdcount: int) -> int:
+    """Offset of the first resource record: past the questions.
+
+    :raises InvalidFieldError: if the question section is truncated.
+    """
+    cursor = 0
+    for _ in range(qdcount):
+        cursor = _read_name(sections, cursor)
+        cursor += 4  # QTYPE + QCLASS
+        if cursor > len(sections):
+            raise InvalidFieldError("DNS question section truncated")
+    return cursor
+
+
+@lru_cache(maxsize=_RECORD_CACHE_SIZE)
+def _parse_records(
+    sections: bytes, qdcount: int, ancount: int, nscount: int, arcount: int
+) -> tuple[
+    tuple[DNSResourceRecord, ...],
+    tuple[DNSResourceRecord, ...],
+    tuple[DNSResourceRecord, ...],
+]:
+    """Parse the answer, authority and additional sections in one pass.
+
+    Cached on the (immutable) section bytes and counts, so reading all
+    three accessors of a message parses it once. Records are frozen
+    dataclasses, so sharing them between callers is safe.
+
+    :raises InvalidFieldError: if a record, its RDATA, or a name runs
+        past the message (bounded — never hangs or over-reads).
+    """
+    cursor = _first_record(sections, qdcount)
+    parsed: list[tuple[DNSResourceRecord, ...]] = []
+    for count in (ancount, nscount, arcount):
+        records: list[DNSResourceRecord] = []
+        for _ in range(count):
+            record, cursor = _parse_rr(sections, cursor)
+            records.append(record)
+        parsed.append(tuple(records))
+    return parsed[0], parsed[1], parsed[2]
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,67 +368,6 @@ class DNS(Protocol):
 
     # -- first question (parsed on demand, never re-encoded) --
 
-    def _read_name(self, offset: int) -> int:
-        """The offset just past the name's in-line bytes at ``offset``. A
-        compression pointer ends the in-line name (this does not follow
-        it — :meth:`_labels` does), so the result advances the cursor to
-        the field after the name.
-
-        :raises InvalidFieldError: on a malformed name.
-        """
-        message = bytes(self)
-        cursor = offset
-        while True:
-            if cursor >= len(message):
-                raise InvalidFieldError("DNS name runs past the message")
-            length = message[cursor]
-            if length == 0:
-                return cursor + 1
-            if length & 0xC0 == 0xC0:  # a pointer ends the in-line name
-                if cursor + 1 >= len(message):
-                    raise InvalidFieldError("truncated DNS compression pointer")
-                return cursor + 2
-            if length & 0xC0:
-                raise InvalidFieldError("reserved DNS label length bits set")
-            cursor += 1 + length
-
-    def _labels(self, offset: int) -> str:
-        """Decode the dotted name beginning at ``offset``.
-
-        :raises InvalidFieldError: on a label that overruns the message,
-            a reserved length prefix, or looping compression pointers
-            (bounded — never hangs).
-        """
-        message = bytes(self)
-        labels: list[str] = []
-        pointers = 0
-        cursor = offset
-        while True:
-            if cursor >= len(message):
-                raise InvalidFieldError("DNS name runs past the message")
-            length = message[cursor]
-            if length == 0:
-                break
-            if length & 0xC0 == 0xC0:  # compression pointer
-                pointers += 1
-                if pointers > _MAX_NAME_POINTERS:
-                    raise InvalidFieldError("DNS name compression loops")
-                if cursor + 1 >= len(message):
-                    raise InvalidFieldError("truncated DNS compression pointer")
-                cursor = ((length & 0x3F) << 8) | message[cursor + 1]
-                continue
-            if length & 0xC0:
-                raise InvalidFieldError("reserved DNS label length bits set")
-            if cursor + 1 + length > len(message):
-                raise InvalidFieldError("DNS label runs past the message")
-            labels.append(
-                message[cursor + 1 : cursor + 1 + length].decode(
-                    "ascii", "replace"
-                )
-            )
-            cursor += 1 + length
-        return ".".join(labels) if labels else "."
-
     @property
     def question_name(self) -> str | None:
         """The QNAME of the first question, decompressed, or ``None``
@@ -250,17 +378,16 @@ class DNS(Protocol):
         """
         if self.qdcount == 0:
             return None
-        return self._labels(self._struct.size)
+        return _labels(self.sections, 0)
 
     def _question_fixed(self) -> tuple[int, int] | None:
         if self.qdcount == 0:
             return None
-        end = self._read_name(self._struct.size)
-        message = bytes(self)
-        if end + 4 > len(message):
+        end = _read_name(self.sections, 0)
+        if end + 4 > len(self.sections):
             raise InvalidFieldError("DNS question truncated")
-        qtype = int.from_bytes(message[end : end + 2], "big")
-        qclass = int.from_bytes(message[end + 2 : end + 4], "big")
+        qtype = int.from_bytes(self.sections[end : end + 2], "big")
+        qclass = int.from_bytes(self.sections[end + 2 : end + 4], "big")
         return qtype, qclass
 
     @property
@@ -279,92 +406,6 @@ class DNS(Protocol):
 
     # -- resource records (parsed on demand, never re-encoded) --
 
-    def _sections_start(self) -> int:
-        """Offset of the first resource record: past the questions.
-
-        :raises InvalidFieldError: if the question section is truncated.
-        """
-        message = bytes(self)
-        cursor = self._struct.size
-        for _ in range(self.qdcount):
-            cursor = self._read_name(cursor)
-            cursor += 4  # QTYPE + QCLASS
-            if cursor > len(message):
-                raise InvalidFieldError("DNS question section truncated")
-        return cursor
-
-    def _decode_txt(self, rdata: bytes) -> str:
-        """Concatenate the character-strings of a TXT record (§3.3.14)."""
-        parts: list[str] = []
-        cursor = 0
-        while cursor < len(rdata):
-            length = rdata[cursor]
-            cursor += 1
-            if cursor + length > len(rdata):
-                raise InvalidFieldError("DNS TXT character-string overruns")
-            parts.append(
-                rdata[cursor : cursor + length].decode("ascii", "replace")
-            )
-            cursor += length
-        return "".join(parts)
-
-    def _decode_rdata(self, rtype: int, offset: int, rdlength: int) -> str:
-        """A human-readable rendering of the RDATA at ``offset``; names
-        follow compression against the whole message."""
-        message = bytes(self)
-        rdata = message[offset : offset + rdlength]
-        if rtype == 1 and rdlength == 4:  # A
-            return bytes_to_ipv4(rdata)
-        if rtype == 28 and rdlength == 16:  # AAAA
-            return bytes_to_ipv6(rdata)
-        if rtype in (2, 5, 12):  # NS, CNAME, PTR — a single name
-            return self._labels(offset)
-        if rtype == 15 and rdlength >= 2:  # MX — preference + exchange
-            preference = int.from_bytes(rdata[:2], "big")
-            return f"{preference} {self._labels(offset + 2)}"
-        if rtype == 16:  # TXT
-            return self._decode_txt(rdata)
-        if rtype == 6:  # SOA — mname, rname, then five 32-bit fields
-            mname = self._labels(offset)
-            rname_at = self._read_name(offset)
-            rname = self._labels(rname_at)
-            fixed = self._read_name(rname_at)
-            if fixed + 20 > len(message):
-                raise InvalidFieldError("DNS SOA record truncated")
-            serial, refresh, retry, expire, minimum = (
-                int.from_bytes(message[fixed + i : fixed + i + 4], "big")
-                for i in range(0, 20, 4)
-            )
-            return (
-                f"{mname} {rname} {serial} {refresh} {retry} {expire} {minimum}"
-            )
-        return rdata.hex()
-
-    def _parse_rr(self, cursor: int) -> tuple[DNSResourceRecord, int]:
-        """Parse the resource record at ``cursor``; return it and the
-        offset of the next record."""
-        message = bytes(self)
-        name = self._labels(cursor)
-        cursor = self._read_name(cursor)
-        if cursor + 10 > len(message):
-            raise InvalidFieldError("DNS resource record truncated")
-        rtype = int.from_bytes(message[cursor : cursor + 2], "big")
-        rclass = int.from_bytes(message[cursor + 2 : cursor + 4], "big")
-        ttl = int.from_bytes(message[cursor + 4 : cursor + 8], "big")
-        rdlength = int.from_bytes(message[cursor + 8 : cursor + 10], "big")
-        cursor += 10
-        if cursor + rdlength > len(message):
-            raise InvalidFieldError("DNS RDATA runs past the message")
-        record = DNSResourceRecord(
-            name=name,
-            rtype=rtype,
-            rclass=rclass,
-            ttl=ttl,
-            rdata=message[cursor : cursor + rdlength],
-            rdata_text=self._decode_rdata(rtype, cursor, rdlength),
-        )
-        return record, cursor + rdlength
-
     def _resource_records(
         self,
     ) -> tuple[
@@ -372,20 +413,15 @@ class DNS(Protocol):
         tuple[DNSResourceRecord, ...],
         tuple[DNSResourceRecord, ...],
     ]:
-        """Parse the answer, authority, and additional sections.
-
-        :raises InvalidFieldError: if a record, its RDATA, or a name runs
-            past the message (bounded — never hangs or over-reads).
-        """
-        cursor = self._sections_start()
-        sections: list[tuple[DNSResourceRecord, ...]] = []
-        for count in (self.ancount, self.nscount, self.arcount):
-            records: list[DNSResourceRecord] = []
-            for _ in range(count):
-                record, cursor = self._parse_rr(cursor)
-                records.append(record)
-            sections.append(tuple(records))
-        return sections[0], sections[1], sections[2]
+        """The three record sections, parsed once (see
+        :func:`_parse_records`) and shared by the accessors below."""
+        return _parse_records(
+            self.sections,
+            self.qdcount,
+            self.ancount,
+            self.nscount,
+            self.arcount,
+        )
 
     @property
     def answers(self) -> tuple[DNSResourceRecord, ...]:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -487,3 +487,61 @@ class TestDNSOverTCP:
         (a,) = dns.answers
         assert (a.rtype_name, a.rdata_text) == ("A", "93.184.216.34")
         assert b"".join(bytes(layer) for layer in layers) == frame
+
+
+class TestSectionParsingIsShared:
+    """#85: the three section accessors share one parse, and nothing
+    round-trips through `bytes(self)` to get at the message."""
+
+    def response_with_all_three_sections(self) -> bytes:
+        header = struct.pack("!HHHHHH", 0x1234, 0x8180, 1, 1, 1, 1)
+        question = build_query(["example", "test"])[12:]
+        # One A record per section, each naming the question by pointer.
+        record = b"\xc0\x0c" + struct.pack("!HHIH", 1, 1, 300, 4)
+        return header + question + (record + b"\x0a\x00\x00\x01") * 3
+
+    def test_reading_all_three_sections_parses_once(self):
+        from netprotocols.layer7 import dns as dns_module
+
+        dns_module._parse_records.cache_clear()
+        message = DNS.decode(self.response_with_all_three_sections())
+        assert len(message.answers) == 1
+        assert len(message.authorities) == 1
+        assert len(message.additionals) == 1
+        info = dns_module._parse_records.cache_info()
+        assert (info.misses, info.hits) == (1, 2)
+
+    def test_accessors_agree_with_a_single_parse(self):
+        from netprotocols.layer7 import dns as dns_module
+
+        raw = self.response_with_all_three_sections()
+        message = DNS.decode(raw)
+        answers, authorities, additionals = (
+            dns_module._parse_records.__wrapped__(
+                message.sections,
+                message.qdcount,
+                message.ancount,
+                message.nscount,
+                message.arcount,
+            )
+        )
+        assert message.answers == answers
+        assert message.authorities == authorities
+        assert message.additionals == additionals
+        assert bytes(message) == raw  # round-trip untouched
+
+    def test_cached_records_are_shared_not_copied(self):
+        """Equal messages share one parse; the records are frozen, so
+        sharing them between callers cannot leak mutation."""
+        raw = self.response_with_all_three_sections()
+        first, second = DNS.decode(raw), DNS.decode(raw)
+        assert first.answers is second.answers
+        with pytest.raises(AttributeError):
+            first.answers[0].name = "mutated"  # type: ignore[misc]
+
+    def test_pointer_into_the_header_is_rejected(self):
+        """Offsets are section-relative now; a pointer below the header
+        length cannot address anything real."""
+        raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\xc0\x02"
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(raw).question_name


### PR DESCRIPTION
## Summary

`layer7/dns.py` called `bytes(self)` — a full re-serialization of the whole message — from six sites, because compression offsets are message-relative while the parser only held `sections`. One `.answers` access rebuilt the message **14 times**. And `answers` / `authorities` / `additionals` each re-parsed *all three* sections, so reading all three parsed the message three times over.

Both of the changes the issue asks for, in order:

1. **No more round-tripping.** The parsers are module-level functions working directly from the `sections` bytes the instance already holds, in section-relative offsets. Only a compression pointer needs translating (subtract the 12-byte header length) — and a pointer addressing the header itself now lands below zero and raises `InvalidFieldError` instead of decoding header bytes as labels. `bytes(self)` appears in no accessor.
2. **One parse for three sections**, via a module-level `lru_cache` keyed by the immutable section bytes plus the counts.

## The frozen-instance question

Nothing is stored on the instance: no `object.__setattr__`, no extra field, no `cached_property` (which `slots=True` rules out anyway). Hashability and equality are untouched, `bytes(decode(x)) == x` still holds, and the memo is bounded at 128 messages. Because it is keyed by value, two equal messages share one parse — records are frozen dataclasses, so sharing them between callers cannot leak mutation, which the tests assert directly.

## Measured

Corpus DNS response, 20k iterations, CPython 3.12 on this machine:

| | before | after | |
|---|---|---|---|
| one uncached parse | 17.03 µs | 12.17 µs | **1.4×** (re-serialization alone) |
| `.answers` | 16.84 µs | 0.20 µs | |
| `.answers` + `.authorities` + `.additionals` | 52.08 µs | 0.54 µs | ratio 2.9× → **1.03×** |

Corpus throughput is unchanged (~115k f/s) because the chain walk never touches record accessors — this is a win for callers that read records, which is what the accessors are for.

## Verification

- [x] Reading all three sections parses once — asserted via `cache_info()` (1 miss, 2 hits)
- [x] `bytes(self)` is not called from any accessor — no occurrences remain in the module
- [x] Round-trip and DNS corpus assertions unchanged
- [x] `uv run ruff check` / `ruff format --check` / `mypy` clean; `uv run pytest` — 757 passed

## Notes

One deliberate behaviour change worth a reviewer's eye: a compression pointer into the fixed header previously produced garbage labels and now raises `InvalidFieldError`. It is unreachable in well-formed messages, the fuzz contract (`ProtocolError` or a value, never anything else) is preserved, and there is a test for it.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_