### PR TITLE
DNS: typed RDATA values and every question, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ARCHITECTURE.md and `docs/CLAIMS.md` are updated to describe this as
   a deliberate, tested exception rather than the "this library never
   hand-declares `__match_args__`" absolute they stated before (#94).
-
-## [2.0.0] - 2026-09-04
+- **DNS resource records expose typed RDATA, and every question, not
+  just the first.** `DNSResourceRecord.rdata_text` decoded A/AAAA/MX/
+  SOA/etc. into a display string only; a new `rdata_value` field adds
+  the typed decoding alongside it (`rdata_text` is unchanged) —
+  `ipaddress.IPv4Address`/`IPv6Address` for A/AAAA, the decompressed
+  target `str` for NS/CNAME/PTR, a new `MXRecord(preference, exchange)`
+  for MX, a new `SOARecord(mname, rname, serial, refresh, retry,
+  expire, minimum)` for SOA, `list[str]` of character-strings for TXT,
+  and `None` — never raises — for the types this library does not
+  decode. Computed eagerly at parse time, like `rdata_text` always has
+  been: a name inside RDATA (a CNAME's target, for instance) can use
+  DNS compression against the *whole* message, so decoding it needs
+  the same message-wide context `rdata_text` already required, which a
+  property computed lazily from `rdata` alone could not resolve.
+  Separately, `DNS.questions` adds a `tuple[DNSQuestion, ...]` walking
+  every entry of the question section — `question_name`/`question_type`
+  /`question_class` exposed only the first and are unchanged (#96).
 
 ### Development
 - **The round-trip property (`bytes(decode(x)) == x`) is now

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -32,7 +32,14 @@ from netprotocols.layer3.ipv6_ext import (
 from netprotocols.layer4.tcp import TCP, TCPOption
 from netprotocols.layer4.udp import UDP
 from netprotocols.layer7.dhcp import DHCP
-from netprotocols.layer7.dns import DNS, DNSOverTCP, DNSResourceRecord
+from netprotocols.layer7.dns import (
+    DNS,
+    DNSOverTCP,
+    DNSQuestion,
+    DNSResourceRecord,
+    MXRecord,
+    SOARecord,
+)
 from netprotocols.packet import Packet
 from netprotocols.registry import (
     DEFAULT,
@@ -76,6 +83,7 @@ __all__ = [
     "ARPHardwareType",
     "ARPOperation",
     "DNSOverTCP",
+    "DNSQuestion",
     "DNSResourceRecord",
     "EtherType",
     "Ethernet",
@@ -96,6 +104,7 @@ __all__ = [
     "InvalidIPv4AddressError",
     "InvalidMACAddressError",
     "InvalidManufacturerCodeError",
+    "MXRecord",
     "MaxDepthExceededError",
     "NDPOption",
     "Packet",
@@ -103,6 +112,7 @@ __all__ = [
     "ProtocolError",
     "Registry",
     "RegistryConflictError",
+    "SOARecord",
     "TCPOption",
     "TruncatedHeaderError",
     "UnknownTableError",

--- a/src/netprotocols/layer7/__init__.py
+++ b/src/netprotocols/layer7/__init__.py
@@ -1,4 +1,19 @@
 from netprotocols.layer7.dhcp import DHCP
-from netprotocols.layer7.dns import DNS, DNSOverTCP, DNSResourceRecord
+from netprotocols.layer7.dns import (
+    DNS,
+    DNSOverTCP,
+    DNSQuestion,
+    DNSResourceRecord,
+    MXRecord,
+    SOARecord,
+)
 
-__all__ = ["DHCP", "DNS", "DNSOverTCP", "DNSResourceRecord"]
+__all__ = [
+    "DHCP",
+    "DNS",
+    "DNSOverTCP",
+    "DNSQuestion",
+    "DNSResourceRecord",
+    "MXRecord",
+    "SOARecord",
+]

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -15,14 +15,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+from ipaddress import IPv4Address, IPv6Address
 from struct import Struct
-from typing import ClassVar, Self
+from typing import ClassVar, NamedTuple, Self
 
 from netprotocols._base import Protocol, bytes_to_ipv4, bytes_to_ipv6
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["DNS", "DNSOverTCP", "DNSResourceRecord"]
+__all__ = [
+    "DNS",
+    "DNSOverTCP",
+    "DNSQuestion",
+    "DNSResourceRecord",
+    "MXRecord",
+    "SOARecord",
+]
 
 #: A compressed name must not follow more than this many pointers; the
 #: bound makes a maliciously looping name terminate instead of hanging.
@@ -60,6 +68,62 @@ _RR_TYPE_NAMES: dict[int, str] = {
 }
 
 
+class MXRecord(NamedTuple):
+    """MX RDATA (RFC 1035 §3.3.9): a mail exchange preference and host.
+
+    A domain can list several MX records; a mail transfer agent tries
+    the lowest :attr:`preference` first (RFC 5321 §5.1) — this type
+    just carries the two fields as decoded, the ordering policy is the
+    caller's.
+
+    :param preference: Preference value; lower is tried first.
+    :param exchange: The mail exchange host name, decompressed.
+    """
+
+    preference: int
+    exchange: str
+
+
+class SOARecord(NamedTuple):
+    """SOA RDATA (RFC 1035 §3.3.13): a zone's authority record.
+
+    :param mname: Primary name server for the zone, decompressed.
+    :param rname: Mailbox of the zone's administrator, decompressed
+        (its first ``.`` stands in for the ``@`` of an email address).
+    :param serial: Zone serial number; a secondary compares this to its
+        own to detect a change.
+    :param refresh: Seconds a secondary waits between checks of
+        :attr:`serial`.
+    :param retry: Seconds a secondary waits before retrying a failed
+        refresh.
+    :param expire: Seconds after which a secondary stops treating its
+        copy of the zone as authoritative if it cannot reach the
+        primary.
+    :param minimum: TTL applied to negative-answer caching (RFC 2308).
+    """
+
+    mname: str
+    rname: str
+    serial: int
+    refresh: int
+    retry: int
+    expire: int
+    minimum: int
+
+
+class DNSQuestion(NamedTuple):
+    """One entry of the question section (RFC 1035 §4.1.2).
+
+    :param name: QNAME, decompressed to dotted form.
+    :param qtype: Query type (``1`` = A, ``28`` = AAAA, ...).
+    :param qclass: Query class (``1`` = IN).
+    """
+
+    name: str
+    qtype: int
+    qclass: int
+
+
 @dataclass(frozen=True, slots=True)
 class DNSResourceRecord:
     """One DNS resource record (RFC 1035 §4.1.3).
@@ -76,6 +140,19 @@ class DNSResourceRecord:
         ``"preference exchange"`` for MX, the concatenated strings for
         TXT, the field tuple for SOA; the hexadecimal RDATA for types
         this library does not special-case.
+    :param rdata_value: A *typed* decoding of ``rdata`` — an
+        :class:`~ipaddress.IPv4Address`/:class:`~ipaddress.IPv6Address`
+        for A/AAAA, the decompressed target ``str`` for CNAME/NS/PTR,
+        :class:`list`\\ [:class:`str`] of character-strings for TXT,
+        :class:`MXRecord` for MX, :class:`SOARecord` for SOA; ``None``
+        for types this library does not decode (read :attr:`rdata_text`
+        or :attr:`rdata` raw instead). Computed eagerly at parse time,
+        like :attr:`rdata_text` — a name inside RDATA (CNAME's target,
+        MX's exchange, SOA's mname/rname) can use DNS compression
+        against the *whole* message, not just the bytes of this one
+        record, so decoding it needs the same message-wide context
+        :attr:`rdata_text` already required; a value computed lazily
+        from ``rdata`` alone could not resolve such a pointer.
     """
 
     name: str
@@ -84,6 +161,15 @@ class DNSResourceRecord:
     ttl: int
     rdata: bytes
     rdata_text: str
+    rdata_value: (
+        IPv4Address
+        | IPv6Address
+        | list[str]
+        | MXRecord
+        | SOARecord
+        | str
+        | None
+    ) = None
 
     @property
     def rtype_name(self) -> str:
@@ -197,8 +283,8 @@ def _labels(sections: bytes, at: int) -> str:
     return ".".join(labels) if labels else "."
 
 
-def _decode_txt(rdata: bytes) -> str:
-    """Concatenate the character-strings of a TXT record (§3.3.14)."""
+def _decode_txt_strings(rdata: bytes) -> list[str]:
+    """The character-strings of a TXT record, in wire order (§3.3.14)."""
     parts: list[str] = []
     cursor = 0
     while cursor < len(rdata):
@@ -213,24 +299,32 @@ def _decode_txt(rdata: bytes) -> str:
             )
         parts.append(rdata[cursor : cursor + length].decode("ascii", "replace"))
         cursor += length
-    return "".join(parts)
+    return parts
 
 
-def _decode_rdata(sections: bytes, rtype: int, at: int, rdlength: int) -> str:
-    """A human-readable rendering of the RDATA at ``at``; names follow
-    compression against the whole message."""
+def _decode_rdata_value(
+    sections: bytes, rtype: int, at: int, rdlength: int
+) -> IPv4Address | IPv6Address | list[str] | MXRecord | SOARecord | str | None:
+    """A *typed* decoding of the RDATA at ``at``, for the record types
+    this library understands; ``None`` for the rest — read
+    :func:`_decode_rdata_text`/the raw bytes instead. Names follow
+    compression against the whole message, which is why this takes
+    ``sections`` and an absolute offset rather than the RDATA bytes
+    alone (RFC 1035 §4.1.4)."""
     rdata = sections[at : at + rdlength]
     if rtype == 1 and rdlength == 4:  # A
-        return bytes_to_ipv4(rdata)
+        return IPv4Address(bytes_to_ipv4(rdata))
     if rtype == 28 and rdlength == 16:  # AAAA
-        return bytes_to_ipv6(rdata)
+        return IPv6Address(bytes_to_ipv6(rdata))
     if rtype in (2, 5, 12):  # NS, CNAME, PTR — a single name
         return _labels(sections, at)
     if rtype == 15 and rdlength >= 2:  # MX — preference + exchange
         preference = int.from_bytes(rdata[:2], "big")
-        return f"{preference} {_labels(sections, at + 2)}"
+        return MXRecord(
+            preference=preference, exchange=_labels(sections, at + 2)
+        )
     if rtype == 16:  # TXT
-        return _decode_txt(rdata)
+        return _decode_txt_strings(rdata)
     if rtype == 6:  # SOA — mname, rname, then five 32-bit fields
         mname = _labels(sections, at)
         rname_at = _read_name(sections, at)
@@ -247,7 +341,46 @@ def _decode_rdata(sections: bytes, rtype: int, at: int, rdlength: int) -> str:
             int.from_bytes(sections[fixed + i : fixed + i + 4], "big")
             for i in range(0, 20, 4)
         )
-        return f"{mname} {rname} {serial} {refresh} {retry} {expire} {minimum}"
+        return SOARecord(
+            mname=mname,
+            rname=rname,
+            serial=serial,
+            refresh=refresh,
+            retry=retry,
+            expire=expire,
+            minimum=minimum,
+        )
+    return None
+
+
+def _decode_rdata_text(
+    rdata: bytes,
+    value: (
+        IPv4Address
+        | IPv6Address
+        | list[str]
+        | MXRecord
+        | SOARecord
+        | str
+        | None
+    ),
+) -> str:
+    """The human-readable rendering of RDATA, formatted from its
+    already-decoded ``value`` where there is one; the hexadecimal RDATA
+    for the types :func:`_decode_rdata_value` returns ``None`` for."""
+    if isinstance(value, MXRecord):
+        return f"{value.preference} {value.exchange}"
+    if isinstance(value, SOARecord):
+        return (
+            f"{value.mname} {value.rname} {value.serial} {value.refresh} "
+            f"{value.retry} {value.expire} {value.minimum}"
+        )
+    if isinstance(value, list):  # TXT
+        return "".join(value)
+    if isinstance(value, str):  # NS, CNAME, PTR
+        return value
+    if value is not None:  # IPv4Address | IPv6Address
+        return str(value)
     return rdata.hex()
 
 
@@ -277,13 +410,16 @@ def _parse_rr(sections: bytes, at: int) -> tuple[DNSResourceRecord, int]:
             expected=rdlength,
             actual=len(sections) - cursor,
         )
+    rdata = sections[cursor : cursor + rdlength]
+    value = _decode_rdata_value(sections, rtype, cursor, rdlength)
     record = DNSResourceRecord(
         name=name,
         rtype=rtype,
         rclass=rclass,
         ttl=ttl,
-        rdata=sections[cursor : cursor + rdlength],
-        rdata_text=_decode_rdata(sections, rtype, cursor, rdlength),
+        rdata=rdata,
+        rdata_text=_decode_rdata_text(rdata, value),
+        rdata_value=value,
     )
     return record, cursor + rdlength
 
@@ -305,6 +441,39 @@ def _first_record(sections: bytes, qdcount: int) -> int:
                 offset=cursor,
             )
     return cursor
+
+
+@lru_cache(maxsize=_RECORD_CACHE_SIZE)
+def _parse_questions(sections: bytes, qdcount: int) -> tuple[DNSQuestion, ...]:
+    """Parse every entry of the question section (RFC 1035 §4.1.2).
+
+    Cached on the (immutable) section bytes and count, mirroring
+    :func:`_parse_records` — reading :attr:`DNS.questions` more than
+    once for equal messages parses it once. Independent of
+    :func:`_first_record`, which only needs the *offset* past the
+    questions and so does the cheaper :func:`_read_name` walk rather
+    than decoding every name with :func:`_labels`.
+
+    :raises InvalidFieldError: if a question's name or its QTYPE/QCLASS
+        run past the message (bounded — never hangs or over-reads).
+    """
+    questions: list[DNSQuestion] = []
+    cursor = 0
+    for _ in range(qdcount):
+        name = _labels(sections, cursor)
+        cursor = _read_name(sections, cursor)
+        if cursor + 4 > len(sections):
+            raise InvalidFieldError(
+                "DNS question section truncated",
+                protocol=DNS,
+                field="sections",
+                offset=cursor,
+            )
+        qtype = int.from_bytes(sections[cursor : cursor + 2], "big")
+        qclass = int.from_bytes(sections[cursor + 2 : cursor + 4], "big")
+        questions.append(DNSQuestion(name=name, qtype=qtype, qclass=qclass))
+        cursor += 4
+    return tuple(questions)
 
 
 @lru_cache(maxsize=_RECORD_CACHE_SIZE)
@@ -478,6 +647,19 @@ class DNS(Protocol):
         is no question."""
         fixed = self._question_fixed()
         return None if fixed is None else fixed[1]
+
+    @property
+    def questions(self) -> tuple[DNSQuestion, ...]:
+        """Every question in the question section, parsed on demand
+        (RFC 1035 §4.1.2) — :attr:`question_name` and its two siblings
+        above expose only the first, kept for backward compatibility;
+        a message with more than one question (rare, but legal) needs
+        this instead. Empty when :attr:`qdcount` is ``0``.
+
+        :raises InvalidFieldError: if a question is malformed (see
+            :func:`_parse_questions`).
+        """
+        return _parse_questions(self.sections, self.qdcount)
 
     # -- resource records (parsed on demand, never re-encoded) --
 

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -3,6 +3,7 @@ crafted cases for the decode contract and compression safety."""
 
 import socket
 import struct
+from ipaddress import IPv4Address, IPv6Address
 
 import pytest
 
@@ -12,11 +13,14 @@ from netprotocols import (
     TCP,
     UDP,
     DNSOverTCP,
+    DNSQuestion,
     DNSResourceRecord,
     Ethernet,
     InvalidFieldError,
     IPv4,
     IPv6,
+    MXRecord,
+    SOARecord,
     TruncatedHeaderError,
 )
 from test_corpus import walk
@@ -188,6 +192,74 @@ class TestDNSFields:
         assert bytes(dns) == raw
 
 
+def build_questions(entries: list[tuple[str, int, int]]) -> bytes:
+    """A DNS message with one question per ``(name, qtype, qclass)``."""
+    header = struct.pack("!HHHHHH", 0x1234, 0x0100, len(entries), 0, 0, 0)
+    body = b"".join(
+        encode_name(name) + struct.pack("!HH", qtype, qclass)
+        for name, qtype, qclass in entries
+    )
+    return header + body
+
+
+class TestDNSQuestions:
+    """#96: `questions` exposes every entry of the question section;
+    `question_name`/`question_type`/`question_class` above still expose
+    only the first, kept for backward compatibility."""
+
+    def test_single_question_matches_the_first_question_accessors(self):
+        raw = build_query(["example", "com"], qtype=1)
+        dns = DNS.decode(raw)
+        assert dns.questions == (
+            DNSQuestion(name="example.com", qtype=1, qclass=1),
+        )
+        assert dns.questions[0].name == dns.question_name
+        assert dns.questions[0].qtype == dns.question_type
+        assert dns.questions[0].qclass == dns.question_class
+
+    def test_multiple_questions_are_all_returned(self):
+        raw = build_questions(
+            [("a.example.com", 1, 1), ("b.example.com", 28, 1)]
+        )
+        dns = DNS.decode(raw)
+        assert dns.questions == (
+            DNSQuestion(name="a.example.com", qtype=1, qclass=1),
+            DNSQuestion(name="b.example.com", qtype=28, qclass=1),
+        )
+        # The single-question accessors still see only the first.
+        assert dns.question_name == "a.example.com"
+
+    def test_no_questions_is_empty(self):
+        dns = DNS.decode(struct.pack("!HHHHHH", 1, 0x8180, 0, 0, 0, 0))
+        assert dns.questions == ()
+
+    def test_round_trip_unaffected_by_parsing(self):
+        raw = build_questions(
+            [("a.example.com", 1, 1), ("b.example.com", 28, 1)]
+        )
+        dns = DNS.decode(raw)
+        _ = dns.questions
+        assert bytes(dns) == raw
+
+    def test_truncated_second_question_raises(self):
+        # First question is well-formed; the second is missing its
+        # QTYPE/QCLASS.
+        header = struct.pack("!HHHHHH", 1, 0x0100, 2, 0, 0, 0)
+        body = encode_name("a.example.com") + struct.pack("!HH", 1, 1)
+        body += encode_name("b.example.com")  # no QTYPE/QCLASS follows
+        with pytest.raises(InvalidFieldError):
+            _ = DNS.decode(header + body).questions
+
+    def test_corpus_questions_match_the_first_question_accessors(self):
+        for frame in CORPUS_DNS:
+            dns = walk(frame)[0][-1]
+            if dns.qdcount == 0:
+                continue
+            assert dns.questions[0].name == dns.question_name
+            assert dns.questions[0].qtype == dns.question_type
+            assert dns.questions[0].qclass == dns.question_class
+
+
 class TestDNSResourceRecords:
     @staticmethod
     def _ipv6(addr: str) -> bytes:
@@ -207,6 +279,7 @@ class TestDNSResourceRecords:
         assert record.rclass == 1
         assert record.ttl == 300
         assert record.rdata_text == "192.0.2.1"
+        assert record.rdata_value == IPv4Address("192.0.2.1")
 
     def test_aaaa_record(self):
         raw = build_response(
@@ -217,6 +290,7 @@ class TestDNSResourceRecords:
         (record,) = DNS.decode(raw).answers
         assert record.rtype_name == "AAAA"
         assert record.rdata_text == "2001:db8::1"
+        assert record.rdata_value == IPv6Address("2001:db8::1")
 
     def test_cname_target_name(self):
         raw = build_response(
@@ -229,6 +303,7 @@ class TestDNSResourceRecords:
         (record,) = DNS.decode(raw).answers
         assert record.rtype_name == "CNAME"
         assert record.rdata_text == "target.example.com"
+        assert record.rdata_value == "target.example.com"
 
     def test_mx_record(self):
         rdata = struct.pack("!H", 10) + encode_name("mail.example.com")
@@ -238,6 +313,9 @@ class TestDNSResourceRecords:
         (record,) = DNS.decode(raw).answers
         assert record.rtype_name == "MX"
         assert record.rdata_text == "10 mail.example.com"
+        assert record.rdata_value == MXRecord(
+            preference=10, exchange="mail.example.com"
+        )
 
     def test_txt_record(self):
         rdata = bytes([5]) + b"hello" + bytes([6]) + b"world!"
@@ -247,6 +325,7 @@ class TestDNSResourceRecords:
         (record,) = DNS.decode(raw).answers
         assert record.rtype_name == "TXT"
         assert record.rdata_text == "helloworld!"
+        assert record.rdata_value == ["hello", "world!"]
 
     def test_soa_record(self):
         rdata = (
@@ -260,6 +339,15 @@ class TestDNSResourceRecords:
         (record,) = DNS.decode(raw).authorities
         assert record.rtype_name == "SOA"
         assert record.rdata_text == "ns.example.com admin.example.com 1 2 3 4 5"
+        assert record.rdata_value == SOARecord(
+            mname="ns.example.com",
+            rname="admin.example.com",
+            serial=1,
+            refresh=2,
+            retry=3,
+            expire=4,
+            minimum=5,
+        )
 
     def test_unknown_type_keeps_hex_rdata(self):
         raw = build_response(
@@ -271,6 +359,7 @@ class TestDNSResourceRecords:
         assert record.rtype_name == "99"
         assert record.rdata == b"\xde\xad\xbe\xef"
         assert record.rdata_text == "deadbeef"
+        assert record.rdata_value is None
 
     def test_sections_split_by_count(self):
         raw = build_response(


### PR DESCRIPTION
## Summary

Part of #96 (the DNS piece — item 1, called the highest-value of the four in the issue). The 1.3.0 option work landed the hard part (`TCP.parsed_options` / `TCPOption.value`); DNS RDATA was still a rendered string only.

`DNSResourceRecord.rdata_text` handles A, AAAA, NS/CNAME/PTR, MX, TXT and SOA, then falls back to `rdata.hex()` — but it returns `str` for all of them. A new `rdata_value` field adds the typed decoding alongside it, unchanged: `ipaddress.IPv4Address`/`IPv6Address` for A/AAAA, the decompressed target `str` for NS/CNAME/PTR, `list[str]` of character-strings for TXT, a new `MXRecord(preference, exchange)` for MX, a new `SOARecord(mname, rname, serial, refresh, retry, expire, minimum)` for SOA, `None` — never raises — for everything else. `rdata_text` is byte-for-byte unchanged.

Separately: only the *first* question was ever exposed (`question_name`/`question_type`/`question_class`); there was no `questions` tuple even though `qdcount` can exceed 1. `DNS.questions -> tuple[DNSQuestion, ...]` adds that, parsed and cached the same way `answers`/`authorities`/`additionals` already are.

## What's included

- `MXRecord`, `SOARecord`, `DNSQuestion` — new `NamedTuple`s, exported at the top level, mirroring `FlowKey`'s "derived value, not a wire format" rationale for being a `NamedTuple` rather than a frozen dataclass.
- `DNSResourceRecord.rdata_value` — a new field (not a `@property`). **Why a field, not a lazy property** (worth calling out explicitly, since it's the one place this PR deviates from the `TCPOption.value`/`IPv4Option.value` lazy-property pattern the rest of this tier follows): a name inside RDATA can use DNS compression against the *whole* message, not just the bytes of that one record. `rdata_text` has always been computed eagerly, at parse time, for exactly this reason — the same message-wide context is required either way, and a property computed lazily from `rdata: bytes` alone could not resolve such a pointer (it's sliced out of the message and loses the absolute offsets pointers reference). `rdata_value` follows the same rule `rdata_text` already established in this file, rather than introducing a second, incompatible convention.
- `_decode_rdata` is split into `_decode_rdata_value` (the new typed decode) and `_decode_rdata_text` (formats `rdata_text` from the already-decoded value). One parse instead of two — a perf win, not just a refactor — and the two accessors can no longer drift apart on the same RDATA the way two independent decoders could.
- `DNS.questions` — parsed and `lru_cache`d the same way `_parse_records` already is. `_first_record` (which only needs the *offset* past the questions to locate the first resource record) is untouched and still does the cheaper `_read_name`-only walk rather than fully decoding names it doesn't need.
- Full test coverage: `rdata_value` for every decoded rtype and the `None` fallback, single- and multi-question `DNS.questions`, empty-question and truncated-question cases, round-trip preserved.

No breaking change: `rdata_value` defaults to `None` (existing direct `DNSResourceRecord(...)` construction, if any, is unaffected), `rdata_text`'s output is byte-for-byte identical to before, and `question_name`/`question_type`/`question_class` are untouched.

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict, `src/` only)
- [x] `uv run --frozen pytest` passes locally (full suite, including every pre-existing `test_dns.py` assertion unchanged)
- [x] `uv run --frozen python scripts/benchmark.py --check --threshold 15` — 129,593 f/s, +5.8% vs. baseline, within threshold
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

### New protocol or dispatch change — also:

Not applicable — no new protocol, no dispatch change. Deleted this block's checklist since it doesn't apply.

## Notes

Part of #96, which splits into four independent PRs by the issue's own instruction; the other three (DHCP option typing, `IPv4Option.value`, `IPv6Routing`/`IPv6Option` value decoding) follow as separate PRs. `#96` itself stays open until all four land.

Part of #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM)_