### PR TITLE
Add a reproducible benchmark harness and an advisory CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,29 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv build
       - run: uv run --isolated --no-project --with dist/*.whl python -c "import netprotocols; print(netprotocols.__version__)"
+
+  # Advisory, deliberately: throughput on a shared runner is noisy, and
+  # a threshold picked without runner data would start failing pull
+  # requests that changed nothing. The job measures, compares against
+  # the committed baseline and reports; `continue-on-error` keeps it
+  # from blocking until a maintainer sets a real threshold (#103).
+  #
+  # Pinned to the baseline's interpreter on purpose: normalization
+  # cancels how fast the machine is, not which CPython it runs (see the
+  # module docstring in scripts/benchmark.py).
+  benchmark:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+      - name: Corpus decode throughput (advisory)
+        run: |
+          {
+            echo '```'
+            uv run --frozen --group bench python scripts/benchmark.py \
+              --check --compare
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DNSResourceRecord`. Purely additive — no name changed meaning.
 
 ### Development
+- **A reproducible decode benchmark, and an advisory CI job that runs
+  it.** `scripts/benchmark.py` walks the 97-frame corpus and reports
+  frames/sec; `--compare` times `dpkt` and `scapy` on the same frames
+  (both dev-only extras in a new `bench` dependency group — the package
+  still has zero runtime dependencies). Because absolute throughput is
+  a property of the machine, every run also times a fixed calibration
+  workload and reports a normalized figure, which is what `--check`
+  compares against `benchmarks/baseline.json`. The CI job is
+  deliberately **advisory** (`continue-on-error`): a threshold chosen
+  without runner data would fail unrelated pull requests, so the job
+  measures and reports until a maintainer sets one. Comparison output
+  carries its own caveats — notably that the libraries are not asked
+  for identical work, since dpkt leaves the DNS-over-TCP payload as raw
+  bytes where this library decodes it — because a benchmark nobody can
+  check is the problem #86 set out to fix, not the goal.
 - `tests/test_version.py` holds `netprotocols.__version__` against the
   version in `pyproject.toml`. The two were kept in step by hand and
   nothing checked them, so a bump that missed one would ship a package

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,13 @@
+{
+  "frames_per_sec": 114388.4,
+  "calibration_per_sec": 17159.4,
+  "normalized": 6.6662,
+  "frames": 97,
+  "repetitions": 30,
+  "trials": 9,
+  "recorded": {
+    "on": "CPython 3.12.3 / x86_64 / Linux",
+    "python": "3.12.3",
+    "netprotocols": "1.3.0"
+  }
+}

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -47,28 +47,82 @@ against dpkt's 123,719 (a 1.6× gap) where the corpus shows 2.9×,
 because the uncached DNS accessors of #85 never get exercised. **Quote
 the corpus figure.**
 
+### Re-measured after Tier 1 (2026-09-01, #86)
+
+Tier 1 (#82, #83, #84, #85) has merged, so every figure above that
+compares decode throughput is stale. Re-measured with the harness this
+tier delivered:
+
+```
+uv run --group bench python scripts/benchmark.py --compare
+```
+
+- CPython 3.12.3, x86-64 Linux, 97 corpus frames, 30 repetitions,
+  **best of 9** — not the mean of 300 used above. The minimum is the
+  more stable statistic (a timed run is only ever interrupted, never
+  helped), but it reads a few per cent faster than a mean, so the two
+  methods are not directly comparable.
+- Run-to-run variance of the normalized figure ≈ ±2%.
+
+| | frames/sec | vs. netprotocols |
+|---|---|---|
+| **netprotocols (post-Tier-1)** | **121,945** | — |
+| dpkt 1.9.8 | 105,292 | 0.86× |
+| scapy 2.7.0 | 19,657 | 0.16× |
+
+Two things must travel with those numbers:
+
+1. **The libraries are not asked for identical work.** On the
+   DNS-over-TCP frames dpkt stops at TCP and leaves the payload as raw
+   bytes; netprotocols continues into `DNSOverTCP` and `DNS`. Where the
+   depths differ, we are doing more, not less — but the comparison is
+   not like-for-like and should never be quoted as if it were. The
+   harness prints this caveat under every comparison run.
+2. **Normalization cancels machine speed, not the interpreter.** The
+   same code and machine normalize to 6.8 on CPython 3.12 and 7.6 on
+   3.13. A baseline belongs to the Python that recorded it.
+
+Note also that the v1.3.0 figure of 36,500 f/s above predates #83, which
+alone accounts for most of the gap to the ~58,000 f/s the same corpus
+walk showed once that had merged.
+
 ---
 
 ## 1. Performance
 
 ### 1.1 "2.1× faster than scapy at decoding"
-**Status: VERIFIED**
+**Status: VERIFIED — and now understated**
 
-36,500 frames/sec against scapy 2.7.0's 17,100 on the corpus walk.
+Was 36,500 frames/sec against scapy 2.7.0's 17,100. Re-measured after
+Tier 1: **121,945 against 19,657, a 6.2× gap** (see the re-measurement
+above for the method and its caveats).
 
-Reproduce: the benchmark harness from #86, once it lands. Until then,
-the scratch method described in the baseline above.
+Reproduce: `uv run --group bench python scripts/benchmark.py --compare`.
+
+The wording is a positioning decision, not a measurement one: 6.2× is
+what the corpus shows on one machine, and whoever writes the README
+should pick the number they are willing to defend on someone else's.
 
 ### 1.2 "Within 15% of dpkt on decode"
-**Status: GATED ON #82, #83, #84** — false today
+**Status: gate satisfied — measured, and the claim is now too modest**
 
-Today: 36,500 f/s against dpkt's 104,000 — we are **2.9× slower**.
-With the three Tier 1 fixes applied to a scratch copy: **89,200 f/s**,
-or 86% of dpkt, while passing all 698 tests unmodified.
+#82, #83, #84 (and #85) have merged and #86 has re-measured on the real
+tree, which is exactly what this claim was waiting for. Measured:
+**121,945 f/s against dpkt 1.9.8's 105,292 — 1.16× dpkt**, where
+v1.3.0 was 2.9× slower. The prediction in #103 was 86% of dpkt; the
+extra came from #85, which the scratch prototype did not include, and
+from best-of rather than mean.
 
-Do not publish any decode-throughput comparison against dpkt until
-those three issues have merged and #86 has re-measured on the real
-tree.
+Before this is published as "faster than dpkt", two caveats from the
+re-measurement section apply and are not optional: the two libraries do
+not parse to the same depth (we go deeper on the DNS frames), and this
+is one machine. A cautious public form — "matches dpkt on the corpus
+walk while decoding further into the stack" — is defensible on the
+evidence; "1.16× faster than dpkt" is defensible only with the machine
+and the depth caveat attached.
+
+Recommend re-running the harness on a second machine before this
+reaches the README. Front-page wording is the maintainer's call.
 
 ### 1.3 "5.3× faster than dpkt at encoding"
 **Status: VERIFIED** — and never yet claimed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ Repository = "https://github.com/EONRaider/NETProtocols"
 Changelog = "https://github.com/EONRaider/NETProtocols/blob/master/CHANGELOG.md"
 
 [dependency-groups]
+bench = [
+    "dpkt>=1.9.8",
+    "scapy>=2.6",
+]
 dev = [
     "hypothesis>=6.100",
     "mypy>=1.14",

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Decode-throughput benchmark over the real-capture fixture corpus.
+
+    uv run --group bench python scripts/benchmark.py
+    uv run --group bench python scripts/benchmark.py --compare
+    uv run --group bench python scripts/benchmark.py --check
+
+The workload is every frame in ``tests/fixtures/`` walked from
+``Ethernet`` to the end of its chain — the corpus exercises DNS, DHCP,
+GRE, VLAN tags and IPv6 extension headers, which a single synthetic TCP
+frame does not. Frames the library rejects are counted, not skipped, so
+a change that "speeds things up" by decoding less shows up.
+
+Comparison mode (``--compare``) times `dpkt` and `scapy` on the same
+frames, and prints exactly what each library was asked to do — the
+comparison is only worth publishing if that is on the record. Both are
+dev-only extras: the package itself still has zero runtime dependencies.
+
+Cross-machine comparison
+------------------------
+Absolute frames/sec is a property of the machine as much as the code, so
+a committed baseline cannot be compared to a run on someone else's
+hardware — or on whichever shared runner CI lands. Every run therefore
+also times a fixed calibration workload built from the same primitives
+as the decode path (``struct`` unpacking, slicing, dict lookups) and
+reports throughput normalized by it. The normalized figure is what
+``--check`` compares; the absolute one is what you quote, with the
+machine named.
+
+``--check`` re-measures with whatever settings the baseline recorded,
+rather than trusting the caller to match them.
+
+Normalization cancels how fast the *machine* is; it does not cancel the
+interpreter. Measured here, the same code and machine normalize to 6.8
+on CPython 3.12 and 7.6 on 3.13, because the release speeds the decode
+path and the calibration workload up by different amounts. A baseline
+is therefore tied to the Python version that recorded it — ``--check``
+says so when they differ, and the CI job pins one version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import struct
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+#: Calibration passes per trial. Fixed, and large enough that a pass
+#: takes tens of milliseconds: timing a workload that runs for barely a
+#: millisecond measures the scheduler, not the machine, and the noise
+#: lands straight in the normalized figure the regression gate reads.
+CALIBRATION_PASSES = 1000
+
+REPOSITORY = Path(__file__).resolve().parent.parent
+FIXTURES = REPOSITORY / "tests" / "fixtures"
+BASELINE = REPOSITORY / "benchmarks" / "baseline.json"
+
+sys.path.insert(0, str(REPOSITORY / "src"))
+
+from netprotocols import Ethernet, Protocol, ProtocolError  # noqa: E402
+
+
+def read_pcap(path: Path) -> list[bytes]:
+    """Minimal classic-pcap reader (standalone, like check_fixtures)."""
+    data = path.read_bytes()
+    magic = data[:4]
+    if magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):
+        endian = ">"
+    elif magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):
+        endian = "<"
+    else:
+        raise ValueError(f"{path.name}: not a pcap")
+    frames, cursor = [], 24
+    while cursor + 16 <= len(data):
+        (incl_len,) = struct.unpack_from(f"{endian}I", data, cursor + 8)
+        cursor += 16
+        frames.append(data[cursor : cursor + incl_len])
+        cursor += incl_len
+    return frames
+
+
+def corpus_frames() -> list[bytes]:
+    return [
+        frame
+        for pcap in sorted(FIXTURES.glob("*.pcap"))
+        for frame in read_pcap(pcap)
+    ]
+
+
+def walk(frame: bytes) -> int:
+    """The documented chain walk; returns the number of layers."""
+    cursor, layers = 0, 0
+    protocol: type[Protocol] | None = Ethernet
+    while protocol is not None:
+        header = protocol.decode(frame[cursor:])
+        cursor += header.header_len
+        protocol = header.next_protocol()
+        layers += 1
+    return layers
+
+
+def decode_netprotocols(frames: list[bytes]) -> int:
+    decoded = 0
+    for frame in frames:
+        try:
+            walk(frame)
+        except ProtocolError:
+            continue
+        decoded += 1
+    return decoded
+
+
+def decode_dpkt(frames: list[bytes]) -> int:
+    import dpkt
+
+    decoded = 0
+    for frame in frames:
+        try:
+            dpkt.ethernet.Ethernet(frame)
+        except Exception:
+            continue
+        decoded += 1
+    return decoded
+
+
+def decode_scapy(frames: list[bytes]) -> int:
+    from scapy.layers.l2 import Ether
+
+    decoded = 0
+    for frame in frames:
+        try:
+            packet = Ether(frame)
+            packet.layers()  # force the lazy chain to materialize
+        except Exception:
+            continue
+        decoded += 1
+    return decoded
+
+
+def calibration_workload() -> int:
+    """A fixed unit of work built from the decode path's primitives.
+
+    Used only as a speed reference for the machine, so a baseline
+    recorded elsewhere stays comparable. Deliberately not a decode: it
+    must not change when the decoder does.
+    """
+    header = struct.Struct("!BBHHHBBH4s4s")
+    buffer = bytes(range(64))
+    table = {number: number * 2 for number in range(16)}
+    total = 0
+    for _ in range(200):
+        fields = header.unpack_from(buffer)
+        total += fields[0] + len(buffer[20:40])
+        total += table.get(fields[1] & 0x0F, 0)
+    return total
+
+
+def best_of(work: Callable[[], Any], trials: int) -> float:
+    """Shortest wall-clock time of ``trials`` runs.
+
+    The minimum, not the mean: a benchmark process is only ever
+    interrupted, never helped, so the fastest run is the closest to the
+    cost of the code itself.
+    """
+    work()  # warm caches and imports
+    return min(_timed(work) for _ in range(trials))
+
+
+def _timed(work: Callable[[], Any]) -> float:
+    start = time.perf_counter()
+    work()
+    return time.perf_counter() - start
+
+
+def measure(
+    frames: list[bytes], repetitions: int, trials: int
+) -> dict[str, Any]:
+    def decode_pass() -> None:
+        for _ in range(repetitions):
+            decode_netprotocols(frames)
+
+    seconds = best_of(decode_pass, trials)
+    frames_per_sec = (repetitions * len(frames)) / seconds
+
+    def calibration_pass() -> None:
+        for _ in range(CALIBRATION_PASSES):
+            calibration_workload()
+
+    calibration_seconds = best_of(calibration_pass, trials)
+    calibration_per_sec = CALIBRATION_PASSES / calibration_seconds
+
+    return {
+        "frames_per_sec": round(frames_per_sec, 1),
+        "calibration_per_sec": round(calibration_per_sec, 1),
+        "normalized": round(frames_per_sec / calibration_per_sec, 4),
+        "frames": len(frames),
+        "repetitions": repetitions,
+        "trials": trials,
+    }
+
+
+def compare(frames: list[bytes], repetitions: int, trials: int) -> list[str]:
+    """Time the comparators on the same frames; skip any not installed."""
+    contenders = [
+        ("netprotocols", decode_netprotocols, "walks and materializes"),
+        ("dpkt", decode_dpkt, "builds its object chain eagerly"),
+        ("scapy", decode_scapy, "dissects, then .layers() forces it"),
+    ]
+    lines = ["", "Comparison (same frames, same loop):", ""]
+    results: list[tuple[str, float, int, str]] = []
+    for name, decoder, note in contenders:
+        try:
+            decoded = decoder(frames)
+        except ImportError:
+            lines.append(f"  {name:<14} not installed — skipped")
+            continue
+
+        def one_pass(decoder: Any = decoder) -> None:
+            for _ in range(repetitions):
+                decoder(frames)
+
+        seconds = best_of(one_pass, trials)
+        results.append(
+            (name, (repetitions * len(frames)) / seconds, decoded, note)
+        )
+    if results:
+        ours = next((r[1] for r in results if r[0] == "netprotocols"), None)
+        for name, rate, decoded, note in results:
+            ratio = "" if ours is None else f"  ({rate / ours:.2f}x ours)"
+            lines.append(
+                f"  {name:<14} {rate:>10,.0f} frames/sec{ratio}\n"
+                f"  {'':<14} {decoded}/{len(frames)} frames decoded; {note}"
+            )
+        lines.extend(_comparison_caveats())
+    return lines
+
+
+def _comparison_caveats() -> list[str]:
+    """Read these before quoting the table above anywhere.
+
+    The point of this harness is a comparison someone can trust, and no
+    two of these libraries do quite the same work per frame. Saying so
+    is part of the measurement, not a disclaimer bolted onto it.
+    """
+    return [
+        "",
+        "  Caveats — the libraries are not asked for identical work:",
+        "   - They do not parse to the same depth. On the DNS-over-TCP",
+        "     frames dpkt stops at TCP and leaves the payload as raw",
+        "     bytes, where netprotocols continues into DNSOverTCP and",
+        "     DNS. Where the depths differ, netprotocols is doing more.",
+        "   - netprotocols materializes every header as a frozen",
+        "     dataclass; dpkt builds objects with lazy attributes;",
+        "     scapy is asked for .layers() so its dissection is not",
+        "     deferred past the timed region.",
+        "   - One machine, one corpus, one CPython. Quote the machine",
+        "     with the number, and re-measure before every release.",
+    ]
+
+
+def check(
+    current: dict[str, Any], baseline_path: Path, threshold: float
+) -> int:
+    """Compare a run against a committed baseline; 0 if within bounds."""
+    if not baseline_path.exists():
+        print(f"No baseline at {baseline_path}; run --update-baseline first.")
+        return 1
+    baseline = json.loads(baseline_path.read_text())
+    before = baseline["normalized"]
+    now = current["normalized"]
+    change = (now - before) / before * 100
+    print(
+        f"\nnormalized throughput: {now:.4f} against baseline "
+        f"{before:.4f} ({change:+.1f}%)"
+    )
+    print(f"baseline recorded: {baseline['recorded']['on']}")
+    running = platform.python_version()
+    recorded_on = baseline["recorded"].get("python", running)
+    if recorded_on.rsplit(".", 1)[0] != running.rsplit(".", 1)[0]:
+        print(
+            f"NOTE: this run is CPython {running}, the baseline is "
+            f"{recorded_on}. Normalization cancels machine speed, not the "
+            "interpreter, so the comparison below is indicative only."
+        )
+    if change < -threshold:
+        print(
+            f"REGRESSION: more than {threshold:.0f}% below the baseline.\n"
+            "If this is expected, re-record with --update-baseline and say "
+            "why in the pull request."
+        )
+        return 1
+    print(f"Within the {threshold:.0f}% threshold.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repetitions", type=int, default=40)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument(
+        "--compare", action="store_true", help="also time dpkt and scapy"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="fail on a regression"
+    )
+    parser.add_argument("--update-baseline", action="store_true")
+    parser.add_argument("--threshold", type=float, default=25.0)
+    parser.add_argument("--json", type=Path, help="write the results here")
+    args = parser.parse_args()
+
+    frames = corpus_frames()
+    if not frames:
+        print(f"No fixtures found under {FIXTURES}", file=sys.stderr)
+        return 1
+
+    repetitions, trials = args.repetitions, args.trials
+    if args.check and BASELINE.exists():
+        # Both figures are a best-of, so they tighten as trials rise --
+        # at different rates. A baseline is therefore only comparable to
+        # a run with the same settings, and the baseline's win.
+        recorded = json.loads(BASELINE.read_text())
+        repetitions = recorded.get("repetitions", repetitions)
+        trials = recorded.get("trials", trials)
+        if (repetitions, trials) != (args.repetitions, args.trials):
+            print(
+                f"Measuring with the baseline's settings "
+                f"({repetitions} repetitions, best of {trials})."
+            )
+
+    result = measure(frames, repetitions, trials)
+    result["recorded"] = {
+        "on": f"CPython {platform.python_version()} / {platform.machine()}"
+        f" / {platform.system()}",
+        "python": platform.python_version(),
+        "netprotocols": __import__("netprotocols").__version__,
+    }
+
+    print(
+        f"netprotocols {result['recorded']['netprotocols']} — "
+        f"{result['frames']} corpus frames, "
+        f"{result['repetitions']} repetitions, best of {result['trials']}"
+    )
+    print(f"  {result['frames_per_sec']:>12,.0f} frames/sec")
+    print(f"  {result['normalized']:>12.4f} normalized (machine-independent)")
+    print(f"  on {result['recorded']['on']}")
+
+    if args.compare:
+        print("\n".join(compare(frames, args.repetitions, args.trials)))
+    if args.json:
+        args.json.write_text(json.dumps(result, indent=2) + "\n")
+    if args.update_baseline:
+        BASELINE.parent.mkdir(parents=True, exist_ok=True)
+        BASELINE.write_text(json.dumps(result, indent=2) + "\n")
+        print(f"\nBaseline written to {BASELINE.relative_to(REPOSITORY)}")
+    if args.check:
+        return check(result, BASELINE, args.threshold)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -179,6 +179,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dpkt"
+version = "1.9.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.165.10"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +438,10 @@ version = "1.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
+bench = [
+    { name = "dpkt" },
+    { name = "scapy" },
+]
 dev = [
     { name = "hypothesis" },
     { name = "mypy" },
@@ -440,6 +453,10 @@ dev = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "dpkt", specifier = ">=1.9.8" },
+    { name = "scapy", specifier = ">=2.6" },
+]
 dev = [
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "mypy", specifier = ">=1.14" },
@@ -537,6 +554,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
     { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
     { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "scapy"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/97/7caec64f05eae3d305d83e7cce1ef2f337710513b89efb334f7278202e79/scapy-2.7.0.tar.gz", hash = "sha256:bfc1ef1b93280aea1ddee53be7f74232aa28ac3d891244d41ee85200d24aa446", size = 2412897, upload-time = "2025-12-26T22:10:53.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6f/bd32e5e8adc391063858da17271bb444e4b009842cffa593bca8b2b78af7/scapy-2.7.0-py3-none-any.whl", hash = "sha256:eb22786da92be6fd8e5c694ae5595e4f5b9ac1f4364c9c45986844f3e3063561", size = 2590982, upload-time = "2025-12-26T22:07:48.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes Tier 1. There was no benchmark anywhere in the repo, and the tier is worth ~3× end to end with nothing to stop it silently regressing.

- `scripts/benchmark.py` — walks the 97-frame corpus, reports frames/sec. Frames the library rejects are counted rather than skipped, so a change that "speeds things up" by decoding less shows up.
- `--compare` — times `dpkt` and `scapy` on the same frames. Both live in a new `bench` dependency group, so the package keeps **zero runtime dependencies**.
- `benchmarks/baseline.json` + `--check` — regression comparison, wired into CI.

## One command

```
uv run --group bench python scripts/benchmark.py --compare
```

## Measured (post-Tier-1, CPython 3.12.3, x86-64 Linux, best of 9)

| | frames/sec | vs. us |
|---|---|---|
| **netprotocols** | **121,945** | — |
| dpkt 1.9.8 | 105,292 | 0.86× |
| scapy 2.7.0 | 19,657 | 0.16× |

v1.3.0 measured 2.9× *slower* than dpkt. `docs/CLAIMS.md` claim 1.2 was gated on #82/#83/#84 and is now measured, with caveats attached (below) and the README wording deliberately left to you.

## The CI job is advisory, on purpose

`continue-on-error: true`. Throughput on a shared runner is noisy, and a threshold I picked here without runner data would start failing pull requests that changed nothing — the one failure mode that costs you time rather than me. The job measures, compares and writes a job summary; **setting a real threshold is your call once there are runner numbers to look at.** This PR's own run will produce the first of them.

## Two limits found while building it

Both are handled in code rather than hidden, and are the reason the numbers above are worth anything:

1. **Calibration sizing.** Absolute throughput is a property of the machine, so each run also times a fixed calibration workload and reports a normalized figure — that collapses the gap between two interpreters on one machine from 5.5% to 0.8%. But my first version ran the calibration for barely a millisecond, which timed the scheduler and put **24% of noise straight into the gate**. It now runs a fixed 1000 passes, sized to tens of milliseconds, independent of `--repetitions`.
2. **Normalization does not cancel the interpreter.** The same code and machine normalize to 6.8 on CPython 3.12 and 7.6 on 3.13. A baseline belongs to the Python that recorded it: `--check` re-measures with the baseline's own settings, warns on a version mismatch, and the CI job pins 3.12 to match `baseline.json`.

## Fairness caveats ship with the output

The issue's premise is that every published benchmark in this space is unusable, so the harness prints, under every comparison:

- The libraries are **not asked for identical work** — on the DNS-over-TCP frames dpkt stops at TCP and leaves the payload as raw bytes where netprotocols continues into `DNSOverTCP` → `DNS`. Where the depths differ, we are doing *more*.
- Each materializes a different amount per frame (frozen dataclasses vs. lazy attributes vs. forced `.layers()`).
- One machine, one corpus, one CPython — quote the machine with the number.

## Verification

- [x] `uv run ruff check` / `ruff format --check` / `mypy` clean; `uv run pytest` — 757 passed
- [x] Workflow YAML parses; `benchmark` job present, `continue-on-error: true`, Python pinned to 3.12
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_