### PR TITLE
Resolve the release-policy finding: 2.2.0's PyPI release was intentional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,15 @@ methodology, and updated 1.1/1.2/1.6 figures.
   published there); left unfixed pending a maintainer decision on
   whether 2.2.0's publication was intentional, since fixing the prose
   first would paper over a real process question.
-
-## [2.2.0] - 2026-09-04
+- **Resolved the seventh finding above: 2.2.0's PyPI publication was
+  confirmed intentional.** The Roadmap section's "per the roadmap's own
+  release policy, only 2.0.0 was an actual PyPI release" is now
+  "the roadmap's original 'only at a major version bump' release policy
+  wasn't actually held to: both 2.0.0 and 2.2.0 — a minor release — are
+  on PyPI," and the roadmap table's 2.2.0 row gained the same
+  **released** marker 2.0.0 already carried. Issue #107, the source
+  both docs draw this from, updated its own stated policy line with a
+  dated correction rather than silently rewriting history.
 
 ### Added
 - **Typed accessors for every enum-backed field.** `_enums.py` defines

--- a/README.md
+++ b/README.md
@@ -394,14 +394,16 @@ comparative-claims embargo lift that closed it out:
 | [1.4.0](https://github.com/EONRaider/NETProtocols/issues/103) | Decode performance |
 | [2.0.0](https://github.com/EONRaider/NETProtocols/issues/104) | A public protocol registry, a shipped chain walker, flow keys — **released** |
 | [2.1.0](https://github.com/EONRaider/NETProtocols/issues/105) | Typed accessors and pattern-matching ergonomics |
-| [2.2.0](https://github.com/EONRaider/NETProtocols/issues/106) | Universal round-trip properties, nightly fuzzing, a pcap reader |
+| [2.2.0](https://github.com/EONRaider/NETProtocols/issues/106) | Universal round-trip properties, nightly fuzzing, a pcap reader — **released** |
 
 Everything through 2.2.0 has landed on `master`, plus a since-landed
 decode-throughput fix
 ([#147](https://github.com/EONRaider/NETProtocols/issues/147), not yet
-versioned); per the roadmap's own release policy, only 2.0.0 was an
-actual PyPI release, and the comparative claims above draw on the
-finished tree. New planned work
+versioned). 2.1.0's and 1.3.1/1.4.0's work shipped folded into 2.0.0
+and 2.2.0 rather than as their own versions, but the roadmap's original
+"only at a major version bump" release policy wasn't actually held to:
+both 2.0.0 and 2.2.0 — a minor release — are on PyPI, and the
+comparative claims above draw on the finished tree. New planned work
 will open fresh issues rather than restating a list here, so this
 section stays accurate without upkeep. The wave before this one — TCP
 and IPv4 option parsing, ICMP message bodies, NDP, IPv6


### PR DESCRIPTION
## Summary

PR #153's audit left one of its seven findings deliberately unfixed: README's Roadmap section claims *"per the roadmap's own release policy, only 2.0.0 was an actual PyPI release,"* which is contradicted by PyPI itself (2.2.0, a minor version, is also published there — plus five earlier minor/patch versions). That PR left it for a maintainer decision rather than rewriting the prose, since the real question was whether 2.2.0's publication was intentional. Confirmed: it was. This PR applies the resulting fix.

## What's included

- **README.md roadmap table**: 2.2.0's row now carries the same **released** marker 2.0.0's row already has.
- **README.md roadmap prose**: replaced the "only 2.0.0 was an actual PyPI release" claim (which wasn't true) with what actually happened — 1.3.1/1.4.0's work folded into the 2.0.0 release and 2.1.0's folded into 2.2.0's, but both 2.0.0 and 2.2.0 themselves were released directly to PyPI, which the roadmap's original "only at a major version bump" policy didn't anticipate.
- **Issue #107** (the source both README.md and `docs/CLAIMS.md` draw this roadmap narrative from): updated its stated release-policy line with a dated correction note recording what actually happened, and marked 2.2.0's table row as released — rather than silently rewriting the historical record of what the policy originally said.
- **CHANGELOG.md**: entry resolving the deferred finding from PR #153's own changelog entry.

## Verification

- [x] `uv run --frozen pytest` passes
- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` are clean
- [x] `uv run --frozen mypy` is clean (strict)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`
- Docs-only change — no source under `src/` touched, no behavior change.

## Notes

Follow-up to #153, which left this exact question open. Not tied to a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzqEV89zgdGLb3QgnZy3vp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzqEV89zgdGLb3QgnZy3vp)_