### PR TITLE
release: automate GitHub release creation after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,36 @@ jobs:
           fi
           echo "Tag ${GITHUB_REF_NAME} matches packaged version ${built}."
       - run: uv publish --trusted-publishing always
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      # CHANGELOG.md is the single source of truth for release notes, so
+      # extract this tag's own section rather than maintaining a second
+      # copy anywhere. A missing section fails loudly instead of
+      # publishing an empty-body release.
+      - name: Extract this version's CHANGELOG section
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            found && /^## \[/ { exit }
+            found { print }
+            $0 ~ "^## \\[" ver "\\]" { found=1 }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No '## [${version}]' section found in CHANGELOG.md."
+            exit 1
+          fi
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "netprotocols ${GITHUB_REF_NAME#v}" \
+            --notes-file release-notes.md \
+            --latest


### PR DESCRIPTION
## Summary
- Adds a `github-release` job to `release.yml`, gated on `needs: publish`, so a tag push now produces the PyPI upload *and* the GitHub release in one automated pipeline.
- The job extracts the tag's own `## [X.Y.Z]` section from `CHANGELOG.md` via `awk` and passes it straight to `gh release create --notes-file`, so release notes have one source of truth instead of being retyped by hand.
- Title format matches prior releases: `netprotocols X.Y.Z`. Marked `--latest`, consistent with how v1.0.0 through v2.2.0 were released manually.

## Why
Every GitHub release through v2.2.0 (including the one just published) had to be created by hand after the tag/CI/publish pipeline finished — `release.yml` never had a step for it. This closes that gap.

## Test plan
- [x] `uv run pytest tests/test_workflows.py` — all 4 wiring assertions pass (publish still gated on `ci`, no reference wiring broken)
- [x] Verified the `awk` extraction in the new step produces output byte-identical to the CHANGELOG section manually used for the actual v2.2.0 release
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the edited YAML parses
- [ ] End-to-end verification only happens on the next real tag push (this can't be dry-run without publishing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)