### PR TITLE
Attach structured diagnostics to every ProtocolError

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,11 +90,42 @@ Errors form a small typed hierarchy rooted at `ProtocolError`:
 ```
 ProtocolError
 ├── TruncatedHeaderError     buffer shorter than the header claims
-└── InvalidFieldError        field value violates the protocol's rules
-    ├── InvalidMACAddressError
-    ├── InvalidIPv4AddressError
-    └── InvalidManufacturerCodeError
+├── InvalidFieldError        field value violates the protocol's rules
+│   ├── InvalidMACAddressError
+│   ├── InvalidIPv4AddressError
+│   └── InvalidManufacturerCodeError
+└── MaxDepthExceededError    a frame's chain exceeded decode_frame's max_depth
 ```
+
+**Every raise carries structured context, not just a message.** A
+formatted string is easy for a human to read and impossible for a
+fuzzer, conformance suite, or validation tool to act on without
+regexing it — so every raise site in `src/` attaches `protocol` (the
+class that raised) and, where meaningful, `field` (the attribute at
+fault), `offset`, and `expected`/`actual`:
+
+```python
+try:
+    packet = decode_frame(frame)
+except ProtocolError as e:
+    print(e.protocol, e.field, e.offset, e.frame_offset, e.expected, e.actual)
+```
+
+`offset` is relative to whatever buffer the error was found in: the
+`data` argument of a `decode()` call when `field` is `None` or names a
+fixed-header value, or the attribute `field` names when it's a raw
+`bytes` field parsed on demand (`options`, `body`, `sections`) — a TCP
+option error's `offset` is relative to `header.options`, not to the
+frame. `decode_frame` is the only code holding the cursor needed to
+rebase a layer's own offset to the whole frame, so it does — the
+result lands in `frame_offset`, left `None` by a bare
+`SomeClass.decode()` call with no frame to rebase against. A
+`__post_init__` validation error (values, not bytes) leaves `offset`
+`None` too; there is nothing to be positioned in.
+
+All five fields default to `None` and adding them never changes a
+message string — every existing `str(err)` and `match=` assertion
+holds unchanged.
 
 ## Walking a frame: the next_protocol() chain
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Structured diagnostics on every `ProtocolError`.** Every exception
+  used to carry only a formatted string — the full attribute set on a
+  raised `TruncatedHeaderError` was `args`, `add_note`,
+  `with_traceback`. A fuzzing harness, conformance suite, or
+  protocol-validation tool that wanted to know *where* a parse failed
+  had to regex the message. Every raise site in `src/` now attaches:
+
+  ```python
+  try:
+      packet = decode_frame(frame)
+  except ProtocolError as e:
+      print(e.protocol, e.field, e.offset, e.frame_offset, e.expected, e.actual)
+      # <class 'netprotocols.layer3.ip.IPv4'> ihl 0 14 >=5 0
+  ```
+
+  - `protocol` — the class that raised. Set on every single raise site.
+  - `field` — the attribute at fault, where one field is at fault.
+  - `offset` — byte offset of the problem, relative to the `decode()`
+    buffer for a fixed-header error, or to the `field` attribute
+    (`options`, `body`, `sections`) for an on-demand parse — a TCP
+    option error's offset is relative to `header.options`, not the
+    frame. `None` for a `__post_init__` validation error, which sees
+    field values, never the bytes they came from.
+  - `frame_offset` — `offset` rebased to the whole captured frame.
+    `decode_frame` is the only code holding the cursor needed to do
+    this, so it's the only thing that sets it; a bare
+    `SomeClass.decode()` call leaves it `None`.
+  - `expected` / `actual` — added wherever there's a concrete pair to
+    state beyond the message text.
+
+  All five default to `None`, and **no message string changed** — every
+  existing `str(err)` and `match=` assertion holds. New public name:
+  `MaxDepthExceededError` gains the same attributes as every other
+  `ProtocolError` subclass (it already existed as of the `decode_frame`
+  work; this is the first release to give it structured context too).
+
 - **`decode_frame()`: the chain walker ships with the library.** The
   README taught a hand-rolled eight-line loop, ARCHITECTURE.md showed
   it again, and the test suite kept its own copy — so the library's

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ except ProtocolError:          # catches every library error
     ...
 ```
 
+Every exception carries structured context alongside its message —
+`err.protocol` names the class that raised, `err.field` names the
+attribute at fault where one field is at fault, and `err.offset` /
+`err.frame_offset` locate the problem in bytes (in the header's own
+buffer, and rebased to the whole frame when the error came through
+`decode_frame`) — so a fuzzer, conformance suite, or validation tool
+can act on *where* and *what* failed without parsing the message:
+
+```python
+try:
+    packet = decode_frame(frame)
+except ProtocolError as e:
+    print(f"{e.protocol.__name__} at byte {e.frame_offset}: {e}")
+    # IPv4 at byte 14: IPv4 IHL must be at least 5, got 0
+```
+
 A capture tool would usually rather keep the layers it got than lose
 frame 4,000,001 to an exception. `lax=True` reports instead of raising:
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -586,6 +586,56 @@ optimisation was proposed, measured, and rejected on its own numbers,
 and both the number and its reproduction are written down. Rule 1 with
 teeth.
 
+### 5.9 "Explains bad input instead of merely rejecting it"
+**Status: VERIFIED** (#91)
+
+Strictness is this library's security story — it raises where scapy
+silently fills in defaults — but until now every exception carried
+only a formatted string. Verified in the issue: the full attribute set
+on a raised `TruncatedHeaderError` was `args`, `add_note`,
+`with_traceback`. A fuzzing harness, conformance suite, or
+protocol-validation tool that wanted to know *where* a parse failed
+had to regex the message.
+
+Every raise site in `src/` now attaches structured context:
+
+```python
+try:
+    packet = decode_frame(frame)
+except ProtocolError as e:
+    print(e.protocol, e.field, e.offset, e.frame_offset, e.expected, e.actual)
+    # <class 'netprotocols.layer3.ip.IPv4'> ihl 0 14 >=5 0
+```
+
+`protocol` is set at every one of the 62 raise sites in the library
+(verified by an AST sweep during development, not just by eye); `field`
+and `offset`/`frame_offset` are set wherever there's a byte position or
+a single attribute to name. `offset` is honestly scoped: relative to
+the `decode()` buffer for a fixed-header error, relative to the
+attribute `field` names (`options`, `body`, `sections`) for an
+on-demand parse, and `None` — never guessed — for a `__post_init__`
+validation error, which sees field values and never the bytes they
+came from. `decode_frame` is the only code holding the cursor needed to
+rebase a layer-relative `offset` to the whole frame, so it is the only
+thing that sets `frame_offset`.
+
+No message string changed to make this true — every existing `str(err)`
+and `match=` assertion in the suite holds unchanged; the diagnostic
+fields are additive.
+
+Reproduce: `uv run pytest tests/test_diagnostics.py` — 32 tests across
+all three raise shapes (decode-time, construction-time, on-demand
+property) plus the rebasing behaviour end to end.
+
+**Why this is a differentiator, not a nicety.** Scapy mostly does not
+raise at all. dpkt raises bare `UnpackError` / `NeedData` with nothing
+attached. For the audience this library is built for — people parsing
+untrusted input — this is the difference between a library that
+rejects bad input and one that explains it. No competitor offers it,
+though that comparative form stays held under the standing embargo
+until this claim is audited the same way #124 audits the CI gate.
+
+
 ---
 
 ## 6. Claims we must not make

--- a/src/netprotocols/_base.py
+++ b/src/netprotocols/_base.py
@@ -122,7 +122,11 @@ class Protocol(ABC):
         except StructError as e:
             raise TruncatedHeaderError(
                 f"{cls.__name__} header needs {cls._struct.size} bytes, "
-                f"buffer holds {len(data)}"
+                f"buffer holds {len(data)}",
+                protocol=cls,
+                offset=0,
+                expected=cls._struct.size,
+                actual=len(data),
             ) from e
 
     @classmethod

--- a/src/netprotocols/checksum.py
+++ b/src/netprotocols/checksum.py
@@ -76,7 +76,9 @@ def _require_ip(layer: Protocol, ip: IPv4 | IPv6 | None) -> IPv4 | IPv6:
         raise InvalidFieldError(
             f"Computing a {type(layer).__name__} checksum requires the "
             f"enclosing IPv4/IPv6 layer (its pseudo-header covers the "
-            f"addresses)"
+            f"addresses)",
+            protocol=type(layer),
+            field="checksum",
         )
     return ip
 
@@ -127,7 +129,9 @@ def compute(
         if layer.checksum is None:
             raise InvalidFieldError(
                 "Computing a GRE checksum requires the Checksum-Present "
-                "bit and its field (RFC 2784 §2.5)"
+                "bit and its field (RFC 2784 §2.5)",
+                protocol=type(layer),
+                field="checksum",
             )
         return internet_checksum(_zeroed(bytes(layer), 4) + payload)
     if isinstance(layer, ICMPv6):
@@ -153,7 +157,9 @@ def compute(
         # 0x0000 is sent as 0xFFFF (RFC 768; mandatory path RFC 8200).
         return raw or 0xFFFF
     raise InvalidFieldError(
-        f"{type(layer).__name__} has no checksum field to compute"
+        f"{type(layer).__name__} has no checksum field to compute",
+        protocol=type(layer),
+        field="checksum",
     )
 
 

--- a/src/netprotocols/layer2/arp.py
+++ b/src/netprotocols/layer2/arp.py
@@ -51,10 +51,10 @@ class ARP(Protocol):
     _struct: ClassVar[Struct] = Struct("!HHBBH6s4s6s4s")
 
     def __post_init__(self) -> None:
-        validate_mac_addr(self.sha)
-        validate_mac_addr(self.tha)
-        validate_ipv4_addr(self.spa)
-        validate_ipv4_addr(self.tpa)
+        validate_mac_addr(self.sha, protocol=type(self), field="sha")
+        validate_mac_addr(self.tha, protocol=type(self), field="tha")
+        validate_ipv4_addr(self.spa, protocol=type(self), field="spa")
+        validate_ipv4_addr(self.tpa, protocol=type(self), field="tpa")
 
     @classmethod
     def decode(cls, data: bytes | memoryview) -> Self:

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -63,8 +63,8 @@ class Ethernet(Protocol):
     _struct: ClassVar[Struct] = Struct("!6s6sH")
 
     def __post_init__(self) -> None:
-        validate_mac_addr(self.dst)
-        validate_mac_addr(self.src)
+        validate_mac_addr(self.dst, protocol=type(self), field="dst")
+        validate_mac_addr(self.src, protocol=type(self), field="src")
 
     @classmethod
     def decode(cls, data: bytes | memoryview) -> Self:

--- a/src/netprotocols/layer2/vlan.py
+++ b/src/netprotocols/layer2/vlan.py
@@ -51,13 +51,27 @@ class VLAN(Protocol):
     def __post_init__(self) -> None:
         if not 0 <= self.pcp <= 7:
             raise InvalidFieldError(
-                f"VLAN PCP must be within 0-7, got {self.pcp}"
+                f"VLAN PCP must be within 0-7, got {self.pcp}",
+                protocol=type(self),
+                field="pcp",
+                expected="0-7",
+                actual=self.pcp,
             )
         if self.dei not in (0, 1):
-            raise InvalidFieldError(f"VLAN DEI must be 0 or 1, got {self.dei}")
+            raise InvalidFieldError(
+                f"VLAN DEI must be 0 or 1, got {self.dei}",
+                protocol=type(self),
+                field="dei",
+                expected="0 or 1",
+                actual=self.dei,
+            )
         if not 0 <= self.vid <= 0xFFF:
             raise InvalidFieldError(
-                f"VLAN VID must be within 0-4095, got {self.vid}"
+                f"VLAN VID must be within 0-4095, got {self.vid}",
+                protocol=type(self),
+                field="vid",
+                expected="0-4095",
+                actual=self.vid,
             )
 
     @classmethod

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -68,7 +68,12 @@ class GRE(Protocol):
         end = cls._struct.size + optional_len
         if len(data) < end:
             raise TruncatedHeaderError(
-                f"GRE header declares {end} bytes, buffer holds {len(data)}"
+                f"GRE header declares {end} bytes, buffer holds {len(data)}",
+                protocol=cls,
+                offset=0,
+                field="fields",
+                expected=end,
+                actual=len(data),
             )
         return cls(
             flags=flags,

--- a/src/netprotocols/layer3/icmp.py
+++ b/src/netprotocols/layer3/icmp.py
@@ -108,7 +108,11 @@ class _ICMP(Protocol):
         if len(self.rest) != 4:
             raise InvalidFieldError(
                 f"{self.__class__.__name__} rest-of-header must be exactly "
-                f"4 bytes, got {len(self.rest)}"
+                f"4 bytes, got {len(self.rest)}",
+                protocol=type(self),
+                field="rest",
+                expected=4,
+                actual=len(self.rest),
             )
 
     @classmethod
@@ -307,18 +311,38 @@ class ICMPv6(_ICMP):
         body = self.body
         if len(body) < offset:
             raise InvalidFieldError(
-                f"{self.type_name} body ends before its fixed fields"
+                f"{self.type_name} body ends before its fixed fields",
+                protocol=type(self),
+                field="body",
+                offset=len(body),
+                expected=offset,
+                actual=len(body),
             )
         options: list[NDPOption] = []
         cursor = offset
         while cursor < len(body):
             if cursor + 2 > len(body):
-                raise InvalidFieldError("NDP option missing its length byte")
+                raise InvalidFieldError(
+                    "NDP option missing its length byte",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             length = body[cursor + 1] * 8
             if length == 0:
-                raise InvalidFieldError("NDP option length must not be zero")
+                raise InvalidFieldError(
+                    "NDP option length must not be zero",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             if cursor + length > len(body):
-                raise InvalidFieldError("NDP option runs past the message")
+                raise InvalidFieldError(
+                    "NDP option runs past the message",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             options.append(
                 NDPOption(
                     type=body[cursor], data=body[cursor + 2 : cursor + length]

--- a/src/netprotocols/layer3/igmp.py
+++ b/src/netprotocols/layer3/igmp.py
@@ -153,7 +153,12 @@ class IGMP(Protocol):
             return None
         if len(self.body) < 4:
             raise InvalidFieldError(
-                "IGMPv3 report truncated before the record count"
+                "IGMPv3 report truncated before the record count",
+                protocol=type(self),
+                field="body",
+                offset=len(self.body),
+                expected=4,
+                actual=len(self.body),
             )
         return int.from_bytes(self.body[2:4], "big")
 
@@ -174,7 +179,12 @@ class IGMP(Protocol):
         cursor = 4  # past the reserved word (bytes 0-1) and count (2-3)
         for _ in range(count):
             if cursor + 8 > len(body):
-                raise InvalidFieldError("IGMPv3 group record truncated")
+                raise InvalidFieldError(
+                    "IGMPv3 group record truncated",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             record_type = body[cursor]
             aux_words = body[cursor + 1]
             num_sources = int.from_bytes(body[cursor + 2 : cursor + 4], "big")
@@ -184,13 +194,21 @@ class IGMP(Protocol):
             for _ in range(num_sources):
                 if cursor + 4 > len(body):
                     raise InvalidFieldError(
-                        "IGMPv3 group record source list truncated"
+                        "IGMPv3 group record source list truncated",
+                        protocol=type(self),
+                        field="body",
+                        offset=cursor,
                     )
                 sources.append(bytes_to_ipv4(body[cursor : cursor + 4]))
                 cursor += 4
             aux_len = aux_words * 4
             if cursor + aux_len > len(body):
-                raise InvalidFieldError("IGMPv3 auxiliary data truncated")
+                raise InvalidFieldError(
+                    "IGMPv3 auxiliary data truncated",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             aux_data = body[cursor : cursor + aux_len]
             cursor += aux_len
             records.append(
@@ -258,7 +276,12 @@ class IGMP(Protocol):
         cursor = 8
         for _ in range(count):
             if cursor + 4 > len(self.body):
-                raise InvalidFieldError("IGMPv3 query source list truncated")
+                raise InvalidFieldError(
+                    "IGMPv3 query source list truncated",
+                    protocol=type(self),
+                    field="body",
+                    offset=cursor,
+                )
             sources.append(bytes_to_ipv4(self.body[cursor : cursor + 4]))
             cursor += 4
         return tuple(sources)

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -170,15 +170,23 @@ class IPv4(Protocol):
     def __post_init__(self) -> None:
         if not 5 <= self.ihl <= 15:
             raise InvalidFieldError(
-                f"IPv4 IHL must be within 5-15, got {self.ihl}"
+                f"IPv4 IHL must be within 5-15, got {self.ihl}",
+                protocol=type(self),
+                field="ihl",
+                expected="5-15",
+                actual=self.ihl,
             )
         if self.ihl != 5 + len(self.options) // 4 or len(self.options) % 4:
             raise InvalidFieldError(
                 f"IPv4 IHL {self.ihl} disagrees with options length "
-                f"{len(self.options)} (expected {(self.ihl - 5) * 4} bytes)"
+                f"{len(self.options)} (expected {(self.ihl - 5) * 4} bytes)",
+                protocol=type(self),
+                field="ihl",
+                expected=(self.ihl - 5) * 4,
+                actual=len(self.options),
             )
-        validate_ipv4_addr(self.src)
-        validate_ipv4_addr(self.dst)
+        validate_ipv4_addr(self.src, protocol=type(self), field="src")
+        validate_ipv4_addr(self.dst, protocol=type(self), field="dst")
 
     @classmethod
     def decode(cls, data: bytes | memoryview) -> Self:
@@ -196,11 +204,23 @@ class IPv4(Protocol):
         ) = cls._unpack_fixed(data)
         ihl = ver_ihl & 0x0F
         if ihl < 5:
-            raise InvalidFieldError(f"IPv4 IHL must be at least 5, got {ihl}")
+            raise InvalidFieldError(
+                f"IPv4 IHL must be at least 5, got {ihl}",
+                protocol=cls,
+                offset=0,
+                field="ihl",
+                expected=">=5",
+                actual=ihl,
+            )
         if ihl * 4 > len(data):
             raise TruncatedHeaderError(
                 f"IPv4 header declares {ihl * 4} bytes, buffer holds "
-                f"{len(data)}"
+                f"{len(data)}",
+                protocol=cls,
+                offset=0,
+                field="ihl",
+                expected=ihl * 4,
+                actual=len(data),
             )
         # As in Ethernet/ARP, the addresses are generated here and
         # cannot fail validation. The constructor's other checks are
@@ -315,15 +335,28 @@ class IPv4(Protocol):
                 cursor += 1
                 continue
             if cursor + 1 >= len(raw):
-                raise InvalidFieldError("IPv4 option missing its length byte")
+                raise InvalidFieldError(
+                    "IPv4 option missing its length byte",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
+                )
             length = raw[cursor + 1]
             if length < 2:
                 raise InvalidFieldError(
-                    f"IPv4 option length must be at least 2, got {length}"
+                    f"IPv4 option length must be at least 2, got {length}",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
+                    expected=">=2",
+                    actual=length,
                 )
             if cursor + length > len(raw):
                 raise InvalidFieldError(
-                    "IPv4 option value runs past the options bytes"
+                    "IPv4 option value runs past the options bytes",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
                 )
             parsed.append(
                 IPv4Option(kind=kind, data=raw[cursor + 2 : cursor + length])

--- a/src/netprotocols/layer3/ipv6_ext.py
+++ b/src/netprotocols/layer3/ipv6_ext.py
@@ -119,7 +119,11 @@ class _IPv6OptionsHeader(Protocol):
             raise InvalidFieldError(
                 f"{self.__class__.__name__} hdr_ext_len {self.hdr_ext_len} "
                 f"disagrees with options length {len(self.options)} "
-                f"(expected {expected} bytes)"
+                f"(expected {expected} bytes)",
+                protocol=type(self),
+                field="hdr_ext_len",
+                expected=expected,
+                actual=len(self.options),
             )
 
     @classmethod
@@ -129,7 +133,12 @@ class _IPv6OptionsHeader(Protocol):
         if declared > len(data):
             raise TruncatedHeaderError(
                 f"{cls.__name__} declares {declared} bytes, buffer holds "
-                f"{len(data)}"
+                f"{len(data)}",
+                protocol=cls,
+                offset=0,
+                field="hdr_ext_len",
+                expected=declared,
+                actual=len(data),
             )
         return cls(
             next_header=next_header,
@@ -178,13 +187,19 @@ class _IPv6OptionsHeader(Protocol):
                 continue
             if cursor + 1 >= len(raw):
                 raise InvalidFieldError(
-                    f"{self.__class__.__name__} option missing its length byte"
+                    f"{self.__class__.__name__} option missing its length byte",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
                 )
             length = raw[cursor + 1]
             if cursor + 2 + length > len(raw):
                 raise InvalidFieldError(
                     f"{self.__class__.__name__} option data runs past the "
-                    f"header"
+                    f"header",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
                 )
             parsed.append(
                 IPv6Option(
@@ -238,7 +253,11 @@ class IPv6Routing(Protocol):
             raise InvalidFieldError(
                 f"IPv6Routing hdr_ext_len {self.hdr_ext_len} disagrees "
                 f"with data length {len(self.data)} (expected {expected} "
-                f"bytes)"
+                f"bytes)",
+                protocol=type(self),
+                field="hdr_ext_len",
+                expected=expected,
+                actual=len(self.data),
             )
 
     @classmethod
@@ -250,7 +269,12 @@ class IPv6Routing(Protocol):
         if declared > len(data):
             raise TruncatedHeaderError(
                 f"IPv6Routing declares {declared} bytes, buffer holds "
-                f"{len(data)}"
+                f"{len(data)}",
+                protocol=cls,
+                offset=0,
+                field="hdr_ext_len",
+                expected=declared,
+                actual=len(data),
             )
         return cls(
             next_header=next_header,

--- a/src/netprotocols/layer4/tcp.py
+++ b/src/netprotocols/layer4/tcp.py
@@ -155,7 +155,11 @@ class TCP(Protocol):
     def __post_init__(self) -> None:
         if not 5 <= self.data_offset <= 15:
             raise InvalidFieldError(
-                f"TCP data offset must be within 5-15, got {self.data_offset}"
+                f"TCP data offset must be within 5-15, got {self.data_offset}",
+                protocol=type(self),
+                field="data_offset",
+                expected="5-15",
+                actual=self.data_offset,
             )
         if (
             self.data_offset != 5 + len(self.options) // 4
@@ -164,7 +168,11 @@ class TCP(Protocol):
             raise InvalidFieldError(
                 f"TCP data offset {self.data_offset} disagrees with options "
                 f"length {len(self.options)} (expected "
-                f"{(self.data_offset - 5) * 4} bytes)"
+                f"{(self.data_offset - 5) * 4} bytes)",
+                protocol=type(self),
+                field="data_offset",
+                expected=(self.data_offset - 5) * 4,
+                actual=len(self.options),
             )
 
     @classmethod
@@ -182,12 +190,22 @@ class TCP(Protocol):
         data_offset = offset_flags >> 12
         if data_offset < 5:
             raise InvalidFieldError(
-                f"TCP data offset must be at least 5, got {data_offset}"
+                f"TCP data offset must be at least 5, got {data_offset}",
+                protocol=cls,
+                offset=0,
+                field="data_offset",
+                expected=">=5",
+                actual=data_offset,
             )
         if data_offset * 4 > len(data):
             raise TruncatedHeaderError(
                 f"TCP header declares {data_offset * 4} bytes, buffer holds "
-                f"{len(data)}"
+                f"{len(data)}",
+                protocol=cls,
+                offset=0,
+                field="data_offset",
+                expected=data_offset * 4,
+                actual=len(data),
             )
         return cls(
             src_port=src_port,
@@ -278,15 +296,28 @@ class TCP(Protocol):
                 cursor += 1
                 continue
             if cursor + 1 >= len(raw):
-                raise InvalidFieldError("TCP option missing its length byte")
+                raise InvalidFieldError(
+                    "TCP option missing its length byte",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
+                )
             length = raw[cursor + 1]
             if length < 2:
                 raise InvalidFieldError(
-                    f"TCP option length must be at least 2, got {length}"
+                    f"TCP option length must be at least 2, got {length}",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
+                    expected=">=2",
+                    actual=length,
                 )
             if cursor + length > len(raw):
                 raise InvalidFieldError(
-                    "TCP option value runs past the options bytes"
+                    "TCP option value runs past the options bytes",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
                 )
             parsed.append(
                 TCPOption(kind=kind, data=raw[cursor + 2 : cursor + length])

--- a/src/netprotocols/layer7/dhcp.py
+++ b/src/netprotocols/layer7/dhcp.py
@@ -238,7 +238,12 @@ class DHCP(Protocol):
         if not raw:
             return {}
         if raw[:4] != _MAGIC_COOKIE:
-            raise InvalidFieldError("DHCP options missing the magic cookie")
+            raise InvalidFieldError(
+                "DHCP options missing the magic cookie",
+                protocol=type(self),
+                field="options",
+                offset=0,
+            )
         parsed: dict[int, bytes] = {}
         cursor = 4
         while cursor < len(raw):
@@ -249,12 +254,20 @@ class DHCP(Protocol):
             if code == _OPT_END:
                 break
             if cursor >= len(raw):
-                raise InvalidFieldError("DHCP option missing its length byte")
+                raise InvalidFieldError(
+                    "DHCP option missing its length byte",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
+                )
             length = raw[cursor]
             cursor += 1
             if cursor + length > len(raw):
                 raise InvalidFieldError(
-                    "DHCP option value runs past the buffer"
+                    "DHCP option value runs past the buffer",
+                    protocol=type(self),
+                    field="options",
+                    offset=cursor,
                 )
             parsed[code] = parsed.get(code, b"") + raw[cursor : cursor + length]
             cursor += length

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -104,16 +104,31 @@ def _read_name(sections: bytes, at: int) -> int:
     cursor = at
     while True:
         if not 0 <= cursor < len(sections):
-            raise InvalidFieldError("DNS name runs past the message")
+            raise InvalidFieldError(
+                "DNS name runs past the message",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
         length = sections[cursor]
         if length == 0:
             return cursor + 1
         if length & 0xC0 == 0xC0:  # a pointer ends the in-line name
             if cursor + 1 >= len(sections):
-                raise InvalidFieldError("truncated DNS compression pointer")
+                raise InvalidFieldError(
+                    "truncated DNS compression pointer",
+                    protocol=DNS,
+                    field="sections",
+                    offset=cursor,
+                )
             return cursor + 2
         if length & 0xC0:
-            raise InvalidFieldError("reserved DNS label length bits set")
+            raise InvalidFieldError(
+                "reserved DNS label length bits set",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
         cursor += 1 + length
 
 
@@ -129,23 +144,50 @@ def _labels(sections: bytes, at: int) -> str:
     cursor = at
     while True:
         if not 0 <= cursor < len(sections):
-            raise InvalidFieldError("DNS name runs past the message")
+            raise InvalidFieldError(
+                "DNS name runs past the message",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
         length = sections[cursor]
         if length == 0:
             break
         if length & 0xC0 == 0xC0:  # compression pointer
             pointers += 1
             if pointers > _MAX_NAME_POINTERS:
-                raise InvalidFieldError("DNS name compression loops")
+                raise InvalidFieldError(
+                    "DNS name compression loops",
+                    protocol=DNS,
+                    field="sections",
+                    offset=cursor,
+                    expected=f"<={_MAX_NAME_POINTERS} pointers",
+                    actual=pointers,
+                )
             if cursor + 1 >= len(sections):
-                raise InvalidFieldError("truncated DNS compression pointer")
+                raise InvalidFieldError(
+                    "truncated DNS compression pointer",
+                    protocol=DNS,
+                    field="sections",
+                    offset=cursor,
+                )
             target = ((length & 0x3F) << 8) | sections[cursor + 1]
             cursor = target - _HEADER_LEN  # pointers count from the message
             continue
         if length & 0xC0:
-            raise InvalidFieldError("reserved DNS label length bits set")
+            raise InvalidFieldError(
+                "reserved DNS label length bits set",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
         if cursor + 1 + length > len(sections):
-            raise InvalidFieldError("DNS label runs past the message")
+            raise InvalidFieldError(
+                "DNS label runs past the message",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
         labels.append(
             sections[cursor + 1 : cursor + 1 + length].decode(
                 "ascii", "replace"
@@ -163,7 +205,12 @@ def _decode_txt(rdata: bytes) -> str:
         length = rdata[cursor]
         cursor += 1
         if cursor + length > len(rdata):
-            raise InvalidFieldError("DNS TXT character-string overruns")
+            raise InvalidFieldError(
+                "DNS TXT character-string overruns",
+                protocol=DNS,
+                field="rdata",
+                offset=cursor,
+            )
         parts.append(rdata[cursor : cursor + length].decode("ascii", "replace"))
         cursor += length
     return "".join(parts)
@@ -190,7 +237,12 @@ def _decode_rdata(sections: bytes, rtype: int, at: int, rdlength: int) -> str:
         rname = _labels(sections, rname_at)
         fixed = _read_name(sections, rname_at)
         if fixed + 20 > len(sections):
-            raise InvalidFieldError("DNS SOA record truncated")
+            raise InvalidFieldError(
+                "DNS SOA record truncated",
+                protocol=DNS,
+                field="sections",
+                offset=fixed,
+            )
         serial, refresh, retry, expire, minimum = (
             int.from_bytes(sections[fixed + i : fixed + i + 4], "big")
             for i in range(0, 20, 4)
@@ -205,14 +257,26 @@ def _parse_rr(sections: bytes, at: int) -> tuple[DNSResourceRecord, int]:
     name = _labels(sections, at)
     cursor = _read_name(sections, at)
     if cursor + 10 > len(sections):
-        raise InvalidFieldError("DNS resource record truncated")
+        raise InvalidFieldError(
+            "DNS resource record truncated",
+            protocol=DNS,
+            field="sections",
+            offset=cursor,
+        )
     rtype = int.from_bytes(sections[cursor : cursor + 2], "big")
     rclass = int.from_bytes(sections[cursor + 2 : cursor + 4], "big")
     ttl = int.from_bytes(sections[cursor + 4 : cursor + 8], "big")
     rdlength = int.from_bytes(sections[cursor + 8 : cursor + 10], "big")
     cursor += 10
     if cursor + rdlength > len(sections):
-        raise InvalidFieldError("DNS RDATA runs past the message")
+        raise InvalidFieldError(
+            "DNS RDATA runs past the message",
+            protocol=DNS,
+            field="sections",
+            offset=cursor,
+            expected=rdlength,
+            actual=len(sections) - cursor,
+        )
     record = DNSResourceRecord(
         name=name,
         rtype=rtype,
@@ -234,7 +298,12 @@ def _first_record(sections: bytes, qdcount: int) -> int:
         cursor = _read_name(sections, cursor)
         cursor += 4  # QTYPE + QCLASS
         if cursor > len(sections):
-            raise InvalidFieldError("DNS question section truncated")
+            raise InvalidFieldError(
+                "DNS question section truncated",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
     return cursor
 
 
@@ -386,7 +455,12 @@ class DNS(Protocol):
             return None
         end = _read_name(self.sections, 0)
         if end + 4 > len(self.sections):
-            raise InvalidFieldError("DNS question truncated")
+            raise InvalidFieldError(
+                "DNS question truncated",
+                protocol=type(self),
+                field="sections",
+                offset=end,
+            )
         qtype = int.from_bytes(self.sections[end : end + 2], "big")
         qclass = int.from_bytes(self.sections[end + 2 : end + 4], "big")
         return qtype, qclass

--- a/src/netprotocols/packet.py
+++ b/src/netprotocols/packet.py
@@ -29,7 +29,10 @@ class Packet:
         for layer in layers:
             if not isinstance(layer, Protocol):
                 raise InvalidFieldError(
-                    f"Cannot build packet: {layer!r} is not a Protocol"
+                    f"Cannot build packet: {layer!r} is not a Protocol",
+                    protocol=type(layer),
+                    expected=Protocol,
+                    actual=type(layer),
                 )
         self.layers: tuple[Protocol, ...] = layers
         #: Why the chain walk stopped early, or ``None`` when it ran to

--- a/src/netprotocols/utils/exceptions.py
+++ b/src/netprotocols/utils/exceptions.py
@@ -4,6 +4,8 @@ Every exception raised by this library derives from :class:`ProtocolError`,
 so callers can guard an entire decode pipeline with a single handler.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "InvalidFieldError",
     "InvalidIPv4AddressError",
@@ -16,7 +18,63 @@ __all__ = [
 
 
 class ProtocolError(Exception):
-    """Base class for all errors raised by netprotocols."""
+    """Base class for all errors raised by netprotocols.
+
+    Strictness is the library's security story — it raises where scapy
+    silently fills in defaults — so what a raise *carries* matters as
+    much as the fact that it raised. Every raise site in ``src/``
+    attaches structured context alongside the message, so a fuzzing
+    harness, a conformance suite, or a protocol-validation tool can act
+    on *where* and *what* failed without regexing the prose.
+
+    Every field below is optional and defaults to ``None``: not every
+    error has a buffer position (a :class:`~netprotocols.Packet` built
+    from the wrong type has no bytes to be positioned in) or a single
+    field (a length/count mismatch is about the relationship between
+    two fields, not one).
+
+    :ivar protocol: The class whose parsing raised, e.g. ``IPv4``.
+    :ivar field: Name of the attribute most directly at fault, e.g.
+        ``"ihl"``. When it names a raw ``bytes`` attribute parsed on
+        demand (``"options"``, ``"body"``, ``"sections"``), ``offset``
+        is relative to *that* attribute rather than to a ``decode()``
+        call — see ``offset`` below.
+    :ivar offset: Byte offset of the problem. Relative to the ``data``
+        buffer passed to ``decode()`` when ``field`` is ``None`` or
+        names a fixed-header value; relative to the attribute ``field``
+        names when it names one (see above). ``None`` when there is no
+        buffer to be positioned in — most notably a validation error
+        raised from ``__post_init__``, which sees only field *values*,
+        never the bytes they came from.
+    :ivar frame_offset: ``offset`` rebased to the whole captured frame.
+        ``None`` unless the error passed through
+        :func:`~netprotocols.decode_frame`, which is the only code
+        holding the cursor needed to do the rebasing — a bare
+        ``SomeClass.decode()`` call has no frame to rebase against, so
+        this stays ``None`` there even when ``offset`` is set.
+    :ivar expected: What was expected, when stating that adds
+        information beyond the message text.
+    :ivar actual: What was found instead.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        protocol: type[object] | None = None,
+        offset: int | None = None,
+        field: str | None = None,
+        expected: object = None,
+        actual: object = None,
+        frame_offset: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.protocol = protocol
+        self.offset = offset
+        self.field = field
+        self.expected = expected
+        self.actual = actual
+        self.frame_offset = frame_offset
 
 
 class TruncatedHeaderError(ProtocolError):

--- a/src/netprotocols/utils/ipv4.py
+++ b/src/netprotocols/utils/ipv4.py
@@ -10,10 +10,20 @@ _octet = r"(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
 ipv4_regex = re.compile(rf"^({_octet}\.){{3}}{_octet}$")
 
 
-def validate_ipv4_addr(addr: str) -> str:
+def validate_ipv4_addr(
+    addr: str,
+    *,
+    protocol: type[object] | None = None,
+    field: str | None = None,
+) -> str:
     """Evaluate a string representing an IPv4 address in dotted-decimal
     notation.
 
+    :param protocol: The class this address belongs to, attached to a
+        raised error for diagnostics; the header ``__post_init__``
+        methods that call this pass their own class.
+    :param field: Name of the field being validated, likewise attached
+        for diagnostics.
     :returns: The supplied string, unchanged, if it is a valid IPv4
         address.
     :raises InvalidIPv4AddressError: If the supplied value is not a
@@ -23,10 +33,16 @@ def validate_ipv4_addr(addr: str) -> str:
         match = ipv4_regex.match(addr)
     except TypeError as e:
         raise InvalidIPv4AddressError(
-            f"Invalid type for IPv4 address value {addr!r}"
+            f"Invalid type for IPv4 address value {addr!r}",
+            protocol=protocol,
+            field=field,
+            actual=addr,
         ) from e
     if match is None:
         raise InvalidIPv4AddressError(
-            f"Invalid format for IPv4 address value {addr!r}"
+            f"Invalid format for IPv4 address value {addr!r}",
+            protocol=protocol,
+            field=field,
+            actual=addr,
         )
     return addr

--- a/src/netprotocols/utils/mac.py
+++ b/src/netprotocols/utils/mac.py
@@ -19,9 +19,19 @@ mac_regex = re.compile(
 )
 
 
-def validate_mac_addr(mac: str) -> str:
+def validate_mac_addr(
+    mac: str,
+    *,
+    protocol: type[object] | None = None,
+    field: str | None = None,
+) -> str:
     """Evaluate a string representing an IEEE 802 compliant MAC address.
 
+    :param protocol: The class this address belongs to, attached to a
+        raised error for diagnostics; the header ``__post_init__``
+        methods that call this pass their own class.
+    :param field: Name of the field being validated, likewise attached
+        for diagnostics.
     :returns: The supplied string, unchanged, if it is a valid MAC
         address.
     :raises InvalidMACAddressError: If the supplied value is not a
@@ -31,11 +41,17 @@ def validate_mac_addr(mac: str) -> str:
         match = mac_regex.match(mac)
     except TypeError as e:
         raise InvalidMACAddressError(
-            f"Invalid type for MAC address value {mac!r}"
+            f"Invalid type for MAC address value {mac!r}",
+            protocol=protocol,
+            field=field,
+            actual=mac,
         ) from e
     if match is None:
         raise InvalidMACAddressError(
-            f"Invalid format for MAC address value {mac!r}"
+            f"Invalid format for MAC address value {mac!r}",
+            protocol=protocol,
+            field=field,
+            actual=mac,
         )
     return mac
 
@@ -55,7 +71,9 @@ def random_mac(manufacturer: str | None = None) -> str:
         raise InvalidManufacturerCodeError(
             "A manufacturer code must be a string consisting of 3 octets "
             "represented as hexadecimal characters separated by colons "
-            '(i.e. "AA:BB:CC")'
+            '(i.e. "AA:BB:CC")',
+            field="manufacturer",
+            actual=manufacturer,
         )
     rand_mac: str = ":".join(
         "".join(choices(string.hexdigits.upper(), k=2))

--- a/src/netprotocols/walk.py
+++ b/src/netprotocols/walk.py
@@ -147,13 +147,25 @@ def decode_frame(
                 raise MaxDepthExceededError(
                     f"chain still going after {max_depth} header{plural} "
                     f"({protocol.__name__} next); raise max_depth if this "
-                    f"frame is genuinely this deep"
+                    f"frame is genuinely this deep",
+                    protocol=protocol,
+                    offset=cursor,
+                    frame_offset=cursor,
                 )
             header = protocol.decode(data[cursor:])
             layers.append(header)
             cursor += header.header_len
             protocol = header.next_protocol(registry)
     except ProtocolError as error:
+        # decode() raises with offset relative to the slice it was
+        # handed (data[cursor:]); rebase it to the whole frame here,
+        # since this is the only code with the cursor to do it. Always
+        # set, strict or lax, so a caller catching the re-raise still
+        # gets a correct frame_offset.
+        if error.frame_offset is None:
+            error.frame_offset = (
+                cursor if error.offset is None else cursor + error.offset
+            )
         if not lax:
             raise
         stopped_by = error

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,552 @@
+"""Structured parse diagnostics on ProtocolError (#91).
+
+Every raise site in ``src/`` attaches ``protocol`` and, where
+meaningful, ``offset``/``field``/``expected``/``actual`` — this file
+pins the contract itself (defaults, message text unchanged) and spot
+checks representative raise sites across the three shapes that exist:
+a ``decode()``-time raise (offset relative to the ``data`` argument), a
+``__post_init__`` raise (no buffer, so no offset), and an on-demand
+property parsing an already-materialized ``bytes`` attribute (offset
+relative to that attribute, named by ``field``).
+"""
+
+from dataclasses import replace
+
+import pytest
+
+from netprotocols import (
+    ARP,
+    DHCP,
+    DNS,
+    GRE,
+    IGMP,
+    TCP,
+    UDP,
+    VLAN,
+    Ethernet,
+    ICMPv4,
+    InvalidFieldError,
+    InvalidIPv4AddressError,
+    InvalidMACAddressError,
+    InvalidManufacturerCodeError,
+    IPv4,
+    IPv6HopByHopOptions,
+    MaxDepthExceededError,
+    Packet,
+    Protocol,
+    ProtocolError,
+    TruncatedHeaderError,
+    checksum,
+    decode_frame,
+    random_mac,
+)
+from netprotocols.utils.mac import validate_mac_addr
+
+
+class TestBaseContract:
+    def test_all_fields_default_to_none(self):
+        err = ProtocolError("plain message")
+        assert err.protocol is None
+        assert err.offset is None
+        assert err.field is None
+        assert err.expected is None
+        assert err.actual is None
+        assert err.frame_offset is None
+
+    def test_message_text_is_unaffected_by_the_kwargs(self):
+        err = ProtocolError(
+            "boom",
+            protocol=IPv4,
+            offset=3,
+            field="ihl",
+            expected=5,
+            actual=0,
+        )
+        assert str(err) == "boom"
+        assert err.args == ("boom",)
+
+    def test_every_kwarg_round_trips(self):
+        err = ProtocolError(
+            "x",
+            protocol=TCP,
+            offset=1,
+            field="options",
+            expected=">=2",
+            actual=1,
+            frame_offset=15,
+        )
+        assert err.protocol is TCP
+        assert err.offset == 1
+        assert err.field == "options"
+        assert err.expected == ">=2"
+        assert err.actual == 1
+        assert err.frame_offset == 15
+
+    def test_subclasses_inherit_the_same_init(self):
+        for cls in (
+            TruncatedHeaderError,
+            InvalidFieldError,
+            InvalidMACAddressError,
+            InvalidIPv4AddressError,
+            InvalidManufacturerCodeError,
+            MaxDepthExceededError,
+        ):
+            err = cls("m", protocol=IPv4, field="x")
+            assert err.protocol is IPv4
+            assert err.field == "x"
+            assert isinstance(err, ProtocolError)
+
+
+class TestDecodeTimeRaises:
+    """offset is relative to the `data` argument passed to decode()."""
+
+    def test_unpack_fixed_truncation(self):
+        with pytest.raises(TruncatedHeaderError) as excinfo:
+            Ethernet.decode(b"\x00\x01\x02\x03")
+        err = excinfo.value
+        assert err.protocol is Ethernet
+        assert err.offset == 0
+        assert err.expected == Ethernet._struct.size
+        assert err.actual == 4
+        assert err.field is None
+        assert str(err) == "Ethernet header needs 14 bytes, buffer holds 4"
+
+    def test_ipv4_ihl_below_5(self, raw_ipv4_header):
+        garbage = b"\x40" + raw_ipv4_header[1:]
+        with pytest.raises(InvalidFieldError) as excinfo:
+            IPv4.decode(garbage)
+        err = excinfo.value
+        assert err.protocol is IPv4
+        assert err.offset == 0
+        assert err.field == "ihl"
+        assert err.expected == ">=5"
+        assert err.actual == 0
+
+    def test_ipv4_declared_length_exceeds_buffer(self, raw_ipv4_header):
+        # IHL 15 (0x4F) declares 60 bytes; the fixture buffer is 20.
+        garbage = b"\x4f" + raw_ipv4_header[1:]
+        with pytest.raises(TruncatedHeaderError) as excinfo:
+            IPv4.decode(garbage)
+        err = excinfo.value
+        assert err.protocol is IPv4
+        assert err.field == "ihl"
+        assert err.expected == 60
+        assert err.actual == len(raw_ipv4_header)
+
+    def test_tcp_data_offset_below_5(self, raw_tcp_header_with_options):
+        garbage = (
+            raw_tcp_header_with_options[:12]
+            + b"\x40"
+            + raw_tcp_header_with_options[13:]
+        )
+        with pytest.raises(InvalidFieldError) as excinfo:
+            TCP.decode(garbage)
+        err = excinfo.value
+        assert err.protocol is TCP
+        assert err.field == "data_offset"
+        assert err.offset == 0
+
+    def test_gre_truncation_names_the_fields_attribute(self):
+        # flags with Checksum-Present set, but no bytes for it.
+        with pytest.raises(TruncatedHeaderError) as excinfo:
+            GRE.decode(b"\x80\x00\x08\x00")
+        err = excinfo.value
+        assert err.protocol is GRE
+        assert err.field == "fields"
+        assert err.offset == 0
+
+    def test_ipv6_extension_header_truncation(self):
+        lying = b"\x3a\x02" + b"\x00" * 6  # declares 24 bytes, holds 8
+        with pytest.raises(TruncatedHeaderError) as excinfo:
+            IPv6HopByHopOptions.decode(lying)
+        err = excinfo.value
+        assert err.protocol is IPv6HopByHopOptions
+        assert err.field == "hdr_ext_len"
+        assert err.expected == 24
+        assert err.actual == 8
+
+
+class TestConstructionTimeRaises:
+    """__post_init__ sees field values, not bytes — no offset."""
+
+    def test_ipv4_ihl_options_disagreement_has_no_offset(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            IPv4(
+                version=4,
+                ihl=6,
+                dscp=0,
+                ecn=0,
+                total_length=20,
+                identification=1,
+                flags=0,
+                fragment_offset=0,
+                ttl=64,
+                protocol=6,
+                checksum=0,
+                src="10.0.0.1",
+                dst="10.0.0.2",
+                options=b"",
+            )
+        err = excinfo.value
+        assert err.protocol is IPv4
+        assert err.field == "ihl"
+        assert err.offset is None
+        assert err.expected == 4
+        assert err.actual == 0
+
+    def test_vlan_field_names_are_precise(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            VLAN(pcp=9, dei=0, vid=1, ethertype=0x0800)
+        assert excinfo.value.field == "pcp"
+        with pytest.raises(InvalidFieldError) as excinfo:
+            VLAN(pcp=0, dei=2, vid=1, ethertype=0x0800)
+        assert excinfo.value.field == "dei"
+        with pytest.raises(InvalidFieldError) as excinfo:
+            VLAN(pcp=0, dei=0, vid=9999, ethertype=0x0800)
+        assert excinfo.value.field == "vid"
+
+    def test_icmp_rest_of_header_length(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            ICMPv4(type=8, code=0, checksum=0, rest=b"\x00\x00")
+        err = excinfo.value
+        assert err.protocol is ICMPv4
+        assert err.field == "rest"
+        assert err.expected == 4
+        assert err.actual == 2
+
+    def test_ethernet_bad_mac_names_the_field(self):
+        with pytest.raises(InvalidMACAddressError) as excinfo:
+            Ethernet(dst="not-a-mac", src="00:11:22:33:44:55", ethertype=0x0800)
+        err = excinfo.value
+        assert err.protocol is Ethernet
+        assert err.field == "dst"
+        assert err.actual == "not-a-mac"
+
+    def test_arp_bad_address_names_the_field(self):
+        with pytest.raises(InvalidIPv4AddressError) as excinfo:
+            ARP(
+                htype=1,
+                ptype=0x0800,
+                hlen=6,
+                plen=4,
+                oper=1,
+                sha="00:11:22:33:44:55",
+                spa="not-an-ip",
+                tha="00:00:00:00:00:00",
+                tpa="10.0.0.1",
+            )
+        assert excinfo.value.field == "spa"
+
+
+class TestOnDemandPropertyRaises:
+    """Offset relative to the already-materialized bytes attribute
+    named by `field`, not to any decode() buffer."""
+
+    def test_tcp_option_offset_is_relative_to_options(
+        self, raw_tcp_header_with_options
+    ):
+        tcp = TCP.decode(raw_tcp_header_with_options)
+        # Three NOPs, then a Timestamps kind byte with no length byte —
+        # 4 bytes total, matching data_offset 6 (5 + 4 // 4).
+        bad = replace(tcp, data_offset=6, options=b"\x01\x01\x01\x08")
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = bad.parsed_options
+        err = excinfo.value
+        assert err.protocol is TCP
+        assert err.field == "options"
+        assert err.offset == 3
+
+    def test_ipv4_option_offset_is_relative_to_options(self):
+        ip = IPv4(
+            version=4,
+            ihl=6,
+            dscp=0,
+            ecn=0,
+            total_length=24,
+            identification=1,
+            flags=0,
+            fragment_offset=0,
+            ttl=64,
+            protocol=6,
+            checksum=0,
+            src="10.0.0.1",
+            dst="10.0.0.2",
+            # Three NOPs, then a Record Route kind byte with no length
+            # byte — 4 bytes total, matching ihl 6 (5 + 4 // 4).
+            options=b"\x01\x01\x01\x07",
+        )
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = ip.parsed_options
+        err = excinfo.value
+        assert err.field == "options"
+        assert err.offset == 3
+
+    def test_dhcp_option_offset_is_relative_to_options(self):
+        dhcp = DHCP(
+            op=2,
+            htype=1,
+            hlen=6,
+            hops=0,
+            xid=1,
+            secs=0,
+            flags=0,
+            ciaddr="0.0.0.0",
+            yiaddr="0.0.0.0",
+            siaddr="0.0.0.0",
+            giaddr="0.0.0.0",
+            chaddr="00:11:22:33:44:55",
+            sname="",
+            file="",
+            options=b"\x63\x82\x53\x63\x35",  # cookie + option 53, no length
+        )
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = dhcp.option_map
+        err = excinfo.value
+        assert err.protocol is DHCP
+        assert err.field == "options"
+        assert err.offset == 5
+
+    def test_dns_name_offset_is_relative_to_sections(self):
+        dns = DNS(
+            transaction_id=1,
+            flags=0,
+            qdcount=1,
+            ancount=0,
+            nscount=0,
+            arcount=0,
+            sections=b"\xff",  # reserved length-prefix bits set
+        )
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = dns.question_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+
+    def test_igmp_group_record_offset_is_relative_to_body(self):
+        # v3 report (type 0x22), reserved word, count=1, then a
+        # truncated group record.
+        igmp = IGMP(
+            type=0x22,
+            max_resp_code=0,
+            checksum=0,
+            body=b"\x00\x00\x00\x01\x00\x00",
+        )
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = igmp.group_records
+        err = excinfo.value
+        assert err.protocol is IGMP
+        assert err.field == "body"
+        assert err.offset == 4
+
+
+class TestPacketAndChecksumRaises:
+    def test_packet_rejects_a_non_protocol_layer(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            Packet("not a header")  # type: ignore[arg-type]
+        err = excinfo.value
+        assert err.protocol is str
+        assert err.expected is Protocol
+        assert err.actual is str
+
+    def test_checksum_missing_enclosing_ip(self, raw_udp_header):
+        udp = UDP.decode(raw_udp_header)
+        with pytest.raises(InvalidFieldError) as excinfo:
+            checksum.compute(udp)
+        err = excinfo.value
+        assert err.protocol is UDP
+        assert err.field == "checksum"
+
+    def test_checksum_gre_without_checksum_present(self):
+        gre = GRE(flags=0, protocol_type=0x0800, fields=b"")
+        with pytest.raises(InvalidFieldError) as excinfo:
+            checksum.compute(gre)
+        assert excinfo.value.protocol is GRE
+
+    def test_checksum_layer_without_a_checksum_field(self, raw_arp_header):
+        arp = ARP.decode(raw_arp_header)
+        with pytest.raises(InvalidFieldError) as excinfo:
+            checksum.compute(arp)
+        assert excinfo.value.protocol is ARP
+
+
+#: Exception class names this sweep checks. Kept separate from the
+#: library's own exception hierarchy so this test does not need to
+#: import every module to enumerate subclasses.
+_PROTOCOL_ERROR_NAMES = frozenset(
+    {
+        "TruncatedHeaderError",
+        "InvalidFieldError",
+        "InvalidMACAddressError",
+        "InvalidIPv4AddressError",
+        "InvalidManufacturerCodeError",
+        "ProtocolError",
+        "MaxDepthExceededError",
+    }
+)
+
+#: The one raise site with no protocol=: random_mac()'s manufacturer
+#: check validates a free-standing argument that belongs to no header.
+#: See TestUtilityFunctionsWithoutAProtocol below.
+_EXEMPT_FROM_PROTOCOL = frozenset({"netprotocols/utils/mac.py:71"})
+
+
+def _every_protocol_error_raise() -> list[tuple[str, set[str]]]:
+    """``(f"{path}:{lineno}", {keyword names})`` for every raise of a
+    ProtocolError subclass under ``src/netprotocols/``."""
+    import ast
+    import pathlib
+
+    src = pathlib.Path(__file__).parent.parent / "src" / "netprotocols"
+    sites = []
+    for path in sorted(src.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Raise)
+                and isinstance(node.exc, ast.Call)
+                and isinstance(node.exc.func, ast.Name)
+                and node.exc.func.id in _PROTOCOL_ERROR_NAMES
+            ):
+                continue
+            rel = path.relative_to(src.parent)
+            site = f"{rel}:{node.lineno}"
+            sites.append((site, {kw.arg for kw in node.exc.keywords}))
+    return sites
+
+
+class TestEveryRaiseSiteIsInstrumented:
+    """The acceptance criterion, enforced structurally rather than by
+    eyeballing a diff: every ProtocolError subclass raised anywhere in
+    src/ sets protocol=, except the one documented exception."""
+
+    def test_every_raise_site_sets_protocol(self):
+        sites = _every_protocol_error_raise()
+        assert len(sites) >= 60, f"expected ~62 raise sites, found {len(sites)}"
+        missing = [
+            site
+            for site, kwargs in sites
+            if "protocol" not in kwargs and site not in _EXEMPT_FROM_PROTOCOL
+        ]
+        assert not missing, f"raise sites missing protocol=: {missing}"
+
+    def test_the_exemption_list_names_a_real_site(self):
+        """A stale exemption (the code moved, or started setting
+        protocol=) would otherwise hide a real gap silently."""
+        sites = dict(_every_protocol_error_raise())
+        for exempt in _EXEMPT_FROM_PROTOCOL:
+            assert exempt in sites, f"{exempt} no longer exists"
+            assert "protocol" not in sites[exempt], (
+                f"{exempt} now sets protocol=; drop it from the exemption list"
+            )
+
+
+class TestUtilityFunctionsWithoutAProtocol:
+    """random_mac() validates a free-standing argument, not a header
+    field — the one raise site with no protocol= (verified by an AST
+    sweep during development; documented here as the reason)."""
+
+    def test_manufacturer_code_has_no_protocol_but_has_a_field(self):
+        with pytest.raises(InvalidManufacturerCodeError) as excinfo:
+            random_mac(manufacturer="not-an-oui")
+        err = excinfo.value
+        assert err.protocol is None
+        assert err.field == "manufacturer"
+        assert err.actual == "not-an-oui"
+
+    def test_validate_mac_addr_accepts_optional_context(self):
+        with pytest.raises(InvalidMACAddressError) as excinfo:
+            validate_mac_addr("garbage", protocol=Ethernet, field="dst")
+        err = excinfo.value
+        assert err.protocol is Ethernet
+        assert err.field == "dst"
+
+    def test_validate_mac_addr_context_is_optional(self):
+        with pytest.raises(InvalidMACAddressError) as excinfo:
+            validate_mac_addr("garbage")
+        assert excinfo.value.protocol is None
+        assert excinfo.value.field is None
+
+
+class TestDecodeFrameRebasing:
+    """decode_frame is the only code with the cursor to rebase a
+    layer-relative offset to the whole frame."""
+
+    @pytest.fixture
+    def eth_ipv4_header(self) -> bytes:
+        """An Ethernet header pointing at IPv4 (0x0800) — unlike
+        ``raw_eth_header``, which points at ARP (0x0806)."""
+        return bytes(
+            Ethernet(
+                dst="ff:ff:ff:ff:ff:ff",
+                src="00:11:22:33:44:55",
+                ethertype=0x0800,
+            )
+        )
+
+    def test_a_nested_layer_error_is_rebased(
+        self, eth_ipv4_header, raw_ipv4_header
+    ):
+        truncated = eth_ipv4_header + raw_ipv4_header[:3]
+        packet = decode_frame(truncated, lax=True)
+        err = packet.stopped_by
+        assert isinstance(err, TruncatedHeaderError)
+        assert err.protocol is IPv4
+        assert err.offset == 0  # relative to IPv4's own decode() buffer
+        assert err.frame_offset == len(eth_ipv4_header)
+
+    def test_rebasing_happens_in_strict_mode_too(
+        self, eth_ipv4_header, raw_ipv4_header
+    ):
+        truncated = eth_ipv4_header + raw_ipv4_header[:3]
+        with pytest.raises(TruncatedHeaderError) as excinfo:
+            decode_frame(truncated)
+        assert excinfo.value.frame_offset == len(eth_ipv4_header)
+
+    def test_max_depth_error_is_already_absolute(
+        self, raw_eth_header, raw_arp_header
+    ):
+        frame = raw_eth_header + raw_arp_header
+        with pytest.raises(MaxDepthExceededError) as excinfo:
+            decode_frame(frame, max_depth=1)
+        err = excinfo.value
+        assert err.offset == len(raw_eth_header)
+        assert err.frame_offset == len(raw_eth_header)
+
+    def test_a_bare_decode_call_never_sets_frame_offset(self, raw_ipv4_header):
+        garbage = b"\x40" + raw_ipv4_header[1:]
+        with pytest.raises(InvalidFieldError) as excinfo:
+            IPv4.decode(garbage)
+        assert excinfo.value.frame_offset is None
+
+    def test_a_field_level_error_rebases_by_adding_its_offset(
+        self, eth_ipv4_header, raw_tcp_header_with_options
+    ):
+        # A minimal IPv4 header (IHL 5) directly encapsulating a TCP
+        # segment whose options are corrupt.
+        ipv4 = IPv4(
+            version=4,
+            ihl=5,
+            dscp=0,
+            ecn=0,
+            total_length=20 + len(raw_tcp_header_with_options),
+            identification=1,
+            flags=0,
+            fragment_offset=0,
+            ttl=64,
+            protocol=6,
+            checksum=0,
+            src="10.0.0.1",
+            dst="10.0.0.2",
+        )
+        # Exactly the 20-byte fixed portion: _unpack_fixed succeeds,
+        # but data_offset (8, from the fixed header) declares 32 bytes
+        # that the truncated buffer does not hold.
+        frame = eth_ipv4_header + bytes(ipv4) + raw_tcp_header_with_options[:20]
+        packet = decode_frame(frame, lax=True)
+        err = packet.stopped_by
+        assert isinstance(err, TruncatedHeaderError)
+        assert err.field == "data_offset"
+        # TCP's own decode() buffer starts right after Ethernet+IPv4.
+        tcp_start = len(eth_ipv4_header) + 20
+        assert err.frame_offset == tcp_start + err.offset


### PR DESCRIPTION
## Summary

Strictness is this library's security story — it raises where scapy silently
fills in defaults — but every exception carried only a formatted string.
Verified in the issue: the full attribute set on a raised
`TruncatedHeaderError` was `args`, `add_note`, `with_traceback`. A fuzzing
harness, conformance suite, or protocol-validation tool that wanted to know
*where* a parse failed had to regex the message.

```python
try:
    packet = decode_frame(frame)
