### PR TITLE
DHCP: add a typed DHCPOption alongside option_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every entry of the question section — `question_name`/`question_type`
   /`question_class` exposed only the first and are unchanged (#96).
 
+## [2.0.0] - 2026-09-04
+
 ### Development
 - **The round-trip property (`bytes(decode(x)) == x`) is now
   Hypothesis-generated for all 18 protocols, not 4.** It previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Separately, `DNS.questions` adds a `tuple[DNSQuestion, ...]` walking
   every entry of the question section — `question_name`/`question_type`
   /`question_class` exposed only the first and are unchanged (#96).
+- **A typed `DHCPOption`, alongside `DHCP.option_map`.** `option_map`
+  was the only accessor in the library returning a bare
+  `dict[int, bytes]` rather than typed objects; it is unchanged (still
+  returns exactly what it always did). A new `parsed_options` property
+  wraps the same, already RFC-3396-concatenated, mapping into a
+  `tuple[DHCPOption, ...]`, mirroring `TCPOption`/`IPv4Option`: `code`,
+  `data`, `code_name`, and a decoded `.value` for the option codes this
+  library understands — a single `ipaddress.IPv4Address` for Subnet
+  Mask (1)/Requested IP Address (50)/Server Identifier (54), a tuple of
+  one or more for Router (3)/Domain Name Server (6) (RFC 2132 permits
+  repeating either), the integer seconds for IP Address Lease Time
+  (51), the raw byte for Message Type (53). `None` — never raises —
+  for codes this library does not decode and malformed option data
+  (#96).
 
 ## [2.0.0] - 2026-09-04
 

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -31,7 +31,7 @@ from netprotocols.layer3.ipv6_ext import (
 )
 from netprotocols.layer4.tcp import TCP, TCPOption
 from netprotocols.layer4.udp import UDP
-from netprotocols.layer7.dhcp import DHCP
+from netprotocols.layer7.dhcp import DHCP, DHCPOption
 from netprotocols.layer7.dns import (
     DNS,
     DNSOverTCP,
@@ -82,6 +82,7 @@ __all__ = [
     "VLAN",
     "ARPHardwareType",
     "ARPOperation",
+    "DHCPOption",
     "DNSOverTCP",
     "DNSQuestion",
     "DNSResourceRecord",

--- a/src/netprotocols/layer7/__init__.py
+++ b/src/netprotocols/layer7/__init__.py
@@ -1,4 +1,4 @@
-from netprotocols.layer7.dhcp import DHCP
+from netprotocols.layer7.dhcp import DHCP, DHCPOption
 from netprotocols.layer7.dns import (
     DNS,
     DNSOverTCP,
@@ -11,6 +11,7 @@ from netprotocols.layer7.dns import (
 __all__ = [
     "DHCP",
     "DNS",
+    "DHCPOption",
     "DNSOverTCP",
     "DNSQuestion",
     "DNSResourceRecord",

--- a/src/netprotocols/layer7/dhcp.py
+++ b/src/netprotocols/layer7/dhcp.py
@@ -5,9 +5,11 @@ DHCP extends the fixed BOOTP frame: a 236-byte header (op through the
 variable list of TLV options. The fixed header is decoded in full; the
 options are kept raw and parsed on demand, so ``bytes(DHCP.decode(x))
 == x`` holds by construction and a message with unusual or vendor
-options still round-trips exactly. ``option_map`` walks the TLV list,
-and ``message_type`` reads the DHCP message type (option 53) that
-distinguishes a DISCOVER from an ACK.
+options still round-trips exactly. ``option_map`` walks the TLV list
+into a ``{code: value}`` dict; ``parsed_options`` wraps the same walk
+into a tuple of typed :class:`DHCPOption`; ``message_type`` reads the
+DHCP message type (option 53) that distinguishes a DISCOVER from an
+ACK.
 
 DHCP rides UDP between the server port (67) and the client port (68);
 it is terminal — it never encapsulates another protocol.
@@ -29,7 +31,7 @@ from netprotocols._base import (
 from netprotocols._enums import ARPHardwareType
 from netprotocols.utils.exceptions import InvalidFieldError
 
-__all__ = ["DHCP"]
+__all__ = ["DHCP", "DHCPOption"]
 
 #: The four-byte value that begins the options field (RFC 2131 §3;
 #: the dotted form 99.130.83.99).
@@ -41,6 +43,18 @@ _OPT_END = 255
 
 #: The DHCP Message Type option (RFC 2132 §9.6).
 _OPT_MESSAGE_TYPE = 53
+
+#: Option codes whose value is a single IPv4 address (RFC 2132 §3.3
+#: Subnet Mask, §9.1 Requested IP Address, §9.7 Server Identifier).
+_SINGLE_ADDRESS_CODES = frozenset({1, 50, 54})
+
+#: Option codes whose value is one or more IPv4 addresses, most
+#: preferred first (RFC 2132 §3.5 Router, §3.8 Domain Name Server).
+_ADDRESS_LIST_CODES = frozenset({3, 6})
+
+#: The IP Address Lease Time option: a 32-bit seconds count (RFC 2132
+#: §9.2).
+_OPT_LEASE_TIME = 51
 
 _OP_NAMES: dict[int, str] = {1: "BOOTREQUEST", 2: "BOOTREPLY"}
 
@@ -54,6 +68,74 @@ _MESSAGE_TYPE_NAMES: dict[int, str] = {
     7: "RELEASE",
     8: "INFORM",
 }
+
+#: DHCP option codes this library names (RFC 2132); unknown codes fall
+#: back to their numeric value.
+_OPTION_CODE_NAMES: dict[int, str] = {
+    1: "Subnet Mask",
+    3: "Router",
+    6: "Domain Name Server",
+    50: "Requested IP Address",
+    51: "IP Address Lease Time",
+    53: "Message Type",
+    54: "Server Identifier",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DHCPOption:
+    """One DHCP option (RFC 2132), already RFC-3396-concatenated if it
+    appeared more than once — see :attr:`DHCP.option_map`, which
+    :attr:`DHCP.parsed_options` wraps.
+
+    :param code: Option code — ``1`` Subnet Mask, ``3`` Router, ``6``
+        Domain Name Server, ``50`` Requested IP Address, ``51`` IP
+        Address Lease Time, ``53`` Message Type, ``54`` Server
+        Identifier, ... (see :attr:`code_name`).
+    :param data: The option's value bytes, kept raw.
+    """
+
+    code: int
+    data: bytes = b""
+
+    @property
+    def code_name(self) -> str:
+        """Display name of the option code, e.g. ``"Subnet Mask"``;
+        falls back to ``"unknown (n)"`` for codes this library does
+        not name."""
+        return _OPTION_CODE_NAMES.get(self.code, f"unknown ({self.code})")
+
+    @property
+    def value(
+        self,
+    ) -> int | IPv4Address | tuple[IPv4Address, ...] | None:
+        """The decoded value, for the codes this library understands:
+        a single :class:`~ipaddress.IPv4Address` for Subnet Mask (1),
+        Requested IP Address (50) and Server Identifier (54); a tuple
+        of one or more, most preferred first, for Router (3) and
+        Domain Name Server (6) (RFC 2132 permits repeating either); the
+        integer seconds for IP Address Lease Time (51); the raw
+        message-type byte as an ``int`` for Message Type (53, see
+        :attr:`DHCP.message_type`). ``None`` — read :attr:`data` raw
+        instead — for codes this library does not decode and data
+        whose length does not match its code (degrades, never
+        raises)."""
+        if self.code in _SINGLE_ADDRESS_CODES and len(self.data) == 4:
+            return IPv4Address(bytes_to_ipv4(self.data))
+        if (
+            self.code in _ADDRESS_LIST_CODES
+            and self.data
+            and len(self.data) % 4 == 0
+        ):
+            return tuple(
+                IPv4Address(bytes_to_ipv4(self.data[i : i + 4]))
+                for i in range(0, len(self.data), 4)
+            )
+        if self.code == _OPT_LEASE_TIME and len(self.data) == 4:
+            return int.from_bytes(self.data, "big")
+        if self.code == _OPT_MESSAGE_TYPE and len(self.data) == 1:
+            return self.data[0]
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -307,6 +389,22 @@ class DHCP(Protocol):
             parsed[code] = parsed.get(code, b"") + raw[cursor : cursor + length]
             cursor += length
         return parsed
+
+    @property
+    def parsed_options(self) -> tuple[DHCPOption, ...]:
+        """The TLV options as a tuple of :class:`DHCPOption`, one per
+        option code, in first-appearance wire order — a typed view
+        over :attr:`option_map` (an option split across several
+        appearances is concatenated there already, per RFC 3396).
+        Empty when the message carries no options.
+
+        :raises InvalidFieldError: if the options are malformed (see
+            :attr:`option_map`).
+        """
+        return tuple(
+            DHCPOption(code=code, data=data)
+            for code, data in self.option_map.items()
+        )
 
     @property
     def message_type(self) -> int | None:

--- a/tests/test_dhcp.py
+++ b/tests/test_dhcp.py
@@ -11,6 +11,7 @@ from netprotocols import (
     DHCP,
     UDP,
     ARPHardwareType,
+    DHCPOption,
     Ethernet,
     InvalidFieldError,
     IPv4,
@@ -188,6 +189,109 @@ class TestDHCPOptions:
     def test_message_type_wrong_length_is_none(self):
         raw = build_dhcp(options=build_options([(53, b"\x05\x05")]))
         assert DHCP.decode(raw).message_type is None
+
+
+class TestDHCPParsedOptions:
+    """#96: `parsed_options` is a typed view over `option_map` -- one
+    `DHCPOption` per (already RFC-3396-concatenated) code, decoding the
+    well-known ones into real values."""
+
+    def test_empty_options_parses_empty(self):
+        assert DHCP.decode(build_dhcp(options=b"")).parsed_options == ()
+
+    def test_single_ipv4_address_options(self):
+        raw = build_dhcp(
+            options=build_options(
+                [
+                    (1, ipv4_bytes("255.255.255.0")),  # subnet mask
+                    (50, ipv4_bytes("192.168.1.100")),  # requested IP
+                    (54, ipv4_bytes("192.168.1.1")),  # server identifier
+                ]
+            )
+        )
+        mask, requested, server_id = DHCP.decode(raw).parsed_options
+        assert mask.code == 1
+        assert mask.code_name == "Subnet Mask"
+        assert mask.value == IPv4Address("255.255.255.0")
+        assert requested.code_name == "Requested IP Address"
+        assert requested.value == IPv4Address("192.168.1.100")
+        assert server_id.code_name == "Server Identifier"
+        assert server_id.value == IPv4Address("192.168.1.1")
+
+    def test_address_list_options(self):
+        raw = build_dhcp(
+            options=build_options(
+                [
+                    (3, ipv4_bytes("10.0.0.1")),  # router, single
+                    (
+                        6,
+                        ipv4_bytes("10.0.0.53") + ipv4_bytes("10.0.0.54"),
+                    ),  # DNS servers, two
+                ]
+            )
+        )
+        router, dns = DHCP.decode(raw).parsed_options
+        assert router.code_name == "Router"
+        assert router.value == (IPv4Address("10.0.0.1"),)
+        assert dns.code_name == "Domain Name Server"
+        assert dns.value == (
+            IPv4Address("10.0.0.53"),
+            IPv4Address("10.0.0.54"),
+        )
+
+    def test_lease_time_option(self):
+        raw = build_dhcp(
+            options=build_options([(51, (86400).to_bytes(4, "big"))])
+        )
+        (lease,) = DHCP.decode(raw).parsed_options
+        assert lease.code_name == "IP Address Lease Time"
+        assert lease.value == 86400
+
+    def test_message_type_option(self):
+        raw = build_dhcp(options=build_options([(53, b"\x05")]))  # ACK
+        (msg_type,) = DHCP.decode(raw).parsed_options
+        assert msg_type.code_name == "Message Type"
+        assert msg_type.value == 5
+
+    def test_unknown_code_keeps_raw_data_and_none_value(self):
+        raw = build_dhcp(options=build_options([(77, b"\x01\x02\x03")]))
+        (option,) = DHCP.decode(raw).parsed_options
+        assert option.code == 77
+        assert option.code_name == "unknown (77)"
+        assert option.data == b"\x01\x02\x03"
+        assert option.value is None
+
+    def test_wrong_length_degrades_to_none_rather_than_raising(self):
+        # Subnet Mask normally 4 bytes; 3 here is malformed but should
+        # not raise -- read `data` raw instead.
+        raw = build_dhcp(options=build_options([(1, b"\xff\xff\xff")]))
+        (option,) = DHCP.decode(raw).parsed_options
+        assert option.value is None
+        assert option.data == b"\xff\xff\xff"
+
+    def test_split_option_is_concatenated_before_wrapping(self):
+        # RFC 3396: mirrors test_split_option_is_concatenated above --
+        # parsed_options sees the already-concatenated bytes, not two
+        # separate DHCPOption entries.
+        raw = build_dhcp(
+            options=build_options([(43, b"\xaa\xbb"), (43, b"\xcc\xdd")])
+        )
+        (option,) = DHCP.decode(raw).parsed_options
+        assert option.code == 43
+        assert option.data == b"\xaa\xbb\xcc\xdd"
+
+    def test_wire_order_is_preserved(self):
+        raw = build_dhcp(
+            options=build_options([(53, b"\x01"), (1, b"\xff\xff\xff\x00")])
+        )
+        codes = [option.code for option in DHCP.decode(raw).parsed_options]
+        assert codes == [53, 1]
+
+    def test_direct_construction(self):
+        option = DHCPOption(code=1, data=ipv4_bytes("255.255.255.0"))
+        assert option.code_name == "Subnet Mask"
+        assert option.value == IPv4Address("255.255.255.0")
+        assert DHCPOption(code=0).data == b""
 
 
 class TestDHCPContract:


### PR DESCRIPTION
## Summary

Part of #96 (the DHCP piece — item 2). `DHCP.option_map` returns `dict[int, bytes]` — the only accessor in the library that returns a bare dict rather than typed objects — and only option 53 (Message Type) was ever interpreted.

`option_map` is unchanged. A new `parsed_options` property wraps the same, already RFC-3396-concatenated mapping into a `tuple[DHCPOption, ...]`, mirroring `TCPOption`/`IPv4Option`: `code`, `data`, `code_name`, and a decoded `.value`.

**Why `parsed_options` is built on top of `option_map` rather than re-walking the raw TLV bytes:** DHCP options can legitimately split across multiple appearances of the same code (RFC 3396) in a way TCP/IPv4 options never do, and `option_map` already handles that concatenation plus the truncation-safety checks. Re-parsing raw bytes independently would either duplicate all of that logic or risk exposing split appearances as separate `DHCPOption` entries with the same code — which isn't what "one option, one value" should mean.

## What's included

- `DHCPOption` — new frozen dataclass (`code: int`, `data: bytes = b""`), mirroring `TCPOption`/`IPv4Option`'s shape exactly. Exported at the top level.
- `DHCPOption.code_name` — display name, same `_OPTION_CODE_NAMES.get(code, f"unknown ({code})")` pattern as every other `*_name` accessor in the codebase.
- `DHCPOption.value` — decodes the well-known option codes with simple, RFC 2132-precise layouts: a single `ipaddress.IPv4Address` for Subnet Mask (1) / Requested IP Address (50) / Server Identifier (54); a tuple of one or more, most preferred first, for Router (3) / Domain Name Server (6) (RFC 2132 explicitly permits repeating either); the integer seconds for IP Address Lease Time (51); the raw message-type byte as `int` for Message Type (53, same value `DHCP.message_type` already exposes). `None` — never raises — for codes this library does not decode and malformed data on a code it does (degrades, same contract as `TCPOption.value`).
- `DHCP.parsed_options` — the tuple accessor, in wire order, built from `self.option_map.items()` (dict iteration order is insertion order, i.e. wire order, in modern Python).
- Full test coverage: single/multi-address options, lease time, message type, unknown codes, wrong-length degradation, RFC 3396 concatenation reflected correctly, wire order, direct construction.
- One unrelated fix bundled in: a prior commit of mine (merged in #136) accidentally dropped the `## [2.0.0]` CHANGELOG heading while appending an entry — caught while adding this PR's own entry, fixed in a separate, clearly-labeled commit here.

No breaking change: `option_map` is byte-for-byte unchanged, `parsed_options` is a new accessor.

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict, `src/` only)
- [x] `uv run --frozen pytest` passes locally (full suite)
- [x] `uv run --frozen python scripts/benchmark.py --check --threshold 15` — 133,134 f/s, +14.5% vs. baseline, within threshold
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

### New protocol or dispatch change — also:

Not applicable — no new protocol, no dispatch change. Deleted this block's checklist since it doesn't apply.

## Notes

Part of #96 (four independent PRs by the issue's own instruction); this is the second of four. `#96` itself stays open until all four land.

Part of #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP7X7H4k3pBWoiAkBdxATM)_