### PR TITLE
Add typed *_enum accessors alongside every enum-backed field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Typed accessors for every enum-backed field.** `_enums.py` defines
+  `EtherType`, `IPProtocol`, `ARPOperation` and `ARPHardwareType`, but
+  until now no decoded field exposed them — only the `*_name` display
+  strings, and the enums themselves were used only for dispatch. Every
+  field with a fixed wire vocabulary now has an `*_enum` companion
+  alongside the existing `int` field and its `*_name` string, mirroring
+  the `src`/`src_address` precedent 1.3.0 established for IP addresses:
+  `Ethernet.ethertype_enum`, `VLAN.ethertype_enum`, `GRE.protocol_enum`,
+  `IPv4.protocol_enum`, `IPv6.next_header_enum` (and the three IPv6
+  extension headers that share the field: `IPv6HopByHopOptions`,
+  `IPv6DestinationOptions`, `IPv6Routing`, `IPv6Fragment`),
+  `ARP.oper_enum`, `ARP.ptype_enum`, `ARP.htype_name`/`ARP.htype_enum`
+  (new — `ARPHardwareType` was exported but referenced nowhere), and
+  `DHCP.htype_name`/`DHCP.htype_enum`. Each returns `None` — never
+  raises — for a wire value this library does not enumerate, so
+  `bytes(decode(x)) == x` is unaffected for unrecognized values; the
+  raw `int` field stays canonical and round-trips regardless (#95).
+
 ## [2.0.0] - 2026-09-04
 
 ### Development

--- a/src/netprotocols/layer2/arp.py
+++ b/src/netprotocols/layer2/arp.py
@@ -14,7 +14,7 @@ from netprotocols._base import (
     ipv4_to_bytes,
     mac_to_bytes,
 )
-from netprotocols._enums import ARPOperation, EtherType
+from netprotocols._enums import ARPHardwareType, ARPOperation, EtherType
 from netprotocols.utils.ipv4 import validate_ipv4_addr
 from netprotocols.utils.mac import validate_mac_addr
 
@@ -26,8 +26,10 @@ class ARP(Protocol):
     """An ARP packet for IPv4-over-Ethernet (the only binding this
     library implements: 6-byte hardware, 4-byte protocol addresses).
 
-    :param htype: Hardware type; ``1`` for Ethernet.
-    :param ptype: Protocol type as an EtherType; ``0x0800`` for IPv4.
+    :param htype: Hardware type; ``1`` for Ethernet (see
+        :class:`~netprotocols.ARPHardwareType`).
+    :param ptype: Protocol type as an EtherType; ``0x0800`` for IPv4
+        (see :class:`~netprotocols.EtherType`).
     :param hlen: Hardware address length in bytes; ``6`` for Ethernet.
     :param plen: Protocol address length in bytes; ``4`` for IPv4.
     :param oper: Operation code; ``1`` request, ``2`` reply (see
@@ -100,6 +102,17 @@ class ARP(Protocol):
             return f"unknown ({self.oper})"
 
     @property
+    def oper_enum(self) -> ARPOperation | None:
+        """The operation code as an :class:`~netprotocols.ARPOperation`,
+        or ``None`` for a value this library does not enumerate;
+        :attr:`oper` stays the canonical ``int`` (see :attr:`oper_name`
+        for the display form)."""
+        try:
+            return ARPOperation(self.oper)
+        except ValueError:
+            return None
+
+    @property
     def ptype_name(self) -> str:
         """Display name of the protocol type, e.g. ``"IPv4"``."""
         try:
@@ -108,9 +121,41 @@ class ARP(Protocol):
             return f"{self.ptype:#06x}"
 
     @property
+    def ptype_enum(self) -> EtherType | None:
+        """The protocol type as an :class:`~netprotocols.EtherType` (see
+        :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
+        value this library does not enumerate."""
+        try:
+            return EtherType(self.ptype)
+        except ValueError:
+            return None
+
+    @property
     def ptype_hex_str(self) -> str:
         """The protocol type as a hexadecimal string, e.g. ``"0x0800"``."""
         return f"{self.ptype:#06x}"
+
+    @property
+    def htype_name(self) -> str:
+        """Display name of the hardware type, e.g. ``"Ethernet"``; falls
+        back to the numeric value for types this library does not
+        name."""
+        try:
+            return ARPHardwareType(self.htype).display_name
+        except ValueError:
+            return f"unknown ({self.htype})"
+
+    @property
+    def htype_enum(self) -> ARPHardwareType | None:
+        """The hardware type as an
+        :class:`~netprotocols.ARPHardwareType`, or ``None`` for a value
+        this library does not enumerate; :attr:`htype` stays the
+        canonical ``int`` (see :attr:`htype_name` for the display
+        form)."""
+        try:
+            return ARPHardwareType(self.htype)
+        except ValueError:
+            return None
 
     @property
     def spa_address(self) -> IPv4Address:

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -95,3 +95,14 @@ class Ethernet(Protocol):
         """Display name of the EtherType, e.g. ``"IPv4"``; falls back to
         the hexadecimal value for types unknown to this library."""
         return _ethertype_name(self.ethertype)
+
+    @property
+    def ethertype_enum(self) -> EtherType | None:
+        """The EtherType as an :class:`~netprotocols.EtherType`, or
+        ``None`` for a value this library does not enumerate;
+        :attr:`ethertype` stays the canonical ``int`` and round-trips
+        regardless (see :attr:`ethertype_name` for the display form)."""
+        try:
+            return EtherType(self.ethertype)
+        except ValueError:
+            return None

--- a/src/netprotocols/layer2/vlan.py
+++ b/src/netprotocols/layer2/vlan.py
@@ -23,6 +23,7 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol
+from netprotocols._enums import EtherType
 from netprotocols.layer2.ethernet import _ethertype_class, _ethertype_name
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import InvalidFieldError
@@ -38,7 +39,8 @@ class VLAN(Protocol):
     :param dei: Drop eligible indicator, ``0`` or ``1``.
     :param vid: VLAN identifier, ``0``-``4095`` (``0`` = priority tag,
         ``0xFFF`` = wildcard).
-    :param ethertype: EtherType of the payload that follows this tag.
+    :param ethertype: EtherType of the payload that follows this tag
+        (see :class:`~netprotocols.EtherType`).
     """
 
     pcp: int
@@ -101,3 +103,14 @@ class VLAN(Protocol):
     def ethertype_name(self) -> str:
         """Display name of the tagged payload's EtherType, e.g. ``"IPv4"``."""
         return _ethertype_name(self.ethertype)
+
+    @property
+    def ethertype_enum(self) -> EtherType | None:
+        """The tagged payload's EtherType as an
+        :class:`~netprotocols.EtherType` (see
+        :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
+        value this library does not enumerate."""
+        try:
+            return EtherType(self.ethertype)
+        except ValueError:
+            return None

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -22,6 +22,7 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol
+from netprotocols._enums import EtherType
 from netprotocols.layer2.ethernet import _ethertype_class, _ethertype_name
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import TruncatedHeaderError
@@ -121,6 +122,16 @@ class GRE(Protocol):
         """Display name of ``protocol_type``, e.g. ``"IPv4"``; falls back
         to the hexadecimal value for EtherTypes unknown to this library."""
         return _ethertype_name(self.protocol_type)
+
+    @property
+    def protocol_enum(self) -> EtherType | None:
+        """``protocol_type`` as an :class:`~netprotocols.EtherType` (see
+        :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
+        value this library does not enumerate."""
+        try:
+            return EtherType(self.protocol_type)
+        except ValueError:
+            return None
 
     @property
     def checksum(self) -> int | None:

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -285,6 +285,18 @@ class IPv4(Protocol):
         return _ip_protocol_name(self.protocol)
 
     @property
+    def protocol_enum(self) -> IPProtocol | None:
+        """The payload protocol as an
+        :class:`~netprotocols.IPProtocol`, or ``None`` for a value this
+        library does not enumerate; :attr:`protocol` stays the
+        canonical ``int`` (see :attr:`protocol_name` for the display
+        form)."""
+        try:
+            return IPProtocol(self.protocol)
+        except ValueError:
+            return None
+
+    @property
     def flags_name(self) -> str:
         """Display name of the fragmentation flags, e.g.
         ``"Don't fragment (DF)"``."""
@@ -434,6 +446,17 @@ class IPv6(Protocol):
     def next_header_name(self) -> str:
         """Display name of the payload protocol, e.g. ``"IPv6-ICMP"``."""
         return _ip_protocol_name(self.next_header)
+
+    @property
+    def next_header_enum(self) -> IPProtocol | None:
+        """The payload protocol as an
+        :class:`~netprotocols.IPProtocol` (see
+        :attr:`IPv4.protocol_enum`); ``None`` for a value this library
+        does not enumerate."""
+        try:
+            return IPProtocol(self.next_header)
+        except ValueError:
+            return None
 
     @property
     def traffic_class_hex_str(self) -> str:

--- a/src/netprotocols/layer3/ipv6_ext.py
+++ b/src/netprotocols/layer3/ipv6_ext.py
@@ -23,6 +23,7 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol
+from netprotocols._enums import IPProtocol
 from netprotocols.layer3.ip import _ip_protocol_class, _ip_protocol_name
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import (
@@ -100,7 +101,8 @@ def _next_header_name(number: int) -> str:
 class _IPv6OptionsHeader(Protocol):
     """Shared shape of the TLV-style extension headers.
 
-    :param next_header: Protocol number of what follows this header.
+    :param next_header: Protocol number of what follows this header
+        (see :class:`~netprotocols.IPProtocol`).
     :param hdr_ext_len: Header length in 8-octet units, excluding the
         first 8 octets; must equal ``(len(options) - 6) // 8``.
     :param options: The header's remaining bytes (TLV-encoded options),
@@ -166,6 +168,17 @@ class _IPv6OptionsHeader(Protocol):
         return _next_header_name(self.next_header)
 
     @property
+    def next_header_enum(self) -> IPProtocol | None:
+        """What follows this header as an
+        :class:`~netprotocols.IPProtocol` (see
+        :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
+        this library does not enumerate."""
+        try:
+            return IPProtocol(self.next_header)
+        except ValueError:
+            return None
+
+    @property
     def parsed_options(self) -> tuple[IPv6Option, ...]:
         """The option TLVs as a tuple of :class:`IPv6Option`, in wire
         order, parsed on demand (RFC 8200 §4.2) — padding included:
@@ -229,7 +242,8 @@ class IPv6DestinationOptions(_IPv6OptionsHeader):
 class IPv6Routing(Protocol):
     """The Routing header (RFC 8200 §4.4), protocol 43.
 
-    :param next_header: Protocol number of what follows this header.
+    :param next_header: Protocol number of what follows this header
+        (see :class:`~netprotocols.IPProtocol`).
     :param hdr_ext_len: Header length in 8-octet units, excluding the
         first 8; must equal ``(len(data) - 4) // 8``.
     :param routing_type: Routing variant (e.g. 2 for Mobile IPv6,
@@ -309,12 +323,24 @@ class IPv6Routing(Protocol):
         """Display name of what follows, e.g. ``"TCP"``."""
         return _next_header_name(self.next_header)
 
+    @property
+    def next_header_enum(self) -> IPProtocol | None:
+        """What follows this header as an
+        :class:`~netprotocols.IPProtocol` (see
+        :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
+        this library does not enumerate."""
+        try:
+            return IPProtocol(self.next_header)
+        except ValueError:
+            return None
+
 
 @dataclass(frozen=True, slots=True)
 class IPv6Fragment(Protocol):
     """The Fragment header (RFC 8200 §4.5), protocol 44 — fixed 8 bytes.
 
-    :param next_header: Protocol number of the *reassembled* payload.
+    :param next_header: Protocol number of the *reassembled* payload
+        (see :class:`~netprotocols.IPProtocol`).
     :param reserved: Reserved byte, carried verbatim.
     :param fragment_offset: Offset of this fragment's data in 8-octet
         units (13 bits).
@@ -370,3 +396,14 @@ class IPv6Fragment(Protocol):
     def next_header_name(self) -> str:
         """Display name of the reassembled payload's protocol."""
         return _next_header_name(self.next_header)
+
+    @property
+    def next_header_enum(self) -> IPProtocol | None:
+        """The reassembled payload's protocol as an
+        :class:`~netprotocols.IPProtocol` (see
+        :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
+        this library does not enumerate."""
+        try:
+            return IPProtocol(self.next_header)
+        except ValueError:
+            return None

--- a/src/netprotocols/layer7/dhcp.py
+++ b/src/netprotocols/layer7/dhcp.py
@@ -26,6 +26,7 @@ from netprotocols._base import (
     bytes_to_mac,
     ipv4_to_bytes,
 )
+from netprotocols._enums import ARPHardwareType
 from netprotocols.utils.exceptions import InvalidFieldError
 
 __all__ = ["DHCP"]
@@ -61,7 +62,9 @@ class DHCP(Protocol):
 
     :param op: Message op code — ``1`` request (client→server), ``2``
         reply (server→client).
-    :param htype: Hardware address type (``1`` = Ethernet).
+    :param htype: Hardware address type (``1`` = Ethernet; see
+        :class:`~netprotocols.ARPHardwareType` — the same registry
+        :class:`~netprotocols.ARP` uses).
     :param hlen: Hardware address length (``6`` for Ethernet).
     :param hops: Relay hop count.
     :param xid: Transaction identifier correlating a request and reply.
@@ -167,6 +170,28 @@ class DHCP(Protocol):
     def op_name(self) -> str:
         """Display name of the op code, e.g. ``"BOOTREQUEST"``."""
         return _OP_NAMES.get(self.op, f"unknown ({self.op:#04x})")
+
+    @property
+    def htype_name(self) -> str:
+        """Display name of the hardware type, e.g. ``"Ethernet"``; falls
+        back to the numeric value for types this library does not
+        name."""
+        try:
+            return ARPHardwareType(self.htype).display_name
+        except ValueError:
+            return f"unknown ({self.htype})"
+
+    @property
+    def htype_enum(self) -> ARPHardwareType | None:
+        """The hardware type as an
+        :class:`~netprotocols.ARPHardwareType`, or ``None`` for a value
+        this library does not enumerate; :attr:`htype` stays the
+        canonical ``int`` (see :attr:`htype_name` for the display
+        form)."""
+        try:
+            return ARPHardwareType(self.htype)
+        except ValueError:
+            return None
 
     @property
     def is_broadcast(self) -> bool:

--- a/tests/test_arp.py
+++ b/tests/test_arp.py
@@ -2,7 +2,13 @@ from ipaddress import IPv4Address, ip_network
 
 import pytest
 
-from netprotocols import ARP, InvalidIPv4AddressError
+from netprotocols import (
+    ARP,
+    ARPHardwareType,
+    ARPOperation,
+    EtherType,
+    InvalidIPv4AddressError,
+)
 
 
 @pytest.fixture
@@ -33,8 +39,12 @@ class TestARP:
         assert arp.tha == "00:00:00:00:00:00"
         assert arp.tpa == "24.166.173.159"
         assert arp.oper_name == "request"
+        assert arp.oper_enum == ARPOperation.REQUEST
         assert arp.ptype_name == "IPv4"
+        assert arp.ptype_enum == EtherType.IPV4
         assert arp.ptype_hex_str == "0x0800"
+        assert arp.htype_name == "Ethernet"
+        assert arp.htype_enum == ARPHardwareType.ETHERNET
         assert arp.header_len == 28
 
     def test_round_trip(self, raw_arp_header):
@@ -52,9 +62,13 @@ class TestARP:
     def test_unknown_display_values_degrade(self, arp_reply):
         from dataclasses import replace
 
-        odd = replace(arp_reply, oper=9, ptype=0x1234)
+        odd = replace(arp_reply, oper=9, ptype=0x1234, htype=99)
         assert odd.oper_name == "unknown (9)"
+        assert odd.oper_enum is None
         assert odd.ptype_name == "0x1234"
+        assert odd.ptype_enum is None
+        assert odd.htype_name == "unknown (99)"
+        assert odd.htype_enum is None
 
     def test_build(self, arp_reply):
         assert arp_reply.oper_name == "reply"

--- a/tests/test_dhcp.py
+++ b/tests/test_dhcp.py
@@ -10,6 +10,7 @@ from conftest import FIXTURES, read_pcap
 from netprotocols import (
     DHCP,
     UDP,
+    ARPHardwareType,
     Ethernet,
     InvalidFieldError,
     IPv4,
@@ -73,6 +74,8 @@ class TestDHCPFields:
         assert dhcp.op == 2
         assert dhcp.op_name == "BOOTREPLY"
         assert dhcp.htype == 1
+        assert dhcp.htype_name == "Ethernet"
+        assert dhcp.htype_enum == ARPHardwareType.ETHERNET
         assert dhcp.hlen == 6
         assert dhcp.xid == 0x3903F326
         assert dhcp.yiaddr == "192.168.1.100"
@@ -89,6 +92,13 @@ class TestDHCPFields:
     def test_unknown_op_degrades(self):
         dhcp = DHCP.decode(build_dhcp(op=7))
         assert dhcp.op_name == "unknown (0x07)"
+
+    def test_unknown_htype_degrades(self):
+        raw = bytearray(build_dhcp())
+        raw[1] = 99  # htype = 99 (not a hardware type this library names)
+        dhcp = DHCP.decode(bytes(raw))
+        assert dhcp.htype_name == "unknown (99)"
+        assert dhcp.htype_enum is None
 
     def test_address_objects(self):
         dhcp = DHCP.decode(

--- a/tests/test_ethernet.py
+++ b/tests/test_ethernet.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netprotocols import ARP, Ethernet, InvalidMACAddressError
+from netprotocols import ARP, Ethernet, EtherType, InvalidMACAddressError
 
 
 class TestEthernet:
@@ -10,6 +10,7 @@ class TestEthernet:
         assert eth.src == "00:07:0d:af:f4:54"
         assert eth.ethertype == 0x0806
         assert eth.ethertype_name == "ARP"
+        assert eth.ethertype_enum == EtherType.ARP
         assert eth.header_len == 14
 
     def test_round_trip(self, raw_eth_header):
@@ -34,6 +35,7 @@ class TestEthernet:
         )
         assert eth.next_protocol() is None
         assert eth.ethertype_name == "0x88cc"
+        assert eth.ethertype_enum is None
 
     def test_invalid_mac_rejected(self):
         with pytest.raises(InvalidMACAddressError):

--- a/tests/test_gre.py
+++ b/tests/test_gre.py
@@ -9,6 +9,7 @@ from conftest import FIXTURES, read_pcap
 from netprotocols import (
     GRE,
     Ethernet,
+    EtherType,
     ICMPv4,
     IPProtocol,
     IPv4,
@@ -66,6 +67,7 @@ class TestGREFields:
         assert gre.header_len == 4
         assert gre.protocol_type == 0x0800
         assert gre.protocol_name == "IPv4"
+        assert gre.protocol_enum == EtherType.IPV4
         assert gre.version == 0
         assert gre.checksum_present == 0
         assert gre.key_present == 0
@@ -117,9 +119,9 @@ class TestGREFields:
 
     def test_unknown_protocol_type_name(self):
         # Transparent Ethernet Bridging (0x6558) is not decoded here.
-        assert GRE.decode(build_gre(protocol_type=0x6558)).protocol_name == (
-            "0x6558"
-        )
+        gre = GRE.decode(build_gre(protocol_type=0x6558))
+        assert gre.protocol_name == "0x6558"
+        assert gre.protocol_enum is None
 
 
 class TestGREChain:

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -2,7 +2,14 @@ from ipaddress import IPv4Address, IPv6Address, ip_network
 
 import pytest
 
-from netprotocols import TCP, InvalidFieldError, IPv4, IPv4Option, IPv6
+from netprotocols import (
+    TCP,
+    InvalidFieldError,
+    IPProtocol,
+    IPv4,
+    IPv4Option,
+    IPv6,
+)
 
 
 def ipv4_with_options(options: bytes) -> IPv4:
@@ -42,6 +49,7 @@ class TestIPv4:
         assert ip.ttl == 64
         assert ip.protocol == 6
         assert ip.protocol_name == "TCP"
+        assert ip.protocol_enum == IPProtocol.TCP
         assert ip.checksum == 0x2B51
         assert ip.checksum_hex_str == "0x2b51"
         assert ip.src == "192.168.1.96"
@@ -61,7 +69,9 @@ class TestIPv4:
         unknown = (
             b"\x45" + raw_ipv4_header[1:9] + b"\xfd" + raw_ipv4_header[10:]
         )
-        assert IPv4.decode(unknown).protocol_name == "unknown (253)"
+        decoded = IPv4.decode(unknown)
+        assert decoded.protocol_name == "unknown (253)"
+        assert decoded.protocol_enum is None
 
     def test_ihl_out_of_range_rejected(self, raw_ipv4_header):
         from dataclasses import replace
@@ -122,6 +132,7 @@ class TestIPv6:
         assert ip.payload_length == 120
         assert ip.next_header == 6
         assert ip.next_header_name == "TCP"
+        assert ip.next_header_enum == IPProtocol.TCP
         assert ip.hop_limit == 255
         assert ip.src == "fe80::1"
         assert ip.dst == "ff02::1"
@@ -148,6 +159,12 @@ class TestIPv6:
         ip = IPv6.decode(raw_ipv6_header)
         assert ip.traffic_class_hex_str == "0x00"
         assert ip.flow_label_hex_str == "0x00000"
+
+    def test_unknown_next_header_enum_is_none(self, raw_ipv6_header):
+        unknown = raw_ipv6_header[:6] + b"\xfd" + raw_ipv6_header[7:]
+        decoded = IPv6.decode(unknown)
+        assert decoded.next_header_name == "unknown (253)"
+        assert decoded.next_header_enum is None
 
 
 class TestIPv4Options:

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -46,6 +46,7 @@ class TestMLDBehindHopByHop:
         assert hbh.header_len == 8
         assert hbh.next_header == IPProtocol.IPV6_ICMP
         assert hbh.next_header_name == "IPv6-ICMP"
+        assert hbh.next_header_enum == IPProtocol.IPV6_ICMP
         # Router Alert option (type 5, length 2, value 0 = MLD).
         assert hbh.options[:4] == b"\x05\x02\x00\x00"
 
@@ -117,6 +118,7 @@ class TestDecodeContract:
         assert routing.header_len == 8
         assert routing.next_protocol() is ICMPv6
         assert routing.next_header_name == "IPv6-ICMP"
+        assert routing.next_header_enum == IPProtocol.IPV6_ICMP
 
     def test_fragment_round_trip_preserves_reserved_bits(self):
         raw = b"\x3a\xa5\x01\x5b\xde\xad\xbe\xef"
@@ -127,6 +129,19 @@ class TestDecodeContract:
         assert fragment.m_flag == 1
         assert bytes(fragment) == raw
         assert fragment.next_header_name == "IPv6-ICMP"
+        assert fragment.next_header_enum == IPProtocol.IPV6_ICMP
+
+    def test_unknown_next_header_enum_is_none(self):
+        # 253/254 are reserved for experimentation (RFC 3692) and named
+        # by no IPProtocol member this library enumerates.
+        for cls in (IPv6HopByHopOptions, IPv6DestinationOptions):
+            header = cls.decode(b"\xfd\x00\x05\x02\x00\x00\x01\x00")
+            assert header.next_header_name == "unknown (253)"
+            assert header.next_header_enum is None
+        routing = IPv6Routing.decode(b"\xfd\x00\x03\x01" + b"\x00" * 4)
+        assert routing.next_header_enum is None
+        fragment = IPv6Fragment.decode(b"\xfd\xa5\x01\x5b\xde\xad\xbe\xef")
+        assert fragment.next_header_enum is None
 
     def test_trailing_bytes_tolerated(self):
         header = IPv6HopByHopOptions.decode(self.RAW_HBH + b"payload")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -8,6 +8,7 @@ import pytest
 from netprotocols import (
     VLAN,
     Ethernet,
+    EtherType,
     InvalidFieldError,
     IPv4,
     Protocol,
@@ -34,6 +35,7 @@ class TestVLANFields:
         assert tag.vid == 42
         assert tag.ethertype == 0x0800
         assert tag.ethertype_name == "IPv4"
+        assert tag.ethertype_enum == EtherType.IPV4
         assert tag.header_len == 4
 
     def test_roundtrip(self) -> None:
@@ -43,6 +45,7 @@ class TestVLANFields:
     def test_unknown_ethertype_name_falls_back(self) -> None:
         tag = VLAN(pcp=0, dei=0, vid=0, ethertype=0xCAFE)
         assert tag.ethertype_name == "0xcafe"
+        assert tag.ethertype_enum is None
 
     def test_tci_packs_the_bitfields(self) -> None:
         assert VLAN(pcp=7, dei=1, vid=42, ethertype=0).tci == 0xE02A + 0x1000


### PR DESCRIPTION
## Summary

`_enums.py` defines `EtherType`, `IPProtocol`, `ARPOperation` and `ARPHardwareType`, but until now no decoded field exposed them as a typed value — only the `*_name` display strings, with the enums themselves used only for internal dispatch. `reveal_type(Ethernet.decode(b"...").ethertype)` was `int`.

1.3.0 established the right pattern for this with addresses: `IPv4.src` stays a `str` and `IPv4.src_address` returns an `ipaddress.IPv4Address`. This does the same for the enum registries: the wire field stays a plain `int` (so `bytes(decode(x)) == x` holds for values this library does not enumerate), and a new `*_enum` property returns the typed enum member or `None` — never raises — for a value it doesn't recognize.

## What's included

- `Ethernet.ethertype_enum`, `VLAN.ethertype_enum`, `GRE.protocol_enum` → `EtherType | None`
- `IPv4.protocol_enum`, `IPv6.next_header_enum` (and the three IPv6 extension headers that share the field: `IPv6HopByHopOptions`, `IPv6DestinationOptions`, `IPv6Routing`, `IPv6Fragment`) → `IPProtocol | None`
- `ARP.oper_enum` → `ARPOperation | None`, `ARP.ptype_enum` → `EtherType | None`
- `ARP.htype_name` / `ARP.htype_enum` and `DHCP.htype_name` / `DHCP.htype_enum` → `ARPHardwareType | None` (new — `ARPHardwareType` was exported but referenced nowhere in `src/` before this)
- Docstring cross-references (`:param: ... (see :class:...)`) added wherever a field gained an enum accessor but didn't already point at its enum class
- Test coverage for the known-value and unknown-value (`None`-degrades) case of every new accessor
- `CHANGELOG.md` entry under a new `## [Unreleased]` section (this repo's changelog had none yet since 2.0.0 shipped)

Scope note: issue #95's text names six accessors explicitly (`ethertype_enum`, `protocol_enum`, `next_header_enum`, `oper_enum`, `htype_name`/`htype_enum` on `ARP`). This PR also adds `VLAN.ethertype_enum`, `GRE.protocol_enum`, the three extra IPv6 extension-header `next_header_enum`s, `ARP.ptype_enum`, and `DHCP.htype_name`/`htype_enum` — every other field in the codebase that maps onto the exact same four enum registries the issue targets, for consistency rather than leaving an identical gap one field over.

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict, `src/` only — 30 source files)
- [x] `uv run --frozen pytest` passes locally (582 tests)
- [x] `uv run --frozen python scripts/benchmark.py --check --threshold 15` — 126,825 f/s, +12.9% vs. baseline, within threshold
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

### New protocol or dispatch change — also:

Not applicable — no new protocol, no dispatch change. Deleted this block's checklist since it doesn't apply.

## Notes

No breaking change: every new accessor is additive (a new property alongside existing fields), consistent with 2.1.0 being a minor version per the roadmap (#105, part of #107).

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM)_