### PR TITLE
Address CodeFactor's tooling-script findings (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,21 @@ methodology, and updated 1.1/1.2/1.6 figures.
   exception the way this project's own `ProtocolError` does, so a
   bare `except` is the correct interop boundary, not a swallowed bug.
   The flagged duplication between `benchmark.py` and
-  `check_in_pyodide.py`'s minimal pcap readers is left as-is — both
-  scripts' docstrings already document that each verification path
-  must stand on its own, independent of the others, which a shared
-  helper would undo for a cosmetic DRY gain.
+  `check_in_pyodide.py`'s minimal pcap readers — nearly byte-identical
+  `read_pcap`/`corpus_frames` functions — is now shared via a new
+  `scripts/_pcap.py`. An initial pass left the duplication in place,
+  reasoning both scripts' docstrings required each verification path
+  to stand fully independent of the others; re-reading them shows that
+  claim is narrower than stated — "standalone" there means not
+  depending on netprotocols (the thing each script verifies), the same
+  usage `CONTRIBUTING.md` and `check_fixtures.py`'s own docstring use,
+  never independence from sibling scripts. `_pcap.py` is itself
+  stdlib-only and does not import netprotocols, so it preserves the
+  property the docstrings actually document. Verified against a real
+  Pyodide runtime after the extraction: the corpus still decodes
+  unchanged, and `check_fixtures.py`'s own, materially different
+  `read_pcap` (it additionally validates linktype and length) is
+  untouched, since it was never part of this duplication.
 
 ### Documentation
 - **Corrected six README.md claims an independent audit against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ dpkt-throughput regression" section for the full profiling writeup,
 before/after numbers under both the old and new benchmark
 methodology, and updated 1.1/1.2/1.6 figures.
 
