### PR TITLE
ICMP: embedded_chain, and document when lax=True is the right default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both forms, rather than raising or inventing a port-slot convention
   for a message type that has none.
 
+- **`ICMPv4`/`ICMPv6` gain `embedded_chain`: an error message's
+  embedded packet, already decoded.** `decode_frame(lax=True,
+  start=...)` already handled this — an RFC-792 error message quotes
+  only the invoking IP header plus 8 bytes of what follows, never a
+  full TCP/UDP header, so decoding it needs the lax path and no
+  `try`/`except`, verified with zero new code before this landed.
+  `embedded_chain` is the pre-wired convenience next to the existing
+  raw `embedded_packet`, same shape as an accessor-plus-typed-view pair
+  elsewhere in this codebase:
+
+  ```python
+  icmp.embedded_chain
+  # decode_frame(icmp.embedded_packet, lax=True, start=IPv4)
+  # → Packet([IPv4(...)]), stopped_by=TruncatedHeaderError(...)
+  ```
+
+  `None` for the same cases `embedded_packet` degrades to (non-error
+  message types, an empty body); starts at `IPv4` for an `ICMPv4`
+  message, `IPv6` for `ICMPv6`. The README documents the distinction
+  the issue asked for: `embedded_chain`'s `lax=True` is the *right*
+  default here because the truncation is RFC-mandated, expected input
+  — not a license to reach for `lax=True` on a complete frame that
+  fails to decode, which is still a bug to raise on.
+
 ### Fixed
 - **The release workflow can no longer publish untested code.** Pushing
   a `v*` tag ran `uv build` and `uv publish` with no dependency on the

--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ decoded exactly as strictly as before; the walk just declines to throw
 away the part that worked. Chain depth is bounded (`max_depth`,
 default 32), so a crafted frame cannot make the walker grind.
 
