### PR TITLE
Generalize the round-trip property to every protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Development
+- **The round-trip property (`bytes(decode(x)) == x`) is now
+  Hypothesis-generated for all 18 protocols, not 4.** It previously
+  held only for `Ethernet`, `UDP`, `TCP` and `IPv6Fragment`; the other
+  14 rested on a single example each. `tests/strategies.py` adds one
+  reusable strategy per protocol — reusable because a strategy that
+  generates *valid* instances is useful for more than this one
+  property — and `tests/test_fuzz.py::TestGeneralizedRoundTrips`
+  asserts the property in one method, parametrized over all 14.
+
+  The interdependent-field protocols the issue specifically flagged
+  are generated as *consistent* combinations, never independently: IPv4
+  draws `ihl` first and sizes `options` to match; the three IPv6
+  extension headers draw `hdr_ext_len` first and size their TLV bytes
+  to match; GRE draws `flags` first and computes `fields`' length from
+  the same `_optional_len()` the decoder itself uses, so the two can
+  never silently disagree.
+
+  The 14 single-example assertions already living in each protocol's
+  own test file (`test_arp.py::test_round_trip` and so on) are kept as
+  regression anchors — a fixed example pinned to a real captured header
+  catches a specific regression fast and readably, which a generated
+  property does not replace.
+
+  One adjacent gap closed while surveying this: `DHCP` and `GRE` were
+  missing from `test_fuzz.py::ALL_PROTOCOLS` entirely, so neither had
+  ever been fuzzed with untrusted bytes for basic decode safety (`any
+  input either decodes or raises ProtocolError, never anything else`).
+  Both are now included.
+
 ### Added
 - **`match`/`case` dissection is documented.** It already worked on
   every decoded header, with zero code changes needed — a frozen

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -428,15 +428,21 @@ internally (`scripts/check_fixtures.py`).
 
 What is true: Hypothesis fuzzing asserts that decoding never raises
 outside `ProtocolError`, that chain walks terminate, that layers
-recompose, and that five TLV/name accessors never hang.
+recompose, that five TLV/name accessors never hang, and — as of #97 —
+that `bytes(decode(x)) == x` is Hypothesis-generated for **all 18**
+protocols, up from 4. `tests/strategies.py` holds one reusable strategy
+per protocol; `tests/test_fuzz.py::TestGeneralizedRoundTrips`
+parametrizes the property over all 14 that were missing it. Reproduce:
+`uv run pytest tests/test_fuzz.py::TestGeneralizedRoundTrips -v`.
 