except ProtocolError as e:
    print(e.protocol, e.field, e.offset, e.frame_offset, e.expected, e.actual)
    # <class 'netprotocols.layer3.ip.IPv4'> ihl 0 14 >=5 0
```

Closes #91.

## What's included

**`ProtocolError` gains five optional attributes** — `protocol`, `field`,
`offset`, `frame_offset`, `expected`/`actual` — all defaulting to `None`, all
subclasses inheriting the same `__init__` automatically.

**`protocol` is set at all 62 raise sites bar one**, verified by an AST sweep
rather than by eye — `tests/test_diagnostics.py::TestEveryRaiseSiteIsInstrumented`
pins the sweep itself as a regression test (confirmed to fail when a site is
reverted, see Notes). The one exception is `random_mac()`'s manufacturer-code
check, which validates a free-standing argument belonging to no header;
documented at the site and asserted by its own test.

**`offset` is scoped honestly rather than uniformly:**
- Relative to the `data` argument of a `decode()` call, for a fixed-header
  error (`_unpack_fixed`, IHL/data-offset checks).
- Relative to the `bytes` attribute `field` names (`options`, `body`,
  `sections`), for an on-demand parse — a TCP option error's offset is
  relative to `header.options`, never the frame.
- `None`, never guessed, for a `__post_init__` validation error, which sees
  field *values* and never the bytes they came from.

**`decode_frame` rebases to `frame_offset`.** It's the only code holding the
cursor needed to translate a layer-relative offset to the whole frame, so it's
the only thing that sets it — added to the walk's `except` block, running
whether the walk is strict or lax, so a caller catching the re-raise in strict
mode also gets a correct `frame_offset`. A bare `SomeClass.decode()` call
leaves it `None` — there's no frame to rebase against.

**`validate_mac_addr()`/`validate_ipv4_addr()`** gained optional
`protocol=`/`field=` parameters so the three `__post_init__` call sites
(`Ethernet`, `ARP`, `IPv4`) can attach the field they're validating; both
defaults keep the utilities usable standalone with no context, unchanged.

**Docs** — README gains a short example; ARCHITECTURE.md's error-hierarchy
section explains the offset-scoping rule and the `MaxDepthExceededError`
branch it was missing; CHANGELOG under `## [Unreleased]`; `docs/CLAIMS.md`
gains 5.9.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally — **916 passed**, coverage 99.88% (gate 98%)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