+### Development
+- **Addressed CodeFactor's static-analysis findings on the tooling
+  scripts (#156).** `scripts/pyodide/check_in_pyodide.py` extracted
+  the built wheel into a hardcoded, predictable `/tmp/netprotocols-
+  wheel` path; it now uses `tempfile.mkdtemp()`, verified against a
+  real Pyodide runtime (`node scripts/pyodide/run_in_pyodide.mjs`)
+  decoding the full corpus unchanged. `scripts/check_fixtures.py`'s
+  `_check_l3` — one 137-line function walking IPv4, IPv6, GRE
+  tunneling, VLAN and every upper-layer checksum — is split into one
+  small function per protocol; output is byte-identical on the full
+  97-frame fixture corpus before and after. `scripts/benchmark.py`'s
+  three broad `except Exception: continue` blocks are unchanged but
+  now documented: `dpkt` and `scapy` have no shared "malformed frame"
+  exception the way this project's own `ProtocolError` does, so a
+  bare `except` is the correct interop boundary, not a swallowed bug.
+  The flagged duplication between `benchmark.py` and
+  `check_in_pyodide.py`'s minimal pcap readers is left as-is — both
+  scripts' docstrings already document that each verification path
+  must stand on its own, independent of the others, which a shared
+  helper would undo for a cosmetic DRY gain.
+
 ### Documentation
 - **Corrected six README.md claims an independent audit against the
   live repo found stale or overstated, none of them accidental

--- a/scripts/_pcap.py
+++ b/scripts/_pcap.py
@@ -1,0 +1,42 @@
+"""Minimal classic-pcap reader shared by the standalone verification
+scripts under ``scripts/`` (``benchmark.py``, ``pyodide/check_in_pyodide.py``).
+
+Stdlib only, and never imports netprotocols — each caller's own
+docstring explains why *that* independence matters (a benchmark or a
+Pyodide-import proof must not depend on the code it is measuring or
+proving works). Sharing this module between those callers does not
+compromise it: this file is standalone from netprotocols exactly like
+they are, it just isn't reimplemented three times over.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+
+def read_pcap(path: Path) -> list[bytes]:
+    """Minimal classic-pcap reader."""
+    data = path.read_bytes()
+    magic = data[:4]
+    if magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):
+        endian = ">"
+    elif magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):
+        endian = "<"
+    else:
+        raise ValueError(f"{path.name}: not a pcap")
+    frames, cursor = [], 24
+    while cursor + 16 <= len(data):
+        (incl_len,) = struct.unpack_from(f"{endian}I", data, cursor + 8)
+        cursor += 16
+        frames.append(data[cursor : cursor + incl_len])
+        cursor += incl_len
+    return frames
+
+
+def corpus_frames(fixtures_dir: Path) -> list[bytes]:
+    return [
+        frame
+        for pcap in sorted(fixtures_dir.glob("*.pcap"))
+        for frame in read_pcap(pcap)
+    ]

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -61,35 +61,11 @@ FIXTURES = REPOSITORY / "tests" / "fixtures"
 BASELINE = REPOSITORY / "benchmarks" / "baseline.json"
 
 sys.path.insert(0, str(REPOSITORY / "src"))
+sys.path.insert(0, str(REPOSITORY / "scripts"))
+
+from _pcap import corpus_frames  # noqa: E402
 
 from netprotocols import ProtocolError, decode_frame  # noqa: E402
-
-
-def read_pcap(path: Path) -> list[bytes]:
-    """Minimal classic-pcap reader (standalone, like check_fixtures)."""
-    data = path.read_bytes()
-    magic = data[:4]
-    if magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):
-        endian = ">"
-    elif magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):
-        endian = "<"
-    else:
-        raise ValueError(f"{path.name}: not a pcap")
-    frames, cursor = [], 24
-    while cursor + 16 <= len(data):
-        (incl_len,) = struct.unpack_from(f"{endian}I", data, cursor + 8)
-        cursor += 16
-        frames.append(data[cursor : cursor + incl_len])
-        cursor += incl_len
-    return frames
-
-
-def corpus_frames() -> list[bytes]:
-    return [
-        frame
-        for pcap in sorted(FIXTURES.glob("*.pcap"))
-        for frame in read_pcap(pcap)
-    ]
 
 
 def decode_netprotocols(frames: list[bytes]) -> int:
@@ -365,7 +341,7 @@ def main() -> int:
     parser.add_argument("--json", type=Path, help="write the results here")
     args = parser.parse_args()
 
-    frames = corpus_frames()
+    frames = corpus_frames(FIXTURES)
     if not frames:
         print(f"No fixtures found under {FIXTURES}", file=sys.stderr)
         return 1

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -110,7 +110,7 @@ def decode_dpkt(frames: list[bytes]) -> int:
     for frame in frames:
         try:
             dpkt.ethernet.Ethernet(frame)
-        except Exception:
+        except Exception:  # dpkt has no shared "malformed frame" exception
             continue
         decoded += 1
     return decoded
@@ -124,7 +124,7 @@ def decode_scapy(frames: list[bytes]) -> int:
         try:
             packet = Ether(frame)
             packet.layers()  # force the lazy chain to materialize
-        except Exception:
+        except Exception:  # scapy has no shared "malformed frame" exception
             continue
         decoded += 1
     return decoded

--- a/scripts/check_fixtures.py
+++ b/scripts/check_fixtures.py
@@ -57,144 +57,203 @@ def pseudo_v6(src: bytes, dst: bytes, proto: int, length: int) -> bytes:
     return src + dst + struct.pack("!IBBBB", length, 0, 0, 0, proto)
 
 
+def _check_icmpv4(upper: bytes, stats: Counter) -> list[str]:
+    stats["icmpv4"] += 1
+    if (
+        internet_checksum(upper[:2] + b"\x00\x00" + upper[4:])
+        != struct.unpack_from("!H", upper, 2)[0]
+    ):
+        return ["icmpv4-checksum"]
+    return []
+
+
+def _check_igmp(upper: bytes, stats: Counter) -> list[str]:
+    stats["igmp"] += 1
+    # IGMP: whole message, checksum at bytes 2-3, no pseudo-header.
+    if (
+        internet_checksum(upper[:2] + b"\x00\x00" + upper[4:])
+        != struct.unpack_from("!H", upper, 2)[0]
+    ):
+        return ["igmp-checksum"]
+    return []
+
+
+def _check_tcp(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter
+) -> list[str]:
+    stats["tcp"] += 1
+    upper_len = len(upper)
+    zeroed = upper[:16] + b"\x00\x00" + upper[18:]
+    if (
+        internet_checksum(pseudo_v4(src, dst, 6, upper_len) + zeroed)
+        != struct.unpack_from("!H", upper, 16)[0]
+    ):
+        return ["tcp-checksum"]
+    return []
+
+
+def _check_udp(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter
+) -> list[str]:
+    stats["udp"] += 1
+    upper_len = len(upper)
+    wire = struct.unpack_from("!H", upper, 6)[0]
+    if wire == 0:
+        stats["udp-no-checksum"] += 1
+        return []
+    zeroed = upper[:6] + b"\x00\x00" + upper[8:]
+    computed = (
+        internet_checksum(pseudo_v4(src, dst, 17, upper_len) + zeroed) or 0xFFFF
+    )
+    if computed != wire:
+        return ["udp-checksum"]
+    return []
+
+
+def _check_gre(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter, depth: int
+) -> list[str]:
+    # GRE: a 4-byte header (flags word + inner EtherType) plus the
+    # optional checksum/key/sequence words the flag bits announce
+    # (RFC 2890), then the tunnelled packet — validated in turn.
+    stats["gre"] += 1
+    gre_flags = struct.unpack_from("!H", upper, 0)[0]
+    inner_ethertype = struct.unpack_from("!H", upper, 2)[0]
+    optional = (
+        (4 if gre_flags & 0x8000 else 0)
+        + (4 if gre_flags & 0x2000 else 0)
+        + (4 if gre_flags & 0x1000 else 0)
+    )
+    return _check_l3(inner_ethertype, upper[4 + optional :], stats, depth + 1)
+
+
+def _check_ipv4(payload: bytes, stats: Counter, depth: int) -> list[str]:
+    failures: list[str] = []
+    ihl = (payload[0] & 0x0F) * 4
+    header = payload[:ihl]
+    stats["ipv4"] += 1
+    if (
+        internet_checksum(header[:10] + b"\x00\x00" + header[12:ihl])
+        != struct.unpack_from("!H", header, 10)[0]
+    ):
+        failures.append("ipv4-header-checksum")
+    src, dst = header[12:16], header[16:20]
+    proto = header[9]
+    total_length = struct.unpack_from("!H", header, 2)[0]
+    flags_frag = struct.unpack_from("!H", header, 6)[0]
+    if flags_frag & 0x1FFF:
+        stats["ipv4-fragment"] += 1
+        return failures  # non-first fragment: no upper-layer header
+    if flags_frag & 0x2000 == 0x2000 and flags_frag & 0x1FFF == 0:
+        stats["ipv4-first-fragment"] += 1
+        return failures  # first fragment: upper checksum spans all parts
+    upper = payload[ihl:total_length]
+    upper_len = len(upper)
+    if proto == 1 and upper_len >= 8:
+        failures += _check_icmpv4(upper, stats)
+    elif proto == 2 and upper_len >= 8:
+        failures += _check_igmp(upper, stats)
+    elif proto == 6 and upper_len >= 20:
+        failures += _check_tcp(src, dst, upper, stats)
+    elif proto == 17 and upper_len >= 8:
+        failures += _check_udp(src, dst, upper, stats)
+    elif proto == 47 and upper_len >= 4:
+        failures += _check_gre(src, dst, upper, stats, depth)
+    return failures
+
+
+def _check_icmpv6(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter
+) -> list[str]:
+    stats["icmpv6"] += 1
+    upper_len = len(upper)
+    zeroed = upper[:2] + b"\x00\x00" + upper[4:]
+    if (
+        internet_checksum(pseudo_v6(src, dst, 58, upper_len) + zeroed)
+        != struct.unpack_from("!H", upper, 2)[0]
+    ):
+        return ["icmpv6-checksum"]
+    return []
+
+
+def _check_tcp6(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter
+) -> list[str]:
+    stats["tcp6"] += 1
+    upper_len = len(upper)
+    zeroed = upper[:16] + b"\x00\x00" + upper[18:]
+    if (
+        internet_checksum(pseudo_v6(src, dst, 6, upper_len) + zeroed)
+        != struct.unpack_from("!H", upper, 16)[0]
+    ):
+        return ["tcp6-checksum"]
+    return []
+
+
+def _check_udp6(
+    src: bytes, dst: bytes, upper: bytes, stats: Counter
+) -> list[str]:
+    stats["udp6"] += 1
+    upper_len = len(upper)
+    zeroed = upper[:6] + b"\x00\x00" + upper[8:]
+    computed = (
+        internet_checksum(pseudo_v6(src, dst, 17, upper_len) + zeroed) or 0xFFFF
+    )
+    if computed != struct.unpack_from("!H", upper, 6)[0]:
+        return ["udp6-checksum"]
+    return []
+
+
+def _check_ipv6(payload: bytes, stats: Counter) -> list[str]:
+    failures: list[str] = []
+    stats["ipv6"] += 1
+    payload_length, next_header = struct.unpack_from("!HB", payload, 4)
+    src, dst = payload[8:24], payload[24:40]
+    upper = payload[40 : 40 + payload_length]
+    # Walk extension headers (hop-by-hop 0, routing 43, dest-opts 60).
+    while next_header in (0, 43, 60) and len(upper) >= 8:
+        stats["ipv6-ext-header"] += 1
+        ext_len = (upper[1] + 1) * 8
+        next_header, upper = upper[0], upper[ext_len:]
+    if next_header == 44 and len(upper) >= 8:
+        if struct.unpack_from("!H", upper, 2)[0] & 0xFFF8:
+            stats["ipv6-fragment"] += 1
+            return failures  # non-first fragment: no upper header
+        stats["ipv6-first-fragment"] += 1
+        # The upper-layer checksum spans the reassembled datagram, not
+        # this fragment's slice: nothing verifiable here.
+        return failures
+    upper_len = len(upper)
+    if next_header == 58 and upper_len >= 4:
+        failures += _check_icmpv6(src, dst, upper, stats)
+    elif next_header == 6 and upper_len >= 20:
+        failures += _check_tcp6(src, dst, upper, stats)
+    elif next_header == 17 and upper_len >= 8:
+        failures += _check_udp6(src, dst, upper, stats)
+    return failures
+
+
 def _check_l3(
     ethertype: int, payload: bytes, stats: Counter, depth: int = 0
 ) -> list[str]:
     """Validate the checksums reachable from an L3 payload named by
     ``ethertype``. Recurses through a GRE tunnel, whose inner protocol
     is itself an EtherType. Returns a list of failure strings."""
-    failures: list[str] = []
     if depth > 8:
-        return failures  # bound pathological tunnel nesting
+        return []  # bound pathological tunnel nesting
 
     if ethertype == 0x0806:
         stats["arp"] += 1
-        return failures
+        return []
 
     if ethertype == 0x0800 and len(payload) >= 20:
-        ihl = (payload[0] & 0x0F) * 4
-        header = payload[:ihl]
-        stats["ipv4"] += 1
-        if (
-            internet_checksum(header[:10] + b"\x00\x00" + header[12:ihl])
-            != struct.unpack_from("!H", header, 10)[0]
-        ):
-            failures.append("ipv4-header-checksum")
-        src, dst = header[12:16], header[16:20]
-        proto = header[9]
-        total_length = struct.unpack_from("!H", header, 2)[0]
-        flags_frag = struct.unpack_from("!H", header, 6)[0]
-        if flags_frag & 0x1FFF:
-            stats["ipv4-fragment"] += 1
-            return failures  # non-first fragment: no upper-layer header
-        if flags_frag & 0x2000 == 0x2000 and flags_frag & 0x1FFF == 0:
-            stats["ipv4-first-fragment"] += 1
-            return failures  # first fragment: upper checksum spans all parts
-        upper = payload[ihl:total_length]
-        upper_len = len(upper)
-        if proto == 1 and upper_len >= 8:
-            stats["icmpv4"] += 1
-            if (
-                internet_checksum(upper[:2] + b"\x00\x00" + upper[4:])
-                != struct.unpack_from("!H", upper, 2)[0]
-            ):
-                failures.append("icmpv4-checksum")
-        elif proto == 2 and upper_len >= 8:
-            stats["igmp"] += 1
-            # IGMP: whole message, checksum at bytes 2-3, no pseudo-header.
-            if (
-                internet_checksum(upper[:2] + b"\x00\x00" + upper[4:])
-                != struct.unpack_from("!H", upper, 2)[0]
-            ):
-                failures.append("igmp-checksum")
-        elif proto == 6 and upper_len >= 20:
-            stats["tcp"] += 1
-            zeroed = upper[:16] + b"\x00\x00" + upper[18:]
-            if (
-                internet_checksum(pseudo_v4(src, dst, 6, upper_len) + zeroed)
-                != struct.unpack_from("!H", upper, 16)[0]
-            ):
-                failures.append("tcp-checksum")
-        elif proto == 17 and upper_len >= 8:
-            stats["udp"] += 1
-            wire = struct.unpack_from("!H", upper, 6)[0]
-            if wire == 0:
-                stats["udp-no-checksum"] += 1
-            else:
-                zeroed = upper[:6] + b"\x00\x00" + upper[8:]
-                computed = (
-                    internet_checksum(
-                        pseudo_v4(src, dst, 17, upper_len) + zeroed
-                    )
-                    or 0xFFFF
-                )
-                if computed != wire:
-                    failures.append("udp-checksum")
-        elif proto == 47 and upper_len >= 4:
-            # GRE: a 4-byte header (flags word + inner EtherType) plus the
-            # optional checksum/key/sequence words the flag bits announce
-            # (RFC 2890), then the tunnelled packet — validated in turn.
-            stats["gre"] += 1
-            gre_flags = struct.unpack_from("!H", upper, 0)[0]
-            inner_ethertype = struct.unpack_from("!H", upper, 2)[0]
-            optional = (
-                (4 if gre_flags & 0x8000 else 0)
-                + (4 if gre_flags & 0x2000 else 0)
-                + (4 if gre_flags & 0x1000 else 0)
-            )
-            failures += _check_l3(
-                inner_ethertype, upper[4 + optional :], stats, depth + 1
-            )
-        return failures
+        return _check_ipv4(payload, stats, depth)
 
     if ethertype == 0x86DD and len(payload) >= 40:
-        stats["ipv6"] += 1
-        payload_length, next_header = struct.unpack_from("!HB", payload, 4)
-        src, dst = payload[8:24], payload[24:40]
-        upper = payload[40 : 40 + payload_length]
-        # Walk extension headers (hop-by-hop 0, routing 43, dest-opts 60).
-        while next_header in (0, 43, 60) and len(upper) >= 8:
-            stats["ipv6-ext-header"] += 1
-            ext_len = (upper[1] + 1) * 8
-            next_header, upper = upper[0], upper[ext_len:]
-        if next_header == 44 and len(upper) >= 8:
-            if struct.unpack_from("!H", upper, 2)[0] & 0xFFF8:
-                stats["ipv6-fragment"] += 1
-                return failures  # non-first fragment: no upper header
-            stats["ipv6-first-fragment"] += 1
-            # The upper-layer checksum spans the reassembled datagram,
-            # not this fragment's slice: nothing verifiable here.
-            return failures
-        upper_len = len(upper)
-        if next_header == 58 and upper_len >= 4:
-            stats["icmpv6"] += 1
-            zeroed = upper[:2] + b"\x00\x00" + upper[4:]
-            if (
-                internet_checksum(pseudo_v6(src, dst, 58, upper_len) + zeroed)
-                != struct.unpack_from("!H", upper, 2)[0]
-            ):
-                failures.append("icmpv6-checksum")
-        elif next_header == 6 and upper_len >= 20:
-            stats["tcp6"] += 1
-            zeroed = upper[:16] + b"\x00\x00" + upper[18:]
-            if (
-                internet_checksum(pseudo_v6(src, dst, 6, upper_len) + zeroed)
-                != struct.unpack_from("!H", upper, 16)[0]
-            ):
-                failures.append("tcp6-checksum")
-        elif next_header == 17 and upper_len >= 8:
-            stats["udp6"] += 1
-            zeroed = upper[:6] + b"\x00\x00" + upper[8:]
-            computed = (
-                internet_checksum(pseudo_v6(src, dst, 17, upper_len) + zeroed)
-                or 0xFFFF
-            )
-            if computed != struct.unpack_from("!H", upper, 6)[0]:
-                failures.append("udp6-checksum")
-        return failures
+        return _check_ipv6(payload, stats)
 
     stats[f"other-0x{ethertype:04x}"] += 1
-    return failures
+    return []
 
 
 def check_frame(frame: bytes, stats: Counter) -> list[str]:

--- a/scripts/pyodide/check_in_pyodide.py
+++ b/scripts/pyodide/check_in_pyodide.py
@@ -58,11 +58,11 @@ def install_wheel() -> None:
     """Extract the wheel built by the CI job's ``uv build`` step onto
     ``sys.path``, exactly as a real ``pip``/``micropip`` install would
     leave it, minus the network fetch micropip would otherwise need."""
+    import tempfile
     import zipfile
 
     (wheel,) = (REPO / "dist").glob("*.whl")
-    target = Path("/tmp/netprotocols-wheel")
-    target.mkdir(exist_ok=True)
+    target = Path(tempfile.mkdtemp(prefix="netprotocols-wheel-"))
     zipfile.ZipFile(wheel).extractall(target)
     sys.path.insert(0, str(target))
 

--- a/scripts/pyodide/check_in_pyodide.py
+++ b/scripts/pyodide/check_in_pyodide.py
@@ -22,12 +22,15 @@ with it, proving the library does its actual job here, not just that
 
 from __future__ import annotations
 
-import struct
 import sys
 from pathlib import Path
 
 REPO = Path("/repo")
 FIXTURES = REPO / "tests" / "fixtures"
+
+sys.path.insert(0, str(REPO / "scripts"))
+
+from _pcap import corpus_frames  # noqa: E402
 
 #: Modules scapy/dpkt need but Pyodide's WebAssembly build of CPython
 #: does not provide (no ioctls, ttys, rlimits, or /etc/passwd under
@@ -67,35 +70,6 @@ def install_wheel() -> None:
     sys.path.insert(0, str(target))
 
 
-def read_pcap(path: Path) -> list[bytes]:
-    """Minimal classic-pcap reader (standalone, like scripts/benchmark.py
-    and scripts/check_fixtures.py — this job must not depend on the
-    library it is trying to prove works)."""
-    data = path.read_bytes()
-    magic = data[:4]
-    if magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):
-        endian = ">"
-    elif magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):
-        endian = "<"
-    else:
-        raise ValueError(f"{path.name}: not a pcap")
-    frames, cursor = [], 24
-    while cursor + 16 <= len(data):
-        (incl_len,) = struct.unpack_from(f"{endian}I", data, cursor + 8)
-        cursor += 16
-        frames.append(data[cursor : cursor + incl_len])
-        cursor += incl_len
-    return frames
-
-
-def corpus_frames() -> list[bytes]:
-    return [
-        frame
-        for pcap in sorted(FIXTURES.glob("*.pcap"))
-        for frame in read_pcap(pcap)
-    ]
-
-
 def main() -> int:
     assert_posix_modules_absent()
     install_wheel()
@@ -103,7 +77,7 @@ def main() -> int:
     import netprotocols
     from netprotocols import ProtocolError, decode_frame
 
-    frames = corpus_frames()
+    frames = corpus_frames(FIXTURES)
     if len(frames) < 40:
         print(f"FAIL: corpus too small ({len(frames)} frames)")
         return 1


### PR DESCRIPTION
## Summary

Addresses the CodeFactor findings filed in #156 — all in `scripts/`, none touching the shipped `src/netprotocols` package. Closes #156.

## What's included

- **Insecure temp dir** (`scripts/pyodide/check_in_pyodide.py`): `install_wheel()` extracted the built wheel into a hardcoded, predictable `/tmp/netprotocols-wheel` path (mkdir + reuse). Switched to `tempfile.mkdtemp()`, which creates an unguessable, owner-only (`0o700`) directory with no separate exists-check/create race window.
- **Complex method** (`scripts/check_fixtures.py`): `_check_l3` was one 137-line function walking IPv4, IPv6, GRE tunneling, VLAN shims and every upper-layer checksum in a single branch tree. Split into a small dispatcher plus one function per protocol (`_check_ipv4`, `_check_ipv6`, `_check_icmpv4`, `_check_igmp`, `_check_tcp`, `_check_udp`, `_check_gre`, `_check_icmpv6`, `_check_tcp6`, `_check_udp6`). No behavior change.
- **Try/except/continue ×3** (`scripts/benchmark.py`): the two undocumented instances now carry a one-line comment explaining why the broad `except Exception` is correct here — `dpkt`/`scapy` have no shared "malformed frame" exception the way this project's own `ProtocolError` does, so this isn't a swallowed bug, it's the interop boundary. Behavior unchanged.
- **Duplicate code** (`scripts/benchmark.py` / `scripts/pyodide/check_in_pyodide.py`): the two scripts carried nearly byte-identical `read_pcap`/`corpus_frames` helpers. Extracted into a new `scripts/_pcap.py` — stdlib-only, no `netprotocols` import, so it preserves the actual independence property both scripts' docstrings document (independence from the library each one verifies, not from each other). `scripts/check_fixtures.py`'s own `read_pcap` is materially different (it also validates linktype and length) and was left untouched, since it was never part of this duplication.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (98 passed)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

Additional verification specific to this change:
- `scripts/check_fixtures.py`'s refactor was diffed for byte-identical stdout against the full 97-frame fixture corpus (`tests/fixtures/`) before and after.
- The `tempfile.mkdtemp()` fix and the `scripts/_pcap.py` extraction were both verified against a **real Pyodide runtime** (`node scripts/pyodide/run_in_pyodide.mjs`, the same driver CI's `pyodide` job uses) — the built wheel still installs and the full corpus still decodes cleanly with 0 unexpected exceptions.

## Notes

A first pass at this left the duplicate-code finding unaddressed, reasoning both scripts' docstrings required each verification path to stand fully independent of the others. An independent review of that reasoning found it didn't hold up — the docstrings' "standalone" language (and `CONTRIBUTING.md`'s own usage) scopes independence to *not depending on netprotocols*, never to independence from sibling scripts — so the second commit on this branch extracts the shared helper instead. Left as-is: nothing else needed further action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ba6LYsJosvNJXbmnxwDFav

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ba6LYsJosvNJXbmnxwDFav)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture validation across IPv4, IPv6, ICMP, TCP, UDP, and GRE traffic while preserving existing checksum, fragmentation, and protocol reporting.
  * Improved temporary file handling during Pyodide verification to avoid conflicts between concurrent checks.
  * Improved handling of classic pcap files, including byte order validation and invalid-file detection.

* **Chores**
  * Consolidated pcap fixture processing across benchmark and verification tools.
  * Added documentation for tooling updates and confirmed unchanged corpus decoding and fixture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->