-What is **not** yet true: `bytes(decode(x)) == x` is
-Hypothesis-generated for only **4 of 18** protocols (#97), and CI runs
-a fixed 200 examples with `derandomize=True` (#98).
+What is **not** yet true: CI still runs a fixed 200 examples with
+`derandomize=True` (#98) — the same 200 inputs on every build since the
+profile was written, for every property including this one.
 
-Until those land, say "property-based fuzzing of the decode path", not
-"of every protocol", and do not imply the round-trip is universally
-generated. The corpus evidence in 5.1 is strong and honest; lean on it.
+Until #98 lands, say "property-based fuzzing of the decode path,
+including a universally-generated round-trip property", not "fuzzed
+with a fresh seed on every run" — the corpus evidence in 5.1 does not
+have this limitation and is strong on its own.
 
 ### 5.3 "99% test coverage"
 **Status: VERIFIED, GATE PENDING #79**

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,274 @@
+"""Hypothesis strategies that produce valid protocol instances.
+
+One function per protocol, each generating field combinations that
+satisfy that class's own constraints — an interdependent pair like
+IPv4's ``ihl``/``options`` or GRE's ``flags``/``fields`` is generated
+*consistently*, never independently, so every instance a strategy
+produces is one the constructor actually accepts.
+
+Reusable beyond the round-trip property in ``test_fuzz.py``: any test
+that wants "an arbitrary valid `SomeProtocol`" can draw from here
+instead of hand-rolling field values.
+"""
+
+from collections.abc import Mapping
+
+from hypothesis import strategies as st
+
+from netprotocols import (
+    ARP,
+    DHCP,
+    DNS,
+    GRE,
+    IGMP,
+    VLAN,
+    DNSOverTCP,
+    ICMPv4,
+    ICMPv6,
+    IPv4,
+    IPv6,
+    IPv6DestinationOptions,
+    IPv6HopByHopOptions,
+    IPv6Routing,
+    Protocol,
+)
+from netprotocols._base import bytes_to_ipv4, bytes_to_ipv6, bytes_to_mac
+
+
+def mac_strings() -> st.SearchStrategy[str]:
+    """A string every decoded MAC field could hold — generated the same
+    way ``decode()`` generates one, so it is valid by construction."""
+    return st.binary(min_size=6, max_size=6).map(bytes_to_mac)
+
+
+def ipv4_strings() -> st.SearchStrategy[str]:
+    """An IPv4 address string, valid by construction (see
+    :func:`mac_strings`)."""
+    return st.binary(min_size=4, max_size=4).map(bytes_to_ipv4)
+
+
+def ipv6_strings() -> st.SearchStrategy[str]:
+    """An IPv6 address string, valid by construction (see
+    :func:`mac_strings`)."""
+    return st.binary(min_size=16, max_size=16).map(bytes_to_ipv6)
+
+
+#: Cap on the generated length of an options/body TLV blob: large
+#: enough to matter, small enough that a run stays fast. Where a
+#: field's length is dictated by another field (IPv4's ihl, GRE's
+#: flags), that field is bounded instead and this constant is unused.
+_MAX_BLOB = 64
+
+#: Cap on hdr_ext_len for the IPv6 extension headers. The wire field is
+#: a full byte (0-255, up to 2048 bytes of options); bounding it here
+#: keeps generated buffers small without narrowing which *shapes* of
+#: header get exercised.
+_MAX_HDR_EXT_LEN = 20
+
+
+@st.composite
+def arp_headers(draw: st.DrawFn) -> ARP:
+    return ARP(
+        htype=draw(st.integers(0, 0xFFFF)),
+        ptype=draw(st.integers(0, 0xFFFF)),
+        hlen=draw(st.integers(0, 0xFF)),
+        plen=draw(st.integers(0, 0xFF)),
+        oper=draw(st.integers(0, 0xFFFF)),
+        sha=draw(mac_strings()),
+        spa=draw(ipv4_strings()),
+        tha=draw(mac_strings()),
+        tpa=draw(ipv4_strings()),
+    )
+
+
+@st.composite
+def vlan_headers(draw: st.DrawFn) -> VLAN:
+    return VLAN(
+        pcp=draw(st.integers(0, 0b111)),
+        dei=draw(st.integers(0, 1)),
+        vid=draw(st.integers(0, 0xFFF)),
+        ethertype=draw(st.integers(0, 0xFFFF)),
+    )
+
+
+@st.composite
+def ipv4_headers(draw: st.DrawFn) -> IPv4:
+    # ihl and options are the interdependent pair the module docstring
+    # warns about: ihl (4 bits, >= 5) declares the options length in
+    # 4-byte words, so the two are drawn together.
+    ihl = draw(st.integers(5, 15))
+    options_len = (ihl - 5) * 4
+    return IPv4(
+        version=draw(st.integers(0, 0xF)),
+        ihl=ihl,
+        dscp=draw(st.integers(0, 0x3F)),
+        ecn=draw(st.integers(0, 0b11)),
+        total_length=draw(st.integers(0, 0xFFFF)),
+        identification=draw(st.integers(0, 0xFFFF)),
+        flags=draw(st.integers(0, 0b111)),
+        fragment_offset=draw(st.integers(0, 0x1FFF)),
+        ttl=draw(st.integers(0, 0xFF)),
+        protocol=draw(st.integers(0, 0xFF)),
+        checksum=draw(st.integers(0, 0xFFFF)),
+        src=draw(ipv4_strings()),
+        dst=draw(ipv4_strings()),
+        options=draw(st.binary(min_size=options_len, max_size=options_len)),
+    )
+
+
+@st.composite
+def ipv6_headers(draw: st.DrawFn) -> IPv6:
+    return IPv6(
+        version=draw(st.integers(0, 0xF)),
+        traffic_class=draw(st.integers(0, 0xFF)),
+        flow_label=draw(st.integers(0, 0xFFFFF)),
+        payload_length=draw(st.integers(0, 0xFFFF)),
+        next_header=draw(st.integers(0, 0xFF)),
+        hop_limit=draw(st.integers(0, 0xFF)),
+        src=draw(ipv6_strings()),
+        dst=draw(ipv6_strings()),
+    )
+
+
+def _ipv6_options_headers[P: Protocol](cls: type[P]) -> st.SearchStrategy[P]:
+    """Shared strategy for the two TLV-style extension headers
+    (:class:`IPv6HopByHopOptions`, :class:`IPv6DestinationOptions`):
+    ``hdr_ext_len`` and ``options`` are the interdependent pair —
+    ``options`` must be exactly ``6 + hdr_ext_len * 8`` bytes."""
+
+    @st.composite
+    def strategy(draw: st.DrawFn) -> P:
+        hdr_ext_len = draw(st.integers(0, _MAX_HDR_EXT_LEN))
+        options_len = 6 + hdr_ext_len * 8
+        return cls(
+            next_header=draw(st.integers(0, 0xFF)),
+            hdr_ext_len=hdr_ext_len,
+            options=draw(st.binary(min_size=options_len, max_size=options_len)),
+        )
+
+    return strategy()
+
+
+ipv6_hop_by_hop_headers = _ipv6_options_headers(IPv6HopByHopOptions)
+ipv6_destination_options_headers = _ipv6_options_headers(IPv6DestinationOptions)
+
+
+@st.composite
+def ipv6_routing_headers(draw: st.DrawFn) -> IPv6Routing:
+    # hdr_ext_len / data is the same interdependent shape as the TLV
+    # options headers above, with a 4-byte fixed portion instead of 6.
+    hdr_ext_len = draw(st.integers(0, _MAX_HDR_EXT_LEN))
+    data_len = 4 + hdr_ext_len * 8
+    return IPv6Routing(
+        next_header=draw(st.integers(0, 0xFF)),
+        hdr_ext_len=hdr_ext_len,
+        routing_type=draw(st.integers(0, 0xFF)),
+        segments_left=draw(st.integers(0, 0xFF)),
+        data=draw(st.binary(min_size=data_len, max_size=data_len)),
+    )
+
+
+def _icmp_headers[P: Protocol](cls: type[P]) -> st.SearchStrategy[P]:
+    """Shared strategy for :class:`ICMPv4`/:class:`ICMPv6`: both are
+    the same shape (``rest`` fixed at 4 bytes, ``body`` free)."""
+
+    @st.composite
+    def strategy(draw: st.DrawFn) -> P:
+        return cls(
+            type=draw(st.integers(0, 0xFF)),
+            code=draw(st.integers(0, 0xFF)),
+            checksum=draw(st.integers(0, 0xFFFF)),
+            rest=draw(st.binary(min_size=4, max_size=4)),
+            body=draw(st.binary(max_size=_MAX_BLOB)),
+        )
+
+    return strategy()
+
+
+icmpv4_headers = _icmp_headers(ICMPv4)
+icmpv6_headers = _icmp_headers(ICMPv6)
+
+
+@st.composite
+def igmp_headers(draw: st.DrawFn) -> IGMP:
+    return IGMP(
+        type=draw(st.integers(0, 0xFF)),
+        max_resp_code=draw(st.integers(0, 0xFF)),
+        checksum=draw(st.integers(0, 0xFFFF)),
+        body=draw(st.binary(max_size=_MAX_BLOB)),
+    )
+
+
+@st.composite
+def dns_headers(draw: st.DrawFn) -> DNS:
+    return DNS(
+        transaction_id=draw(st.integers(0, 0xFFFF)),
+        flags=draw(st.integers(0, 0xFFFF)),
+        qdcount=draw(st.integers(0, 0xFFFF)),
+        ancount=draw(st.integers(0, 0xFFFF)),
+        nscount=draw(st.integers(0, 0xFFFF)),
+        arcount=draw(st.integers(0, 0xFFFF)),
+        sections=draw(st.binary(max_size=_MAX_BLOB)),
+    )
+
+
+@st.composite
+def dns_over_tcp_headers(draw: st.DrawFn) -> DNSOverTCP:
+    return DNSOverTCP(message_length=draw(st.integers(0, 0xFFFF)))
+
+
+@st.composite
+def dhcp_headers(draw: st.DrawFn) -> DHCP:
+    return DHCP(
+        op=draw(st.integers(0, 0xFF)),
+        htype=draw(st.integers(0, 0xFF)),
+        hlen=draw(st.integers(0, 0xFF)),
+        hops=draw(st.integers(0, 0xFF)),
+        xid=draw(st.integers(0, 0xFFFFFFFF)),
+        secs=draw(st.integers(0, 0xFFFF)),
+        flags=draw(st.integers(0, 0xFFFF)),
+        ciaddr=draw(ipv4_strings()),
+        yiaddr=draw(ipv4_strings()),
+        siaddr=draw(ipv4_strings()),
+        giaddr=draw(ipv4_strings()),
+        chaddr=draw(st.binary(min_size=16, max_size=16)),
+        sname=draw(st.binary(min_size=64, max_size=64)),
+        file=draw(st.binary(min_size=128, max_size=128)),
+        options=draw(st.binary(max_size=_MAX_BLOB)),
+    )
+
+
+@st.composite
+def gre_headers(draw: st.DrawFn) -> GRE:
+    # flags / fields is the module's other interdependent pair: the
+    # flag bits announce exactly which optional fields are present, so
+    # fields' length is computed from flags, never drawn independently.
+    flags = draw(st.integers(0, 0xFFFF))
+    fields_len = GRE._optional_len(flags)
+    return GRE(
+        flags=flags,
+        protocol_type=draw(st.integers(0, 0xFFFF)),
+        fields=draw(st.binary(min_size=fields_len, max_size=fields_len)),
+    )
+
+
+#: One entry per protocol without an existing Hypothesis-generated
+#: round-trip test (see test_fuzz.py::TestConstrainedRoundTrips for
+#: the other four: Ethernet, UDP, TCP, IPv6Fragment). Keyed by class
+#: name for readable parametrize IDs.
+ROUND_TRIP_STRATEGIES: Mapping[str, st.SearchStrategy[Protocol]] = {
+    "ARP": arp_headers(),
+    "VLAN": vlan_headers(),
+    "IPv4": ipv4_headers(),
+    "IPv6": ipv6_headers(),
+    "IPv6HopByHopOptions": ipv6_hop_by_hop_headers,
+    "IPv6DestinationOptions": ipv6_destination_options_headers,
+    "IPv6Routing": ipv6_routing_headers(),
+    "ICMPv4": icmpv4_headers,
+    "ICMPv6": icmpv6_headers,
+    "IGMP": igmp_headers(),
+    "DNS": dns_headers(),
+    "DNSOverTCP": dns_over_tcp_headers(),
+    "DHCP": dhcp_headers(),
+    "GRE": gre_headers(),
+}

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -13,13 +13,16 @@ counterexample; bump ``max_examples`` locally to explore.
 
 import contextlib
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from conftest import corpus_frames
 from netprotocols import (
     ARP,
+    DHCP,
     DNS,
+    GRE,
     IGMP,
     TCP,
     UDP,
@@ -37,6 +40,7 @@ from netprotocols import (
     Packet,
     ProtocolError,
 )
+from strategies import ROUND_TRIP_STRATEGIES
 from test_corpus import walk
 
 settings.register_profile(
@@ -60,6 +64,8 @@ ALL_PROTOCOLS = (
     TCP,
     UDP,
     DNS,
+    DHCP,
+    GRE,
 )
 
 CORPUS_FRAMES = [frame for _, _, frame in corpus_frames()]
@@ -176,6 +182,26 @@ class TestConstrainedRoundTrips:
             identification=identification,
         )
         assert IPv6Fragment.decode(bytes(header)) == header
+
+
+class TestGeneralizedRoundTrips:
+    """``bytes(decode(x)) == x`` for every protocol, not just the four
+    above — one property, parametrized over the strategies in
+    strategies.py (#97). The 14 single-example assertions living in
+    each protocol's own test file (``test_arp.py::test_round_trip`` and
+    similarly for the others) are kept as regression anchors pinned to
+    a real captured header, which this property does not replace: a
+    fixed example catches a specific regression fast and readably, a
+    generated one explores the space the fixed example cannot."""
+
+    @pytest.mark.parametrize("name", sorted(ROUND_TRIP_STRATEGIES))
+    @given(data=st.data())
+    def test_round_trip(self, name: str, data: st.DataObject) -> None:
+        header = data.draw(ROUND_TRIP_STRATEGIES[name])
+        raw = bytes(header)
+        decoded = type(header).decode(raw)
+        assert decoded == header
+        assert bytes(decoded) == raw
 
 
 class TestPacketProperties:


### PR DESCRIPTION
## Summary

`bytes(decode(x)) == x` is the library's core guarantee, and it was proven
unevenly: Hypothesis-generated for **4 of 18** protocols (`Ethernet`, `UDP`,
`TCP`, `IPv6Fragment`), a single hand-picked example for the other 14. No
DHCP, DNS, IPv4-with-options, IPv6Routing, GRE, IGMP, ARP or ICMP round-trip
was ever fuzzed.

Closes #97.

## What's included

**`tests/strategies.py`** — one Hypothesis strategy per missing protocol,
each generating field combinations that satisfy that class's own
constraints. Reusable beyond this one property (acceptance criterion 3:
"Strategies live somewhere reusable, not inline in one test") — a strategy
that produces a valid instance of a protocol is useful for whatever gets
tested against it next.

**`tests/test_fuzz.py::TestGeneralizedRoundTrips`** — the round-trip
asserted in a single method, parametrized over all 14 (acceptance criterion
1: "Every protocol has a Hypothesis-generated round-trip test" — 4 existing
+ 14 new = 18 of 18).

**Interdependent fields generated consistently**, per the issue's explicit
warning:
- IPv4 draws `ihl` first and sizes `options` to match.
- The three IPv6 extension headers draw `hdr_ext_len` first and size their
  TLV bytes to match.
- GRE draws `flags` first and computes `fields`' length from the same
  `_optional_len()` the decoder itself uses, so strategy and decoder can
  never quietly disagree about what a valid instance looks like.

**The 14 single-example assertions are kept as regression anchors**
(acceptance criterion 2, the "kept deliberately" branch) — a fixed example
pinned to a real captured header catches a specific regression fast and
readably, which a generated property doesn't replace; the two are
complementary, not redundant.

**`docs/CLAIMS.md` 5.2** updated: the round-trip half of "property-based
fuzzing of every decoder" is now true (18 of 18), stated precisely instead
of a stale "4 of 18". The remaining caveat — CI runs a fixed 200 examples
with `derandomize=True` — is unchanged and is #98's to close, not this
issue's.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict) — the two shared strategies
      (`IPv6HopByHopOptions`/`IPv6DestinationOptions`, `ICMPv4`/`ICMPv6`)
      use PEP 695 generics (`def f[P: Protocol](cls: type[P])`), which ruff's
      `--fix` converted from an initial `TypeVar` and mypy accepts cleanly
- [x] `uv run pytest` passes locally — **948 passed**, coverage 99.88%
      (gate 98%)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]` (`### Development`,
      matching this project's convention for internal/test-only changes)

Every one of the 14 new strategies was also smoke-tested standalone (100
examples each, independent of the wired-up parametrized test) before being
wired into `test_fuzz.py`, so a failure in the parametrized version could
only be a wiring bug, not a strategy bug — none occurred.

### New protocol or dispatch change — also:

N/A — no protocol, dispatch, or public API change; `src/` is untouched by
this PR (confirmed: `git diff --stat` touches only `tests/`, `CHANGELOG.md`,
`docs/CLAIMS.md`).

## Notes

**One adjacent gap closed while surveying the file.** `DHCP` and `GRE` were
missing from `test_fuzz.py`'s `ALL_PROTOCOLS` entirely, so neither had ever
been fuzzed with untrusted bytes for the basic decode-safety property
(`decode()` either returns or raises `ProtocolError`, never anything else).
Both are now included, and the full derandomized run holds for both. This
is adjacent to, not required by, #97's specific ask — flagging it here
rather than silently bundling it in.

**On why `pytest.mark.parametrize` + `@given(data=st.data())` rather than 14
separate methods.** The issue asks for "a single parametrized property
asserting the round-trip across all of them," which this is: one test
function, parametrized by protocol name, drawing from the matching strategy
via `st.data()`. This is Hypothesis's own supported pattern for combining
`@given` with `pytest.mark.parametrize`. Each parametrized case still gets
its own Hypothesis run (100+ examples, deterministic under the project's
`derandomize=True` profile) and its own pass/fail in the test report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnVMNGwTRDktC4rkABtgt)_