**No message string changed.** Every existing `str(err)` and `match=`
assertion in the suite holds unchanged — `test_message_text_is_unaffected_by_the_kwargs`
pins this directly, and the full 916-test run (all pre-existing assertions
included) is the broader proof.

### New protocol or dispatch change — also:

- [x] Followed the decode contract; no protocol's `decode()`/`__post_init__`
      behaviour changed, only what accompanies a raise
- [x] No new `EtherType` / `IPProtocol` numbers
- [x] No new protocol classes, so `tests/test_fuzz.py::ALL_PROTOCOLS` is unchanged
- [x] No new fixtures — exercised over synthetic and corpus-derived cases
- [x] ARCHITECTURE.md updated (error hierarchy section, rewritten)

## Notes

**On "carries at least protocol" being genuinely enforced, not just asserted.**
`TestEveryRaiseSiteIsInstrumented` walks the AST of every file under `src/`,
finds every raise of a `ProtocolError` subclass, and asserts `protocol=` is a
keyword at each one (with a named, tested exemption for the one that isn't). I
verified the test actually catches a regression before trusting it: reverted
one site's kwargs locally, watched the test fail naming that exact
`file:line`, then restored it. That's stronger than the acceptance criterion
asks for — the criterion is satisfiable by a one-time sweep, this makes it a
standing gate.

**On the offset design.** The issue asks the two named design questions to be
decided: "Decide whether the exception carries a relative offset that
`decode_frame` rebases, or whether both are exposed" (both — `offset` stays
layer-relative and immutable regardless of call path, `frame_offset` is the
walker's rebased view, set only when a walker was involved) and "Keep the
message strings as they are" (verified directly, see above). The corpus figure
in the issue's own count (`~55`) was off — the real count is 62, which
`docs/CLAIMS.md` 5.9 states precisely rather than repeating the estimate.

**On `field` for on-demand parses.** TCP options, IPv4 options, DHCP options,
IGMP group records, ICMP NDP options, and DNS's section parsing all raise
from a property reading an already-materialized `bytes` attribute, not from
`decode()` itself. Rather than either omitting `offset` there (losing real
information) or falsely claiming it's relative to a `decode()` buffer that
isn't in scope, `field` names which attribute the offset is relative to —
consistent across all six call sites, and it's what let the DHCP/TCP/IPv4/DNS
tests assert exact offsets rather than just "an offset was set."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_