### PR TITLE
Make the benchmark gate blocking at 15%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,28 +50,42 @@ jobs:
       - run: uv build
       - run: uv run --isolated --no-project --with dist/*.whl python -c "import netprotocols; print(netprotocols.__version__)"
 
-  # Advisory, deliberately: throughput on a shared runner is noisy, and
-  # a threshold picked without runner data would start failing pull
-  # requests that changed nothing. The job measures, compares against
-  # the committed baseline and reports; `continue-on-error` keeps it
-  # from blocking until a maintainer sets a real threshold (#103).
+  # Blocking, at 15% below the committed baseline. The threshold has
+  # runner data behind it: this job's first run measured 3.7% away from
+  # a baseline recorded on entirely different hardware, and run-to-run
+  # spread on one machine is ~2%. 15% is therefore roughly four times
+  # the noise it has to tolerate, which leaves real regressions (Tier 1
+  # moved this number by 30-90% a step) nowhere to hide.
+  #
+  # A failure re-measures once before failing, because a shared runner
+  # can lose a slice of CPU to a neighbour: a genuine regression fails
+  # both attempts, a noisy one usually does not.
   #
   # Pinned to the baseline's interpreter on purpose: normalization
   # cancels how fast the machine is, not which CPython it runs (see the
-  # module docstring in scripts/benchmark.py).
+  # module docstring in scripts/benchmark.py). If a change is a
+  # deliberate trade, re-record with --update-baseline and say why.
   benchmark:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
-      - name: Corpus decode throughput (advisory)
+      - name: Corpus decode throughput
+        shell: bash
         run: |
+          # Keep the benchmark's own exit status: piping the whole thing
+          # into tee would report tee's, and wrapping it in a { } group
+          # would report the trailing echo's -- either way the gate
+          # would pass while the check failed.
+          status=0
+          uv run --frozen --group bench python scripts/benchmark.py \
+            --check --threshold 15 --compare >benchmark.out 2>&1 || status=$?
           {
             echo '```'
-            uv run --frozen --group bench python scripts/benchmark.py \
-              --check --compare
+            cat benchmark.out
             echo '```'
-          } | tee -a "$GITHUB_STEP_SUMMARY"
+          } >>"$GITHUB_STEP_SUMMARY"
+          cat benchmark.out
+          exit "$status"

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ amass.log
 
 # Application-specific
 .logs/tests/fixtures/staging/
+
+# Written by the benchmark CI step (scripts/benchmark.py output)
+benchmark.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,21 +108,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DNSResourceRecord`. Purely additive — no name changed meaning.
 
 ### Development
-- **A reproducible decode benchmark, and an advisory CI job that runs
-  it.** `scripts/benchmark.py` walks the 97-frame corpus and reports
-  frames/sec; `--compare` times `dpkt` and `scapy` on the same frames
-  (both dev-only extras in a new `bench` dependency group — the package
-  still has zero runtime dependencies). Because absolute throughput is
-  a property of the machine, every run also times a fixed calibration
-  workload and reports a normalized figure, which is what `--check`
-  compares against `benchmarks/baseline.json`. The CI job is
-  deliberately **advisory** (`continue-on-error`): a threshold chosen
-  without runner data would fail unrelated pull requests, so the job
-  measures and reports until a maintainer sets one. Comparison output
-  carries its own caveats — notably that the libraries are not asked
-  for identical work, since dpkt leaves the DNS-over-TCP payload as raw
-  bytes where this library decodes it — because a benchmark nobody can
-  check is the problem #86 set out to fix, not the goal.
+- **A reproducible decode benchmark, and a CI job that fails on a
+  regression.** `scripts/benchmark.py` walks the 97-frame corpus and
+  reports frames/sec; `--compare` times `dpkt` and `scapy` on the same
+  frames (both dev-only extras in a new `bench` dependency group — the
+  package still has zero runtime dependencies). Because absolute
+  throughput is a property of the machine, every run also times a fixed
+  calibration workload and reports a normalized figure, which is what
+  `--check` compares against `benchmarks/baseline.json`. **The CI job
+  blocks at 15% below the baseline**: measured, that is about four
+  times the noise it must tolerate — the job's first run landed 3.7%
+  from a baseline recorded on entirely different hardware, and
+  run-to-run spread on one machine is ~2%, while the Tier 1 changes
+  moved the number by 30-90% each. A failing check re-measures once
+  before failing, so a runner that loses CPU to a neighbour does not
+  block an unrelated pull request. Comparison output carries its own
+  caveats — notably that the libraries are not asked for identical
+  work, since dpkt leaves the DNS-over-TCP payload as raw bytes where
+  this library decodes it — because a benchmark nobody can check is the
+  problem #86 set out to fix, not the goal.
 - `tests/test_version.py` holds `netprotocols.__version__` against the
   version in `pyproject.toml`. The two were kept in step by hand and
   nothing checked them, so a bump that missed one would ship a package

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -309,7 +309,9 @@ def main() -> int:
         "--check", action="store_true", help="fail on a regression"
     )
     parser.add_argument("--update-baseline", action="store_true")
-    parser.add_argument("--threshold", type=float, default=25.0)
+    # CI passes this explicitly so the gate's number is visible in
+    # ci.yml; the default matches it so a local run gates the same.
+    parser.add_argument("--threshold", type=float, default=15.0)
     parser.add_argument("--json", type=Path, help="write the results here")
     args = parser.parse_args()
 
@@ -358,7 +360,17 @@ def main() -> int:
         BASELINE.write_text(json.dumps(result, indent=2) + "\n")
         print(f"\nBaseline written to {BASELINE.relative_to(REPOSITORY)}")
     if args.check:
-        return check(result, BASELINE, args.threshold)
+        status = check(result, BASELINE, args.threshold)
+        if status != 0:
+            print(
+                "\nRe-measuring once before failing: a shared runner can "
+                "lose a slice of CPU to a neighbour mid-run. A real "
+                "regression fails this second attempt too."
+            )
+            second = measure(frames, repetitions, trials)
+            second["recorded"] = result["recorded"]
+            status = check(second, BASELINE, args.threshold)
+        return status
     return 0
 
 


### PR DESCRIPTION
## Summary

#86 landed the harness with the CI job advisory, pending runner data. That data now exists, so the gate goes blocking at **15%**.

## Why 15% holds up

| signal | magnitude |
|---|---|
| cross-machine: first CI run vs. a baseline recorded on my hardware | **3.7%** |
| run-to-run spread on one machine | ~2% |
| each Tier 1 change moved the number by | 30–90% |

15% sits roughly four times above the noise it must tolerate and far below anything worth catching.

## Two bugs that had to be fixed for "blocking" to mean anything

Removing `continue-on-error` would have been cosmetic on its own — the step's exit status was masked **twice**:

1. `… | tee "$GITHUB_STEP_SUMMARY"` reports **tee's** status, not the script's.
2. Wrapping the command in a `{ …; echo; }` group reports the **trailing echo's** status.

Verified against a deliberately doubled baseline: the shape as merged exits **0** on a regression; the new step exits **1**. It now captures the status, writes the summary, echoes to the log, and exits with it.

A failing check also **re-measures once before failing**. A shared runner can lose a slice of CPU to a neighbour mid-run; a genuine regression fails the second attempt too, so this costs one repeat in the rare case and avoids blocking an unrelated PR in the common one.

## Verification

Both directions exercised locally with a temporarily doubled baseline (restored afterwards — `benchmarks/baseline.json` is unchanged in this diff):

- **pass** → exit 0, summary contains `Within the 15% threshold`
- **fail** → exit 1, summary records the regression twice (initial + retry)

The script default now matches the workflow's explicit `--threshold 15`, so a local `--check` gates exactly as CI does while the number stays visible in `ci.yml`.

- [x] `uv run ruff check` / `ruff format --check` / `mypy` clean; `uv run pytest` — 757 passed
- [x] Workflow parses; `benchmark` job has no `continue-on-error`, `shell: bash`, `--threshold 15`
- [x] `CHANGELOG.md` entry updated (the #86 entry described the job as advisory)

## Note

This PR's own `benchmark` job is the first blocking run — if it fails, that is the gate working on real data rather than a problem with the change, and the message says how to re-record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_