### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-09-04
 
 ### Added
 - **Typed accessors for every enum-backed field.** `_enums.py` defines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netprotocols"
-version = "2.0.0"
+version = "2.2.0"
 description = "Low-level implementations of common networking protocols"
 readme = "README.md"
 license = "MIT"

--- a/src/netprotocols/__init__.py
+++ b/src/netprotocols/__init__.py
@@ -74,7 +74,7 @@ from netprotocols.walk import MAX_DEPTH, decode_frame
 # registrations name the classes. See netprotocols/_defaults.py.
 _defaults.install(DEFAULT)
 
-__version__ = "2.0.0"
+__version__ = "2.2.0"
 
 __all__ = [
     "ARP",

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "netprotocols"
-version = "2.0.0"
+version = "2.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Version bump for the release that closes out the post-1.3.0 roadmap ([#107](https://github.com/EONRaider/NETProtocols/issues/107)). Bumps `pyproject.toml`, `src/netprotocols/__init__.py`, and `uv.lock` from 2.0.0 to **2.2.0**, and turns the `CHANGELOG.md` `## [Unreleased]` header into `## [2.2.0] - 2026-09-04` — same mechanics as the 2.0.0 release ([#133](https://github.com/EONRaider/NETProtocols/pull/133)).

**Why 2.2.0 and not a major bump:** everything accumulated on `master` since 2.0.0 is additive — Tier 3 (#105, typed accessors and pattern-matching ergonomics), Tier 4 (#106, round-trip properties/fuzzing/pcap reader), and this session's #124 audit + embargo lift (docs/tooling only). No breaking changes, so this is a minor bump per semver. 2.2.0 rather than 2.1.0 because the roadmap ([#107](https://github.com/EONRaider/NETProtocols/issues/107)) itself pre-assigned Tier 3 → 2.1.0 and Tier 4 → 2.2.0 as milestone labels before either shipped; since neither was released standalone, shipping the combined state under the higher, already-public label (referenced throughout `README.md`'s roadmap table and issue #106) is more faithful to that plan than semver reasoning alone would require, and 2.1.0 was never actually a released version to skip past.

## What's included

- `pyproject.toml`, `src/netprotocols/__init__.py`: version 2.0.0 → 2.2.0
- `uv.lock`: regenerated (`uv lock`) to match
- `CHANGELOG.md`: `## [Unreleased]` → `## [2.2.0] - 2026-09-04`

## Verification

- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict)
- [x] `uv run --frozen pytest` passes — 1088 passed
- [x] `python -c "from netprotocols import __version__; print(__version__)"` → `2.2.0`

## Notes

Once merged, pushing tag `v2.2.0` triggers `release.yml`: re-runs the full CI matrix against the tagged commit, verifies the tag matches the packaged version, and publishes to PyPI via trusted publishing — same as 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143tMFpiopxYLf6A2EeDyo9

---
_Generated by [Claude Code](https://claude.ai/code/session_0143tMFpiopxYLf6A2EeDyo9)_