### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-09-04
 
 ### Development
 - **The round-trip property (`bytes(decode(x)) == x`) is now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netprotocols"
-version = "1.3.0"
+version = "2.0.0"
 description = "Low-level implementations of common networking protocols"
 readme = "README.md"
 license = "MIT"

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -60,7 +60,7 @@ from netprotocols.walk import MAX_DEPTH, decode_frame
 # registrations name the classes. See netprotocols/_defaults.py.
 _defaults.install(DEFAULT)
 
-__version__ = "1.3.0"
+__version__ = "2.0.0"
 
 __all__ = [
     "ARP",

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "netprotocols"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Cuts 2.0.0 — Tier 2 of the post-1.3.0 roadmap (#107), now that #104 and all six of its sub-issues (#87, #88, #89, #90, #91, #92) are closed. Mirrors the exact shape of the 1.3.0 release commit (`0f86821`): `CHANGELOG.md`'s `## [Unreleased]` heading becomes `## [2.0.0] - 2026-09-04`, `pyproject.toml` and `netprotocols.__version__` bump to `2.0.0`, and `uv.lock` is regenerated to match. No functional changes — those already merged in #130, #131, #132 (and earlier this cycle in #125, #126, #127).

**Why major:** #90 deletes `Packet.payload` outright (it was always exactly `bytes(self)`, a redundant duplicate of `__bytes__`). Everything else in the tier is additive.

## What ships in 2.0.0

- A public protocol registry (#87) — a third party can extend the decode walk without forking.
- `decode_frame()` (#88) — the chain walker ships with the library instead of living in the README and three copy-pasted test files.
- Structured `ProtocolError` diagnostics (#91) — `protocol`, `field`, `offset`, `frame_offset`, `expected`/`actual` on every raise site.
- `Packet` type indexing (`packet[TCP]`), `.get()`, and hashing; `.payload` deleted (#90, breaking).
- Canonical, direction-independent flow keys for TCP/UDP conversations (#89).
- `ICMPv4`/`ICMPv6.embedded_chain` — an error message's truncated embedded packet, decoded with no `try`/`except` (#92).

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict)
- [x] `uv run --frozen pytest` passes locally (includes `test_version.py`'s `__version__`/`pyproject.toml` agreement check)
- [x] `uv run --frozen python scripts/benchmark.py --check --threshold 15` — within threshold (-3.2% vs. baseline)
- [x] `uv build` succeeds and produces `netprotocols-2.0.0`

## Notes

**Merging this does not publish anything by itself.** Per `.github/workflows/release.yml`, only a pushed `v2.0.0` tag on the resulting merge commit triggers CI + `uv publish` to real PyPI (trusted publishing) — that is a separate, deliberate step after this merges, and I'll confirm with you before pushing that tag since a published version can only be yanked, never replaced.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVCFe7B1U5VeJRoUbx24vb


---
_Generated by [Claude Code](https://claude.ai/code/session_01SVCFe7B1U5VeJRoUbx24vb)_