+One case where reaching for `lax=True` is the *right* default, not
+just a convenience: an ICMP error message's embedded packet. RFC 792
+only guarantees the invoking IP header plus 8 bytes of what follows —
+never a full TCP/UDP header — so decoding it with the strict path
+raises on ordinary, correctly formed traffic. `ICMPv4`/`ICMPv6` expose
+this pre-wired as `embedded_chain`:
+
+```python
+icmp.embedded_chain  # decode_frame(icmp.embedded_packet, lax=True, start=IPv4)
+                      # → Packet([IPv4(...)]), stopped_by=TruncatedHeaderError(...)
+```
+
+`embedded_packet` stays available for the raw bytes; reach for
+`embedded_chain` when you want them already decoded and are prepared
+to read `stopped_by`. Outside this one RFC-mandated case, a *complete*
+frame that fails to decode is still a bug to raise on — `lax=True`
+elsewhere is a capture tool's choice, not a default.
+
 ## Flow keys
 
 `Packet.flow_key()` (or the free function, `netprotocols.flow_key()`,

--- a/src/netprotocols/layer3/icmp.py
+++ b/src/netprotocols/layer3/icmp.py
@@ -15,6 +15,18 @@ x`` holds by construction: an echo's ``identifier`` /
 message's ``ndp_target_address`` / ``ndp_options`` parse the RFC 4861
 target and option TLVs (a source/target link-layer address reads back
 as a MAC string).
+
+``embedded_chain`` goes one step further than ``embedded_packet`` and
+decodes it, via :func:`~netprotocols.decode_frame` in **lax** mode —
+deliberately, not out of caution: RFC 792 only guarantees the invoking
+IP header plus 8 bytes of what follows, so the embedded transport
+header is routinely truncated, and that is expected input, not
+malformed input. Reach for ``embedded_chain`` when you want the
+decoded headers and are prepared to read ``stopped_by``; reach for
+``embedded_packet`` when you want the raw bytes and will decode them
+yourself. Neither accessor is a reason to default to ``lax=True``
+elsewhere — a *complete* frame that fails to decode is still a bug to
+raise on, not to quietly report.
 """
 
 from __future__ import annotations
@@ -24,7 +36,10 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol, bytes_to_ipv6, bytes_to_mac
+from netprotocols.layer3.ip import IPv4, IPv6
+from netprotocols.packet import Packet
 from netprotocols.utils.exceptions import InvalidFieldError
+from netprotocols.walk import decode_frame
 
 __all__ = ["ICMPv4", "ICMPv6", "NDPOption"]
 
@@ -179,6 +194,31 @@ class _ICMP(Protocol):
         if self.type not in self._error_types or not self.body:
             return None
         return self.body
+
+    @property
+    def embedded_chain(self) -> Packet | None:
+        """:attr:`embedded_packet`, decoded as far as the RFC-792
+        truncation allows — ``None`` for the same cases
+        :attr:`embedded_packet` degrades to (non-error message types,
+        an empty body).
+
+        RFC 792 says an error message quotes only the invoking IP
+        header plus the first 8 bytes of what follows it — not a full
+        TCP/UDP header — so this is a *legitimate* partial decode, not
+        malformed input. It uses :func:`~netprotocols.decode_frame` in
+        lax mode for exactly that reason: no ``try``/``except`` needed,
+        and the walk reports why it stopped on the returned packet's
+        ``stopped_by`` (typically
+        :class:`~netprotocols.TruncatedHeaderError` for the truncated
+        transport header) rather than raising. Starts at
+        :class:`~netprotocols.IPv4` for an :class:`ICMPv4` message,
+        :class:`~netprotocols.IPv6` for :class:`ICMPv6`.
+        """
+        raw = self.embedded_packet
+        if raw is None:
+            return None
+        start = IPv4 if isinstance(self, ICMPv4) else IPv6
+        return decode_frame(raw, lax=True, start=start)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -7,6 +7,7 @@ from netprotocols import (
     IPv4,
     IPv6,
     NDPOption,
+    TruncatedHeaderError,
 )
 
 #: The target of the corpus Neighbor Solicitation/Advertisement pair.
@@ -64,6 +65,29 @@ class TestICMPv4:
         icmp = ICMPv4(type=11, code=0, checksum=0, rest=b"\x00" * 4)
         assert icmp.embedded_packet is None
 
+    def test_embedded_chain_decodes_the_truncated_original(
+        self, raw_ipv4_header
+    ):
+        """RFC 792 quotes only the invoking IP header plus 8 bytes of
+        what follows — never a full TCP header — so this is a routine
+        partial decode, not malformed input: no try/except needed, and
+        the walk reports why it stopped rather than raising."""
+        original = raw_ipv4_header + b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        icmp = ICMPv4.decode(b"\x0b\x00\x00\x00\x00\x00\x00\x00" + original)
+        chain = icmp.embedded_chain
+        assert chain is not None
+        assert len(chain) == 1
+        assert isinstance(chain[0], IPv4)
+        assert chain[0].src == "192.168.1.96"
+        assert isinstance(chain.stopped_by, TruncatedHeaderError)
+
+    def test_echo_types_have_no_embedded_chain(self, raw_icmpv4_echo_request):
+        assert ICMPv4.decode(raw_icmpv4_echo_request).embedded_chain is None
+
+    def test_embedded_chain_with_an_empty_body_degrades_to_none(self):
+        icmp = ICMPv4(type=11, code=0, checksum=0, rest=b"\x00" * 4)
+        assert icmp.embedded_chain is None
+
     def test_unknown_type_name(self):
         icmp = ICMPv4(type=200, code=0, checksum=0, rest=b"\x00" * 4)
         assert icmp.type_name == "Unknown, Unassigned or Deprecated"
@@ -104,6 +128,30 @@ class TestICMPv6:
         assert icmp.identifier is None
         embedded = IPv6.decode(icmp.embedded_packet)
         assert embedded.src == "fe80::1"
+
+    def test_embedded_chain_decodes_the_truncated_original(
+        self, raw_ipv6_header
+    ):
+        """As RFC 792 for ICMPv4 error messages: the invoking header
+        plus a truncated transport header (RFC 4443 uses "as much of
+        the invoking packet as fits" rather than a fixed 8 bytes, but
+        a short quote is equally routine) decodes as far as it can,
+        with no try/except and no raise for the truncation."""
+        original = raw_ipv6_header + b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        icmp = ICMPv6.decode(b"\x03\x00\x00\x00\x00\x00\x00\x00" + original)
+        chain = icmp.embedded_chain
+        assert chain is not None
+        assert len(chain) == 1
+        assert isinstance(chain[0], IPv6)
+        assert chain[0].src == "fe80::1"
+        assert isinstance(chain.stopped_by, TruncatedHeaderError)
+
+    def test_echo_types_have_no_embedded_chain(self, raw_icmpv6_echo_request):
+        assert ICMPv6.decode(raw_icmpv6_echo_request).embedded_chain is None
+
+    def test_embedded_chain_with_an_empty_body_degrades_to_none(self):
+        icmp = ICMPv6(type=1, code=0, checksum=0, rest=b"\x00" * 4)
+        assert icmp.embedded_chain is None
 
     def test_ndp_types_have_no_echo_or_error_fields(self):
         icmp = ICMPv6(


### PR DESCRIPTION
## Summary

Closes #92. `decode_frame(lax=True, start=IPv4)` already solved this issue's core problem with zero new code — verified before writing anything: an RFC-792 ICMP error message quotes only the invoking IP header plus 8 bytes of what follows, never a full TCP/UDP header, so decoding it needs the lax path, not a `try`/`except`. Of the issue's four acceptance criteria, three were already true on master; the fourth — *the distinction is documented, so nobody reaches for `lax` by default* — is the actual work here, plus a small pre-wired convenience accessor.

## What's included

- `ICMPv4`/`ICMPv6` (via the shared `_ICMP` base) gain `embedded_chain`: `decode_frame(icmp.embedded_packet, lax=True, start=IPv4-or-IPv6)`, next to the existing raw `embedded_packet` — same shape as this codebase's other accessor-plus-typed-view pairs. `None` for the same cases `embedded_packet` degrades to (non-error message types, an empty body).
- `icmp.py` now imports `IPv4`/`IPv6` (from `layer3.ip`) and `decode_frame` (from `walk`) at module level. Verified no import cycle before committing to that (rather than deferring, per `with_checksums()`'s pattern): neither `ip.py` nor `walk.py` imports `icmp.py`, directly or transitively — checked via `python -c "import netprotocols"` and two isolated import paths (`from netprotocols.layer3.icmp import ...`, `from netprotocols.layer3 import icmp`).
- The module docstring and a new README section explain the actual distinction: `embedded_chain`'s `lax=True` is the *right* default here only because the truncation is RFC-mandated, expected input — not a general license to reach for `lax=True` on a complete frame that fails to decode, which is still a bug to raise on.
- `tests/test_icmp.py`: `embedded_chain` decodes a truncated embedded packet cleanly with `stopped_by` set (ICMPv4 → `IPv4`, ICMPv6 → `IPv6`); returns `None` for non-error types and an empty body, mirroring `embedded_packet`'s existing tests.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict)
- [x] `uv run --frozen pytest` passes locally
- [x] `uv run --frozen python scripts/benchmark.py --check --threshold 15` — within threshold (+14.0% vs. baseline)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

No new protocol/dispatch change, so that checklist block doesn't apply.

## Notes

Last of the three remaining Tier 2 issues (#90 → #89 → #92, per the roadmap's #107 working agreement). Once this merges, Tier 2 (#104) is fully closed — the version bump to 2.0.0 and CHANGELOG heading change are a release-cut decision left to the repo owner.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVCFe7B1U5VeJRoUbx24vb


---
_Generated by [Claude Code](https://claude.ai/code/session_01SVCFe7B1U5VeJRoUbx24vb)_