### PR TITLE
refactor: code-quality review and cleanup before the next protocol wave

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -23,4 +23,4 @@ When a CI check fails or CodeRabbit (or any other bot/reviewer) reports a findin
 3. **Delegate review of that fix** to a second, separate sub-agent before pushing — distinct from the agent that implemented the fix. This agent should verify the fix actually closes the gap (ideally by constructing a case that would have slipped past the old code and confirming the new code catches it, not just that the reported symptom is gone), and check it didn't introduce the same class of bug elsewhere.
 4. Only after both steps pass does the fix get pushed and the finding marked resolved.
 
-This applies to fixes for CI-reported bugs specifically. It does not require every commit or every piece of new feature work in this repo to go through this two-step delegation — just the fix-a-bug-CI-found loop, where the risk of an author's blind spots recurring is highest.
+This applies to fixes for bugs reported by CI, CodeRabbit, another bot, or a human reviewer — the fix-a-reported-bug loop, where the risk of an author's blind spots recurring is highest. It does not require every commit or every piece of new feature work in this repo to go through this two-step delegation.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -1,0 +1,26 @@
+# Steward: driving PRs to green in this repo
+
+Repo-specific guidance for any Claude Code session babysitting, driving-to-green, or otherwise acting on an open pull request in this repository. This takes precedence over generic PR-babysitting conventions on the points below; it does not expand access or let a session skip anything those generic rules mark as "never."
+
+## Independent implementation and review for CI/CodeRabbit-reported bugs
+
+**Rule 1 — independent implementation.** A fix to a bug reported by CI (a failing check, a CodeRabbit finding, a bot review comment) must be implemented by an independent session or sub-agent — never by the same session/agent that authored the code the bug was found in.
+
+**Rule 2 — independent review.** Each such fix, once implemented, must be reviewed by another independent agent before proceeding (pushing, resolving the finding's thread, moving to the next item). This review is a separate pass from whichever agent wrote the fix.
+
+### Why this exists
+
+Observed directly on [PR #158](https://github.com/EONRaider/NETProtocols/pull/158): the same session that authored a refactor (source dedup, test hardening, new CI workflows) also implemented every fix for what CodeRabbit found in that code. This repeated the exact failure mode being fixed at least once — a regression test written to guard `mutation.yml`'s DNS mutation-testing scope checked `pattern in text` against the whole file rather than the actual executed command block, the same "checks vocabulary, not behavior" bug already fixed twice earlier in the same review pass (a `uses:` line-matching regex, and a reproducible-build test that checked for the word "reproducible" rather than an actual hash comparison). The author's own blind spots — the same assumptions and habits that produced the original bug — carried straight into the fix, and an external reviewer had to catch it again on the next round.
+
+An agent fixing its own bug tends to re-apply the same mental model that produced it. A fresh session or sub-agent, with no investment in the original approach, is more likely to notice when a fix is narrower than the problem, or repeats the original mistake in a new shape.
+
+### How to apply this in practice
+
+When a CI check fails or CodeRabbit (or any other bot/reviewer) reports a finding on a PR in this repo:
+
+1. **Diagnose** in the current session — reading the failure, the diff, and the relevant code is fine and doesn't need to be delegated.
+2. **Delegate the fix itself** to an independent sub-agent (e.g. via the Agent tool), giving it the finding and enough context to act, but without it inheriting the current session's authorship of the original code — it should approach the fix fresh, not defend or extend its own prior work.
+3. **Delegate review of that fix** to a second, separate sub-agent before pushing — distinct from the agent that implemented the fix. This agent should verify the fix actually closes the gap (ideally by constructing a case that would have slipped past the old code and confirming the new code catches it, not just that the reported symptom is gone), and check it didn't introduce the same class of bug elsewhere.
+4. Only after both steps pass does the fix get pushed and the finding marked resolved.
+
+This applies to fixes for CI-reported bugs specifically. It does not require every commit or every piece of new feature work in this repo to go through this two-step delegation — just the fix-a-bug-CI-found loop, where the risk of an author's blind spots recurring is highest.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  # --- Python tooling, managed by uv --------------------------------
+  #
+  # This project's dependencies are declared exclusively via PEP 735
+  # [dependency-groups] in pyproject.toml (see uv.lock), not the older
+  # [project.optional-dependencies] table. Dependabot's "pip" ecosystem
+  # does not parse [dependency-groups]; only the native "uv" ecosystem
+  # does (GA since March 2025, with dependency-groups parsing landing
+  # in dependabot/dependabot-core#11796), so "uv" is used here rather
+  # than "pip".
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # netprotocols ships zero runtime dependencies today, so every
+      # update currently comes from the "dev" dependency-group (pytest,
+      # mypy, ruff, etc.) -- kept current here as its own group rather
+      # than left to open one PR per package. Matched by explicit
+      # package name instead of `dependency-type: development`: as of
+      # this writing Dependabot's dependency-type classifier does not
+      # work correctly for the uv ecosystem and reports every
+      # dependency as "production" regardless of where it's declared
+      # (see dependabot/dependabot-core#13202), which would leave a
+      # `dependency-type: development` group empty -- or, used the
+      # other way around, wrongly sweep this same dev tooling into a
+      # "runtime" group. A future runtime dependency added under
+      # [project.dependencies] is intentionally left out of this list,
+      # so it keeps updating on its own outside this group rather than
+      # being bundled in with dev tooling.
+      dev-dependencies:
+        patterns:
+          - "hypothesis"
+          - "mypy"
+          - "pytest"
+          - "pytest-cov"
+          - "ruff"
+
+  # --- GitHub Actions -------------------------------------------------
+  #
+  # Keeps the SHA-pinned `uses:` references in .github/workflows current
+  # (Dependabot updates both the pinned SHA and its trailing `# vX.Y.Z`
+  # comment).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,22 @@ on:
   # definition means the release gate cannot drift from the PR gate.
   workflow_call:
 
+# Cancel a stale run the moment a newer one starts for the same branch
+# or pull request, so a quick follow-up push doesn't leave two ladders
+# racing for runners. Keyed on the PR number when this is a pull_request
+# run and on the ref otherwise, so push/workflow_call runs on distinct
+# refs (e.g. master vs. a release tag) never share a group and cancel
+# each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
       - run: uv run ruff check
@@ -24,8 +34,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
       - run: uv run mypy
@@ -36,19 +46,60 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv run --frozen pytest --cov=netprotocols --cov-report=term
 
+  # Scans the dev dependency group (the only third-party code CI itself
+  # pulls in) for known vulnerabilities. Exported with --no-emit-project
+  # so the audit sees pinned, hashed third-party requirements only --
+  # not an unhashable `-e .` reference to this repo's own in-tree
+  # package, which pip-audit cannot install under --require-hashes
+  # (implied automatically once any requirement carries a hash).
+  dependency-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: "3.12"
+      - name: Export dev dependencies
+        run: >-
+          uv export --group dev --format requirements-txt --no-emit-project
+          -o requirements-dev.txt
+      - name: Audit dev dependencies for known vulnerabilities
+        run: >-
+          uv run --with pip-audit --no-project
+          pip-audit -r requirements-dev.txt
+
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - run: uv build
       - run: uv run --isolated --no-project --with dist/*.whl python -c "import netprotocols; print(netprotocols.__version__)"
+      # Builds are supposed to be a pure function of the source tree, so
+      # two runs back-to-back must emit byte-identical wheels. Diffing
+      # their sha256 (rather than the files directly) catches drift
+      # from things like embedded timestamps or non-deterministic
+      # archive member ordering without needing a full binary diff.
+      - name: Verify the wheel build is reproducible
+        run: |
+          set -euo pipefail
+          uv build -o dist-repro-1
+          uv build -o dist-repro-2
+          hash1=$(sha256sum dist-repro-1/*.whl | cut -d ' ' -f1)
+          hash2=$(sha256sum dist-repro-2/*.whl | cut -d ' ' -f1)
+          echo "Build 1 sha256: $hash1"
+          echo "Build 2 sha256: $hash2"
+          if [ "$hash1" != "$hash2" ]; then
+            echo "::error::Wheel build is not reproducible: sha256 differs between two successive 'uv build' runs."
+            exit 1
+          fi
+          echo "Wheel build is reproducible."
 
   # Proves the README's browser/WASM claim (#99) against the real
   # thing, not a simulation of it: boots an actual Pyodide runtime
@@ -59,12 +110,12 @@ jobs:
   pyodide:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
       - run: uv build
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - run: npm ci
@@ -91,8 +142,8 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
       - name: Corpus decode throughput

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+# Advanced-setup workflow (a checked-in file) rather than GitHub's
+# built-in "default setup", so this analysis lives in version control
+# alongside the rest of this repository's CI (ci.yml, fuzz.yml,
+# release.yml, mutation.yml, scorecard.yml) and its action pins are
+# reviewable the same way theirs are. Default setup is configured
+# through repository settings instead of a file, so it isn't available
+# to author from here.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Arbitrary; weekly on Sundays, clear of fuzz.yml's and mutation.yml's
+    # daily 03:00/04:00 UTC slots and scorecard.yml's own Sunday 05:00
+    # UTC slot.
+    - cron: "0 6 * * 0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      # Python is interpreted, so there is nothing for autobuild (or a
+      # manual build step) to do: build-mode: none has CodeQL extract
+      # the database straight from source instead. This is the build
+      # mode the CodeQL Action's own docs recommend for interpreted
+      # languages, and it sidesteps the question of an autobuild step
+      # fitting this project's uv-based build at all.
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: python
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,75 @@
+name: Docs lint
+
+# Runs lycheeverse/lychee (a link checker) over the small set of
+# hand-maintained docs that carry the project's external claims and
+# cross-references: README.md, ARCHITECTURE.md, CONTRIBUTING.md,
+# CHANGELOG.md, and docs/CLAIMS.md. Two triggers, for two different
+# failure modes: the pull_request path filter catches a broken link
+# introduced *by* a docs edit, and the weekly schedule catches a link
+# that was fine when written but has since gone dead out from under an
+# otherwise-unchanged file (a renamed issue, a retired badge service, a
+# moved external page) -- which no docs PR would ever surface.
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "README.md"
+      - "ARCHITECTURE.md"
+      - "CONTRIBUTING.md"
+      - "CHANGELOG.md"
+      - "docs/CLAIMS.md"
+  schedule:
+    # Arbitrary; weekly on Mondays, clear of fuzz.yml's/mutation.yml's
+    # daily 03:00/04:00 UTC slots and scorecard.yml's Sunday 05:00 slot.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      # lychee-action's `token` input defaults to `${{ github.token }}`,
+      # which it exports as GITHUB_TOKEN; lychee reads that itself to
+      # check github.com links through the API instead of scraping the
+      # page. That's what keeps the ~15 github.com/EONRaider/NETProtocols
+      # issue/release links in these docs from tripping an anonymous
+      # rate limit -- most relevant on the weekly schedule run, which
+      # has no pull request author's own browsing to blend in with.
+      #
+      # --timeout/--max-retries/--retry-wait-time are more generous
+      # than lychee's own defaults (20s/3/1s) to absorb a slow or
+      # momentarily rate-limited external host without failing the
+      # build outright.
+      #
+      # --exclude covers img.shields.io, which serves this project's
+      # three static README badges: a shared, heavily-trafficked CDN
+      # known to intermittently rate-limit or time out under bulk/CI
+      # traffic across many unrelated repos, independent of whether
+      # any given badge URL is actually broken. Every other file was
+      # checked by hand for placeholder/example domains (example.com,
+      # localhost, and the like) before this workflow was added; none
+      # were found, so no other entries are excluded here.
+      - name: Check links in the project's hand-maintained docs
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --no-progress
+            --verbose
+            --timeout 30
+            --max-retries 3
+            --retry-wait-time 10
+            --exclude '^https://img\.shields\.io'
+            README.md
+            ARCHITECTURE.md
+            CONTRIBUTING.md
+            CHANGELOG.md
+            docs/CLAIMS.md

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,6 +12,10 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -29,8 +33,8 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
       # Keyed by run id with a prefix restore-key: a fixed key would
@@ -40,7 +44,7 @@ jobs:
       # today's as a new entry, so Hypothesis's example database grows
       # night over night instead of starting cold every time.
       - name: Restore accumulated Hypothesis examples
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .hypothesis
           key: hypothesis-nightly-${{ github.run_id }}
@@ -57,7 +61,7 @@ jobs:
       # repo write access to re-run the job locally.
       - name: Upload the failing example database
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hypothesis-nightly-failure-${{ github.run_id }}
           path: .hypothesis

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -47,17 +47,24 @@ jobs:
             mutmut-nightly-
       - name: Install the project with dev dependencies
         run: uv sync --group dev --frozen
-      # Scope (src/netprotocols/checksum.py, src/netprotocols/_tlv.py,
-      # and DNS's name-compression functions in
-      # src/netprotocols/layer7/dns.py) and the surviving-mutant
-      # threshold are both read from the project's mutmut config
-      # (pyproject.toml's [tool.mutmut] table), not hardcoded here, so
-      # this step and that config can't drift apart. That config —
-      # and the mutmut dependency itself — lands with the mutmut-audit
-      # item; until then this job is expected to fail for lack of
-      # either.
+      # File-level scope (src/netprotocols/checksum.py, _tlv.py, and
+      # dns.py) comes from the project's mutmut config (pyproject.toml's
+      # [tool.mutmut] table) via only_mutate, not hardcoded here.
+      # dns.py's in-scope surface is narrower still -- only the
+      # name-compression byte walk, not the record/RDATA/dataclass code
+      # the rest of the file holds -- and mutmut has no config-level way
+      # to express that, so these positional filters (kept in lockstep
+      # with the ones documented next to only_mutate in pyproject.toml)
+      # are what actually narrow it; a filter added or renamed there
+      # without a matching update here is exactly the kind of drift this
+      # comment can't prevent on its own.
       - name: Run mutmut against the scoped targets
-        run: uv run --frozen mutmut run
+        run: |
+          uv run --frozen mutmut run \
+            'netprotocols.checksum.*' \
+            'netprotocols._tlv.*' \
+            'netprotocols.layer7.dns.x__read_name*' \
+            'netprotocols.layer7.dns.x__labels*'
       # A failed scheduled run already notifies repo watchers by
       # default (GitHub's standard behavior) — that red run *is* the
       # report; nothing here files an issue on top of it. This just

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,78 @@
+name: Nightly mutation testing
+
+# Separate from ci.yml on purpose, same reasoning as fuzz.yml: ci.yml is
+# reused via workflow_call by release.yml, so folding a schedule trigger
+# into it would fire mutation testing on every release too, not just
+# once a night.
+on:
+  schedule:
+    # Arbitrary; offset an hour past fuzz.yml's 03:00 UTC slot so the
+    # two nightly jobs don't contend for the same runner pool.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Mutation testing itself is exploratory/maintenance, not a
+  # compatibility gate, so this is pinned to one interpreter — same
+  # reasoning as fuzz.yml's "fuzz" job.
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: "3.12"
+      # mutmut hashes each mutated file plus the tests that cover it and
+      # skips re-running mutants whose inputs haven't changed since the
+      # last recorded result, so carrying its cache forward night over
+      # night saves real work — same accumulation pattern as fuzz.yml's
+      # Hypothesis example database. Keyed by run id with a prefix
+      # restore-key for the same reason: a fixed key would restore
+      # forever but never save a new entry.
+      - name: Restore accumulated mutmut cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            .mutmut-cache
+            mutants
+          key: mutmut-nightly-${{ github.run_id }}
+          restore-keys: |
+            mutmut-nightly-
+      - name: Install the project with dev dependencies
+        run: uv sync --group dev --frozen
+      # Scope (src/netprotocols/checksum.py, src/netprotocols/_tlv.py,
+      # and DNS's name-compression functions in
+      # src/netprotocols/layer7/dns.py) and the surviving-mutant
+      # threshold are both read from the project's mutmut config
+      # (pyproject.toml's [tool.mutmut] table), not hardcoded here, so
+      # this step and that config can't drift apart. That config —
+      # and the mutmut dependency itself — lands with the mutmut-audit
+      # item; until then this job is expected to fail for lack of
+      # either.
+      - name: Run mutmut against the scoped targets
+        run: uv run --frozen mutmut run
+      # A failed scheduled run already notifies repo watchers by
+      # default (GitHub's standard behavior) — that red run *is* the
+      # report; nothing here files an issue on top of it. This just
+      # makes the surviving mutants recoverable without needing repo
+      # write access to re-run mutmut locally. Covers both the
+      # sqlite-file cache and the mutated-copies directory since either
+      # may be what a given mutmut version writes; whichever doesn't
+      # exist is silently skipped.
+      - name: Upload mutmut results on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mutmut-nightly-failure-${{ github.run_id }}
+          path: |
+            .mutmut-cache
+            mutants
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,33 @@
+name: PR Title Lint
+
+# Enforces Conventional Commits shape (https://www.conventionalcommits.org/)
+# on the *pull request title* only — e.g. `feat: ...`, `fix: ...`,
+# `docs: ...`, `chore: ...`. This is unrelated to this repo's guidance on
+# individual commit messages within a PR (see CONTRIBUTING.md); nothing
+# here checks or rewrites those.
+#
+# Runs on `pull_request` (not `pull_request_target`) so it only ever sees
+# the PR's own metadata with a read-only, non-elevated token — no need for
+# the elevated-permissions trigger the action's own docs suggest for
+# repos that also want its optional "[WIP]" title support, which this
+# repo doesn't use.
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags: ["v*"]
 
+# Serialize runs for the same tag/ref instead of cancelling one mid-publish:
+# a release that's already uploading to PyPI or cutting a GitHub release
+# must run to completion, so a re-trigger queues behind it rather than
+# tearing it down.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -23,10 +31,11 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      attestations: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - run: uv build
       # The QA ladder cannot catch a mistagged release: every check
       # passes because the code is fine and only the tag is wrong. Read
@@ -58,6 +67,16 @@ jobs:
             exit 1
           fi
           echo "Tag ${GITHUB_REF_NAME} matches packaged version ${built}."
+      # Lets anyone who downloads the wheel or sdist verify, via GitHub's
+      # attestation API, that this exact workflow run built it from this
+      # exact commit -- run before the artifacts are published so a
+      # failed attestation blocks the release instead of trailing it.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
       - run: uv publish --trusted-publishing always
 
   github-release:
@@ -66,7 +85,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       # CHANGELOG.md is the single source of truth for release notes, so
       # extract this tag's own section rather than maintaining a second
       # copy anywhere. A missing section fails loudly instead of

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+name: OSSF Scorecard
+
+# Separate from ci.yml, same reasoning as fuzz.yml and mutation.yml: ci.yml
+# is reused via workflow_call by release.yml, so folding a schedule trigger
+# into it would run this analysis on every release too, not just weekly.
+on:
+  push:
+    branches: [master]
+  schedule:
+    # Arbitrary; weekly on Sundays, clear of fuzz.yml's and mutation.yml's
+    # daily 03:00/04:00 UTC slots.
+    - cron: "0 5 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # The Scorecard team runs a weekly scan of public GitHub repos
+          # (https://github.com/ossf/scorecard#public-data). Setting
+          # publish_results: true feeds this workflow's own run into that
+          # dataset, which is what the README's api.securityscorecards.dev
+          # badge displays.
+          publish_results: true
+
+      # Upload the SARIF results as a workflow artifact, per the action's
+      # standard setup.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ benchmark.out
 # CI installs it fresh from package-lock.json, same as any other
 # lockfile-pinned dependency.
 scripts/pyodide/node_modules/
+
+# mutmut's mutation-testing workspace/cache
+mutants/
+.mutmut-cache

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -397,6 +397,8 @@ headers and `bytes(packet)` joins them, ready for a raw socket.
 src/netprotocols/
 ├── __init__.py     public API re-exports, __version__, registry install
 ├── _base.py        Protocol ABC, decode contract, address helpers
+├── _tlv.py         walk_kind_length_value(): shared TCP/IPv4/IPv6
+│                   options TLV walker
 ├── _enums.py       EtherType, IPProtocol, ARPOperation (imports nothing)
 ├── registry.py     public dispatch tables: register(), Registry
 ├── walk.py         decode_frame(): the shipped chain walker
@@ -457,7 +459,14 @@ the same:
    enforces it) and put the registration in `_defaults.py` alongside
    the rest. Numbers valid only inside an IPv6 chain go in
    `ip.proto.v6` rather than `ip.proto`, which is the whole of the
-   gating.
+   gating. Reuse the shared helpers rather than re-deriving the same
+   pattern in a new module: `hex_str`
+   ([`_base.py`](src/netprotocols/_base.py)) for a hex-formatted
+   field, the `_ip_protocol_enum`
+   ([`layer3/ip.py`](src/netprotocols/layer3/ip.py)) /
+   `_ethertype_enum` ([`layer2/ethernet.py`](src/netprotocols/layer2/ethernet.py))
+   pattern for an enum-or-`None` accessor, and `walk_kind_length_value`
+   ([`_tlv.py`](src/netprotocols/_tlv.py)) for TLV-shaped options.
 5. **Add display properties** for anything a human would want rendered
    (`flags_str`-style names, hex strings). Degrade gracefully on
    unknown values — return `"unknown (47)"`, never raise from a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Two enforcement points that are easy to miss:
   [`tests/test_fuzz.py`](tests/test_fuzz.py) so the "decode never
   escapes `ProtocolError`" property covers it.
 - **Enum lockstep.** The display-name completeness tests live in
-  `tests/test_ipv6_ext.py`; new enum members must have display names.
+  `tests/test_enums.py`; new enum members must have display names.
 
 ## Tests and the fixture corpus
 
@@ -138,6 +138,13 @@ file. Add an entry under `## [Unreleased]` in
   that's expected, not a failure on your end.
 - Commits and PRs describe the change and the reasoning; the diff shows
   the *what*, the message explains the *why*.
+- PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)
+  shape — a `type:` prefix such as `feat:`, `fix:`, `docs:`, or `chore:`
+  (optionally scoped, e.g. `feat(layer4):`) — checked automatically by
+  `.github/workflows/pr-title-lint.yml`. This governs only the PR title
+  itself; it says nothing about the shape of commit messages within the
+  PR — the *what*/*why* guidance just above is unaffected and still
+  applies to those.
 
 By contributing, you agree that your contributions are licensed under
 the project's [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ below, its reproduction command, and its caveats):
   and never touches the host doing it — importing scapy populates live
   interface and routing tables as a side effect of the import
   statement.
-- **An 88.3 KB wheel against scapy's 2.47 MB** — about 29× smaller.
+- **A 90.4 KiB wheel against scapy's 2.47 MiB** — 28.0× smaller.
 - **Regression-gated in CI, which — as far as we could establish by
   auditing ten comparable Python packet libraries' CI configurations
   (dpkt, scapy, pypacker, construct, pcapkit, dnspython, pyshark,

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CodeFactor](https://www.codefactor.io/repository/github/eonraider/netprotocols/badge/master)](https://www.codefactor.io/repository/github/eonraider/netprotocols/overview/master)
 [![CI](https://github.com/EONRaider/NETProtocols/actions/workflows/ci.yml/badge.svg)](https://github.com/EONRaider/NETProtocols/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/EONRaider/NETProtocols/badge)](https://securityscorecards.dev/viewer/?uri=github.com/EONRaider/NETProtocols)
 ![Python Version](https://img.shields.io/badge/python-3.12%2B-blue?logo=python)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 ![Typed](https://img.shields.io/badge/typing-strict-informational)

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -357,7 +357,7 @@ netprotocols **54.0 ms**, scapy.all **458.3 ms** — netprotocols imports
 **8.5× faster**, down from the implied ~14-21× at v1.3.0's "40 ms vs
 570-870 ms." netprotocols' own import cost grew (40 ms → 54 ms) as
 Tiers 2-4 added the registry, walker, diagnostics and new protocol
-modules; scapy's did not move enough to change the picture. Also: 92
+modules; scapy's did not move enough to change the picture. Also: 93
 modules loaded against `scapy.all`'s 259 (dpkt, not part of this claim:
 117 modules, 41.0 ms).
 
@@ -375,11 +375,11 @@ the prior figure here was built from `netprotocols-2.0.0`, two releases
 behind the tree every other number in this file now describes — this
 was stale, not a real regression.*
 
-88.3 KB wheel (`uv build`, `netprotocols-2.2.0-py3-none-any.whl`,
-90,390 bytes, deterministic across repeated builds) against scapy
+90.4 KB wheel (`uv build`, `netprotocols-2.2.1-py3-none-any.whl`,
+92,553 bytes, deterministic across repeated builds) against scapy
 2.7.0's 2.47 MB (2,590,982 bytes, current PyPI `bdist_wheel`) —
-**28.7× smaller**, down from the ~46× recorded at v1.3.0 and the 29.6×
-this section previously quoted from the 2.0.0-era build. 6,413 lines
+**28.0× smaller**, down from the ~46× recorded at v1.3.0 and the 29.6×
+this section previously quoted from the 2.0.0-era build. 6,466 lines
 (`wc -l` over `src/`) against scapy's unchanged 246,813 — netprotocols
 grew from 3,732 lines as Tiers 2-4 added the registry, walker,
 structured diagnostics and new protocol coverage, plus smaller
@@ -712,7 +712,7 @@ percentage read as stable across both drifts by coincidence: the miss
 count never moved while the codebase grew around it. Exactly the kind
 of thing Rule 4 exists to catch.*
 
-2,091 statements, 1 missed (99.95%). Enforced, not merely reported:
+2,052 statements, 1 missed (99.95%). Enforced, not merely reported:
 `[tool.coverage.report]` sets `fail_under = 98`, and the `test` CI job
 runs with `--cov-report=term` on every push and pull request, so a
 regression below the gate fails the build (#79).
@@ -908,7 +908,7 @@ except ProtocolError as e:
     # <class 'netprotocols.layer3.ip.IPv4'> ihl 0 14 >=5 0
 ```
 
-`protocol` is set at every one of the 62 raise sites in the library
+`protocol` is set at every one of the 60 raise sites in the library
 (verified by an AST sweep during development, not just by eye); `field`
 and `offset`/`frame_offset` are set wherever there's a byte position or
 a single attribute to name. `offset` is honestly scoped: relative to

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -375,9 +375,9 @@ the prior figure here was built from `netprotocols-2.0.0`, two releases
 behind the tree every other number in this file now describes — this
 was stale, not a real regression.*
 
-90.4 KB wheel (`uv build`, `netprotocols-2.2.1-py3-none-any.whl`,
+90.4 KiB wheel (`uv build`, `netprotocols-2.2.1-py3-none-any.whl`,
 92,553 bytes, deterministic across repeated builds) against scapy
-2.7.0's 2.47 MB (2,590,982 bytes, current PyPI `bdist_wheel`) —
+2.7.0's 2.47 MiB (2,590,982 bytes, current PyPI `bdist_wheel`) —
 **28.0× smaller**, down from the ~46× recorded at v1.3.0 and the 29.6×
 this section previously quoted from the 2.0.0-era build. 6,466 lines
 (`wc -l` over `src/`) against scapy's unchanged 246,813 — netprotocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ source = ["netprotocols"]
 
 [tool.coverage.report]
 show_missing = true
-# The suite covers 99% of 2091 statements; the only miss is Packet's
+# The suite covers 99% of 2052 statements; the only miss is Packet's
 # __eq__ NotImplemented branch. Gate at 98 rather than at the current
 # figure so a legitimately unreachable branch does not fail CI, and
 # well above it so the bar is actually held.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,24 @@ select = [
     "C4",        # flake8-comprehensions
     "SIM",       # flake8-simplify
     "RUF",       # ruff-specific
+    "D100", "D101", "D103", # pydocstyle: missing docstring on a
+                             # public module/class/function -- the
+                             # narrow slice of pydocstyle that already
+                             # holds repo-wide (see per-file-ignores)
+                             # without adopting its prose-style rules
+                             # (D2xx/D4xx) or its "public" definition's
+                             # blind spot for underscore-prefixed
+                             # helpers, which this can't catch.
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests rely on descriptive names, not docstrings, by established
+# convention (95 classes / 42 functions currently undocumented), and
+# scripts/ is maintainer-only benchmark/fixture tooling, not the
+# shipped package -- scoping the new pydocstyle rules to src/ avoids
+# mandating a sweep unrelated to what they exist to catch.
+"tests/*" = ["D100", "D101", "D103"]
+"scripts/*" = ["D100", "D101", "D103"]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ bench = [
 ]
 dev = [
     "hypothesis>=6.100",
+    "mutmut>=3.7.0",
     "mypy>=1.14",
     "pytest>=8.3",
     "pytest-cov>=6.0",
@@ -83,3 +84,46 @@ show_missing = true
 # figure so a legitimately unreachable branch does not fail CI, and
 # well above it so the bar is actually held.
 fail_under = 98
+
+[tool.mutmut]
+# Scoped mutation-testing audit (backlog: mutmut-audit), not a
+# full-codebase run: only the checksum module (every protocol's
+# checksum handling routes through it), the shared TLV walker, and
+# DNS's name-compression byte walk carry real correctness stakes dense
+# enough to justify the runtime. `source_paths` still lists the whole
+# `src` tree because mutmut mirrors it under `mutants/` to keep the
+# package importable; `only_mutate` is what actually narrows which
+# files get mutated (everything else is copied through unmodified).
+source_paths = ["src"]
+only_mutate = [
+    "src/netprotocols/checksum.py",
+    "src/netprotocols/_tlv.py",
+    "src/netprotocols/layer7/dns.py",
+]
+pytest_add_cli_args_test_selection = [
+    "tests/test_checksum.py",
+    "tests/test_tlv.py",
+    "tests/test_dns.py",
+]
+# dns.py's in-scope surface is narrower still: only the low-level
+# name-compression byte walk (_read_name/_labels and any private
+# helpers they call), not the record/question parsing built on top of
+# it. mutmut has no config-level way to scope below a whole file, so
+# reproduce the audited DNS slice with a `mutant_names` filter on top
+# of the file-level scope above:
+#   uv run mutmut run 'netprotocols.checksum.*' 'netprotocols._tlv.*' \
+#       'netprotocols.layer7.dns.x__read_name*' \
+#       'netprotocols.layer7.dns.x__labels*'
+# Mutants mutmut generates elsewhere in dns.py (record/RDATA parsing,
+# the DNS/DNSOverTCP dataclasses, ...) are out of scope for this audit
+# and were not triaged.
+#
+# Triage note — one accepted-equivalent survivor: `_pseudo_header`'s
+# IPv6 arm packs its 32-bit length field with `struct.pack("!IBBBB",
+# ...)`; a mutant swapping "I" for the signed "i" only diverges from
+# the original for a payload >= 2**31 bytes (2 GiB), which no test in
+# this suite can construct or run in reasonable time/memory. The same
+# mutation on the IPv4 arm's 16-bit length field *is* killed — see
+# test_ipv4_pseudo_header_length_field_is_unsigned in test_checksum.py,
+# which exercises the exact signed/unsigned boundary at a testable
+# (40 KB) scale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ select = [
 [tool.mypy]
 strict = true
 python_version = "3.12"
-files = ["src"]
+files = ["src", "tests/conftest.py", "tests/strategies.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,12 +118,21 @@ pytest_add_cli_args_test_selection = [
 # the DNS/DNSOverTCP dataclasses, ...) are out of scope for this audit
 # and were not triaged.
 #
-# Triage note — one accepted-equivalent survivor: `_pseudo_header`'s
-# IPv6 arm packs its 32-bit length field with `struct.pack("!IBBBB",
-# ...)`; a mutant swapping "I" for the signed "i" only diverges from
-# the original for a payload >= 2**31 bytes (2 GiB), which no test in
-# this suite can construct or run in reasonable time/memory. The same
-# mutation on the IPv4 arm's 16-bit length field *is* killed — see
-# test_ipv4_pseudo_header_length_field_is_unsigned in test_checksum.py,
-# which exercises the exact signed/unsigned boundary at a testable
-# (40 KB) scale.
+# Triage note — accepted-equivalent survivors (two, both true no-op
+# mutations rather than gaps in coverage):
+#
+# 1. `_pseudo_header`'s IPv6 arm packs its 32-bit length field with
+#    `struct.pack("!IBBBB", ...)`; a mutant swapping "I" for the
+#    signed "i" only diverges from the original for a payload
+#    >= 2**31 bytes (2 GiB), which no test in this suite can construct
+#    or run in reasonable time/memory. The same mutation on the IPv4
+#    arm's 16-bit length field *is* killed — see
+#    test_ipv4_pseudo_header_length_field_is_unsigned in
+#    test_checksum.py, which exercises the exact signed/unsigned
+#    boundary at a testable (40 KB) scale.
+#
+# 2. `_labels`' final label decode, `.decode("ascii", "replace")`, has
+#    a mutant that upper-cases the codec name to "ASCII". Python's
+#    codec lookup normalizes case, so "ascii" and "ASCII" name the
+#    exact same codec — every input decodes identically either way,
+#    with no observable difference for any test to catch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,10 @@ source = ["netprotocols"]
 
 [tool.coverage.report]
 show_missing = true
-# The suite covers 99% of 2052 statements; the only miss is Packet's
-# __eq__ NotImplemented branch. Gate at 98 rather than at the current
-# figure so a legitimately unreachable branch does not fail CI, and
-# well above it so the bar is actually held.
+# The suite covers 99.95% of 2052 statements (2051 hit, 1 miss); the
+# only miss is Packet's __eq__ NotImplemented branch. Gate at 98 rather
+# than at the current figure so a legitimately unreachable branch does
+# not fail CI, and well above it so the bar is actually held.
 fail_under = 98
 
 [tool.mutmut]

--- a/src/netprotocols/_base.py
+++ b/src/netprotocols/_base.py
@@ -56,6 +56,7 @@ __all__ = [
     "bytes_to_ipv4",
     "bytes_to_ipv6",
     "bytes_to_mac",
+    "hex_str",
     "ipv4_to_bytes",
     "ipv6_to_bytes",
     "mac_to_bytes",
@@ -186,6 +187,13 @@ def bytes_to_ipv6(data: bytes) -> str:
     head = ":".join(parts[:best_start])
     tail = ":".join(parts[best_start + best_len :])
     return f"{head}::{tail}"
+
+
+def hex_str(value: int, width: int) -> str:
+    """Render `value` as a hexadecimal string zero-padded to `width`
+    total characters including the '0x' prefix, e.g.
+    ``hex_str(0x1c2a, 6) == "0x1c2a"``."""
+    return f"{value:#0{width}x}"
 
 
 class Protocol(ABC):

--- a/src/netprotocols/_tlv.py
+++ b/src/netprotocols/_tlv.py
@@ -81,14 +81,25 @@ def walk_kind_length_value(
                 offset=cursor,
             )
         length = raw[cursor + 1]
-        if min_option_length is not None and length < min_option_length:
+        # When the length counts the kind and length bytes themselves,
+        # it can never validly be below 2 -- that floor is structural,
+        # not a per-caller policy, so it applies even if a future
+        # caller passes a lower (or no) min_option_length. Below 2,
+        # `end = cursor + length` would not advance past `cursor`,
+        # hanging the walk forever on a length of 0.
+        effective_min = min_option_length
+        if length_includes_header:
+            effective_min = (
+                2 if effective_min is None else max(2, effective_min)
+            )
+        if effective_min is not None and length < effective_min:
             raise InvalidFieldError(
                 f"{protocol.__name__} option length must be at least "
-                f"{min_option_length}, got {length}",
+                f"{effective_min}, got {length}",
                 protocol=protocol,
                 field=field,
                 offset=cursor,
-                expected=f">={min_option_length}",
+                expected=f">={effective_min}",
                 actual=length,
             )
         if length_includes_header:

--- a/src/netprotocols/_tlv.py
+++ b/src/netprotocols/_tlv.py
@@ -1,0 +1,114 @@
+"""Shared kind/length/value option-TLV walker.
+
+TCP options (RFC 9293 §3.2), IPv4 options (RFC 791 §3.1), and the two
+IPv6 TLV extension headers (RFC 8200 §4.2) all walk the same shape of
+blob: a sequence of kind (or type) bytes, most of them followed by a
+length byte and that many bytes of data. Three real differences
+separate them — TCP/IPv4 stop the walk early on an EOL byte and reject
+a length below 2, while IPv6 has neither a terminator nor a length
+floor; and TCP/IPv4's length byte counts itself and the kind byte,
+while IPv6's counts only the trailing data — so this module holds the
+one walker parameterized over those differences, and each call site
+differs only in how it wraps a ``(kind, data)`` pair into its own
+dataclass.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from netprotocols.utils.exceptions import InvalidFieldError
+
+__all__ = ["walk_kind_length_value"]
+
+
+def walk_kind_length_value(
+    raw: bytes,
+    *,
+    lone_byte_kinds: frozenset[int],
+    terminator_kind: int | None,
+    min_option_length: int | None,
+    length_includes_header: bool,
+    protocol: type,
+    field: str = "options",
+) -> Iterator[tuple[int, bytes]]:
+    """Walk a TLV-encoded options blob, yielding ``(kind, data)`` pairs
+    in wire order.
+
+    :param raw: The options bytes to walk.
+    :param lone_byte_kinds: Kind values that are a single byte with no
+        length or data (e.g. TCP/IPv4 EOL ``0``, NOP ``1``; IPv6 Pad1
+        ``0``) — yielded with ``data`` set to ``b""``.
+    :param terminator_kind: If set and this lone-byte kind is seen, the
+        walk stops right there without an error even if bytes remain
+        (TCP/IPv4's EOL, ``0``); ``None`` for IPv6, which has no
+        terminator per RFC 8200 — Pad1 does not stop the walk.
+    :param min_option_length: If set, a length byte smaller than this
+        raises (TCP/IPv4 require ``>=2``); ``None`` for IPv6, which has
+        no such floor.
+    :param length_includes_header: ``True`` for TCP/IPv4, where the
+        length byte counts the kind and length bytes themselves, so
+        the data slice is ``raw[cursor + 2 : cursor + length]`` and the
+        cursor advances by ``length``. ``False`` for IPv6, where the
+        length byte counts only the trailing data, so the data slice
+        is ``raw[cursor + 2 : cursor + 2 + length]`` and the cursor
+        advances by ``2 + length``.
+    :param protocol: The class to attach to a raised
+        :class:`~netprotocols.utils.exceptions.InvalidFieldError`
+        (also named in its message text via ``protocol.__name__``).
+    :param field: The field name to attach to a raised error; every
+        current caller parses an attribute named ``options``.
+
+    :raises InvalidFieldError: if a kind byte has no following length
+        byte, if a length is below ``min_option_length``, or if a
+        length would run past ``raw`` — bounded, so the walk never
+        hangs or over-reads regardless of what ``raw`` contains.
+    """
+    cursor = 0
+    while cursor < len(raw):
+        kind = raw[cursor]
+        if kind in lone_byte_kinds:
+            yield kind, b""
+            if terminator_kind is not None and kind == terminator_kind:
+                return
+            cursor += 1
+            continue
+        if cursor + 1 >= len(raw):
+            raise InvalidFieldError(
+                f"{protocol.__name__} option missing its length byte",
+                protocol=protocol,
+                field=field,
+                offset=cursor,
+            )
+        length = raw[cursor + 1]
+        if min_option_length is not None and length < min_option_length:
+            raise InvalidFieldError(
+                f"{protocol.__name__} option length must be at least "
+                f"{min_option_length}, got {length}",
+                protocol=protocol,
+                field=field,
+                offset=cursor,
+                expected=f">={min_option_length}",
+                actual=length,
+            )
+        if length_includes_header:
+            end = cursor + length
+            if end > len(raw):
+                raise InvalidFieldError(
+                    f"{protocol.__name__} option value runs past the "
+                    f"options bytes",
+                    protocol=protocol,
+                    field=field,
+                    offset=cursor,
+                )
+        else:
+            end = cursor + 2 + length
+            if end > len(raw):
+                raise InvalidFieldError(
+                    f"{protocol.__name__} option data runs past the header",
+                    protocol=protocol,
+                    field=field,
+                    offset=cursor,
+                )
+        yield kind, raw[cursor + 2 : end]
+        cursor = end

--- a/src/netprotocols/layer2/arp.py
+++ b/src/netprotocols/layer2/arp.py
@@ -16,6 +16,7 @@ from netprotocols._base import (
     mac_to_bytes,
 )
 from netprotocols._enums import ARPHardwareType, ARPOperation, EtherType
+from netprotocols.layer2.ethernet import _ethertype_enum, _ethertype_name
 from netprotocols.utils.ipv4 import validate_ipv4_addr
 from netprotocols.utils.mac import validate_mac_addr
 
@@ -116,20 +117,14 @@ class ARP(Protocol):
     @property
     def ptype_name(self) -> str:
         """Display name of the protocol type, e.g. ``"IPv4"``."""
-        try:
-            return EtherType(self.ptype).display_name
-        except ValueError:
-            return f"{self.ptype:#06x}"
+        return _ethertype_name(self.ptype)
 
     @property
     def ptype_enum(self) -> EtherType | None:
         """The protocol type as an :class:`~netprotocols.EtherType` (see
         :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
         value this library does not enumerate."""
-        try:
-            return EtherType(self.ptype)
-        except ValueError:
-            return None
+        return _ethertype_enum(self.ptype)
 
     @property
     def ptype_hex_str(self) -> str:

--- a/src/netprotocols/layer2/arp.py
+++ b/src/netprotocols/layer2/arp.py
@@ -11,6 +11,7 @@ from netprotocols._base import (
     Protocol,
     bytes_to_ipv4,
     bytes_to_mac,
+    hex_str,
     ipv4_to_bytes,
     mac_to_bytes,
 )
@@ -133,7 +134,7 @@ class ARP(Protocol):
     @property
     def ptype_hex_str(self) -> str:
         """The protocol type as a hexadecimal string, e.g. ``"0x0800"``."""
-        return f"{self.ptype:#06x}"
+        return hex_str(self.ptype, 6)
 
     @property
     def htype_name(self) -> str:

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -46,6 +46,13 @@ def _ethertype_name(ethertype: int) -> str:
         return f"{ethertype:#06x}"
 
 
+def _ethertype_enum(ethertype: int) -> EtherType | None:
+    try:
+        return EtherType(ethertype)
+    except ValueError:
+        return None
+
+
 @dataclass(frozen=True, slots=True)
 class Ethernet(Protocol):
     """An Ethernet II header.
@@ -102,7 +109,4 @@ class Ethernet(Protocol):
         ``None`` for a value this library does not enumerate;
         :attr:`ethertype` stays the canonical ``int`` and round-trips
         regardless (see :attr:`ethertype_name` for the display form)."""
-        try:
-            return EtherType(self.ethertype)
-        except ValueError:
-            return None
+        return _ethertype_enum(self.ethertype)

--- a/src/netprotocols/layer2/ethernet.py
+++ b/src/netprotocols/layer2/ethernet.py
@@ -47,6 +47,8 @@ def _ethertype_name(ethertype: int) -> str:
 
 
 def _ethertype_enum(ethertype: int) -> EtherType | None:
+    """The ``EtherType`` member for a numeric value, or ``None`` if it
+    isn't one this library recognizes."""
     try:
         return EtherType(ethertype)
     except ValueError:

--- a/src/netprotocols/layer2/vlan.py
+++ b/src/netprotocols/layer2/vlan.py
@@ -24,7 +24,11 @@ from typing import ClassVar, Self
 
 from netprotocols._base import Protocol
 from netprotocols._enums import EtherType
-from netprotocols.layer2.ethernet import _ethertype_class, _ethertype_name
+from netprotocols.layer2.ethernet import (
+    _ethertype_class,
+    _ethertype_enum,
+    _ethertype_name,
+)
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import InvalidFieldError
 
@@ -110,7 +114,4 @@ class VLAN(Protocol):
         :class:`~netprotocols.EtherType` (see
         :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
         value this library does not enumerate."""
-        try:
-            return EtherType(self.ethertype)
-        except ValueError:
-            return None
+        return _ethertype_enum(self.ethertype)

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol
+from netprotocols._base import Protocol, hex_str
 from netprotocols._enums import EtherType
 from netprotocols.layer2.ethernet import _ethertype_class, _ethertype_name
 from netprotocols.registry import Registry
@@ -170,4 +170,4 @@ class GRE(Protocol):
         """The checksum as a hexadecimal string, e.g. ``"0x1c2a"``, or
         ``None`` when no checksum is present."""
         checksum = self.checksum
-        return None if checksum is None else f"{checksum:#06x}"
+        return None if checksum is None else hex_str(checksum, 6)

--- a/src/netprotocols/layer3/gre.py
+++ b/src/netprotocols/layer3/gre.py
@@ -23,7 +23,11 @@ from typing import ClassVar, Self
 
 from netprotocols._base import Protocol, hex_str
 from netprotocols._enums import EtherType
-from netprotocols.layer2.ethernet import _ethertype_class, _ethertype_name
+from netprotocols.layer2.ethernet import (
+    _ethertype_class,
+    _ethertype_enum,
+    _ethertype_name,
+)
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import TruncatedHeaderError
 
@@ -128,10 +132,7 @@ class GRE(Protocol):
         """``protocol_type`` as an :class:`~netprotocols.EtherType` (see
         :attr:`~netprotocols.Ethernet.ethertype_enum`); ``None`` for a
         value this library does not enumerate."""
-        try:
-            return EtherType(self.protocol_type)
-        except ValueError:
-            return None
+        return _ethertype_enum(self.protocol_type)
 
     @property
     def checksum(self) -> int | None:

--- a/src/netprotocols/layer3/icmp.py
+++ b/src/netprotocols/layer3/icmp.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol, bytes_to_ipv6, bytes_to_mac
+from netprotocols._base import Protocol, bytes_to_ipv6, bytes_to_mac, hex_str
 from netprotocols.layer3.ip import IPv4, IPv6
 from netprotocols.packet import Packet
 from netprotocols.utils.exceptions import InvalidFieldError
@@ -163,7 +163,7 @@ class _ICMP(Protocol):
     @property
     def checksum_hex_str(self) -> str:
         """The checksum as a hexadecimal string, e.g. ``"0x83f7"``."""
-        return f"{self.checksum:#06x}"
+        return hex_str(self.checksum, 6)
 
     # -- message-specific fields (read on demand, never re-encoded) --
 

--- a/src/netprotocols/layer3/igmp.py
+++ b/src/netprotocols/layer3/igmp.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol, bytes_to_ipv4
+from netprotocols._base import Protocol, bytes_to_ipv4, hex_str
 from netprotocols.utils.exceptions import InvalidFieldError
 
 __all__ = ["IGMP", "IGMPv3GroupRecord"]
@@ -289,4 +289,4 @@ class IGMP(Protocol):
     @property
     def checksum_hex_str(self) -> str:
         """The checksum as a hexadecimal string, e.g. ``"0x0b3a"``."""
-        return f"{self.checksum:#06x}"
+        return hex_str(self.checksum, 6)

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -25,6 +25,7 @@ from netprotocols._base import (
     ipv6_to_bytes,
 )
 from netprotocols._enums import IPProtocol
+from netprotocols._tlv import walk_kind_length_value
 from netprotocols.registry import (
     DEFAULT,
     TABLE_IP_PROTO,
@@ -81,11 +82,21 @@ def _ip_protocol_name(number: int) -> str:
         return f"unknown ({number})"
 
 
+def _ip_protocol_enum(number: int) -> IPProtocol | None:
+    try:
+        return IPProtocol(number)
+    except ValueError:
+        return None
+
+
 #: Single-byte IPv4 option kinds that carry no length or value
 #: (RFC 791 §3.1): End of Option List terminates the parse,
 #: No-Operation pads.
 _OPT_EOL = 0
 _OPT_NOP = 1
+
+#: The lone-byte kinds, precomputed once for :func:`.walk_kind_length_value`.
+_LONE_BYTE_KINDS = frozenset({_OPT_EOL, _OPT_NOP})
 
 #: Option kinds this library decodes a typed :attr:`IPv4Option.value`
 #: for, beyond naming (RFC 791 §3.1; RFC 2113 for Router Alert).
@@ -381,10 +392,7 @@ class IPv4(Protocol):
         library does not enumerate; :attr:`protocol` stays the
         canonical ``int`` (see :attr:`protocol_name` for the display
         form)."""
-        try:
-            return IPProtocol(self.protocol)
-        except ValueError:
-            return None
+        return _ip_protocol_enum(self.protocol)
 
     @property
     def flags_name(self) -> str:
@@ -425,46 +433,17 @@ class IPv4(Protocol):
             below the 2-byte minimum or runs past the options bytes
             (bounded — never hangs or over-reads).
         """
-        raw = self.options
-        parsed: list[IPv4Option] = []
-        cursor = 0
-        while cursor < len(raw):
-            kind = raw[cursor]
-            if kind in (_OPT_EOL, _OPT_NOP):
-                parsed.append(IPv4Option(kind=kind))
-                if kind == _OPT_EOL:
-                    break
-                cursor += 1
-                continue
-            if cursor + 1 >= len(raw):
-                raise InvalidFieldError(
-                    "IPv4 option missing its length byte",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            length = raw[cursor + 1]
-            if length < 2:
-                raise InvalidFieldError(
-                    f"IPv4 option length must be at least 2, got {length}",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                    expected=">=2",
-                    actual=length,
-                )
-            if cursor + length > len(raw):
-                raise InvalidFieldError(
-                    "IPv4 option value runs past the options bytes",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            parsed.append(
-                IPv4Option(kind=kind, data=raw[cursor + 2 : cursor + length])
+        return tuple(
+            IPv4Option(kind=kind, data=data)
+            for kind, data in walk_kind_length_value(
+                self.options,
+                lone_byte_kinds=_LONE_BYTE_KINDS,
+                terminator_kind=_OPT_EOL,
+                min_option_length=2,
+                length_includes_header=True,
+                protocol=type(self),
             )
-            cursor += length
-        return tuple(parsed)
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -543,10 +522,7 @@ class IPv6(Protocol):
         :class:`~netprotocols.IPProtocol` (see
         :attr:`IPv4.protocol_enum`); ``None`` for a value this library
         does not enumerate."""
-        try:
-            return IPProtocol(self.next_header)
-        except ValueError:
-            return None
+        return _ip_protocol_enum(self.next_header)
 
     @property
     def traffic_class_hex_str(self) -> str:

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -20,6 +20,7 @@ from netprotocols._base import (
     Protocol,
     bytes_to_ipv4,
     bytes_to_ipv6,
+    hex_str,
     ipv4_to_bytes,
     ipv6_to_bytes,
 )
@@ -394,7 +395,7 @@ class IPv4(Protocol):
     @property
     def checksum_hex_str(self) -> str:
         """The header checksum as a hexadecimal string, e.g. ``"0xf24e"``."""
-        return f"{self.checksum:#06x}"
+        return hex_str(self.checksum, 6)
 
     @property
     def src_address(self) -> IPv4Address:
@@ -550,12 +551,12 @@ class IPv6(Protocol):
     @property
     def traffic_class_hex_str(self) -> str:
         """The traffic class as a hexadecimal string, e.g. ``"0x00"``."""
-        return f"{self.traffic_class:#04x}"
+        return hex_str(self.traffic_class, 4)
 
     @property
     def flow_label_hex_str(self) -> str:
         """The flow label as a hexadecimal string, e.g. ``"0x9f8c3"``."""
-        return f"{self.flow_label:#07x}"
+        return hex_str(self.flow_label, 7)
 
     @property
     def src_address(self) -> IPv6Address:

--- a/src/netprotocols/layer3/ip.py
+++ b/src/netprotocols/layer3/ip.py
@@ -83,6 +83,8 @@ def _ip_protocol_name(number: int) -> str:
 
 
 def _ip_protocol_enum(number: int) -> IPProtocol | None:
+    """The ``IPProtocol`` member for a numeric value, or ``None`` if it
+    isn't one this library recognizes."""
     try:
         return IPProtocol(number)
     except ValueError:

--- a/src/netprotocols/layer3/ipv6_ext.py
+++ b/src/netprotocols/layer3/ipv6_ext.py
@@ -25,7 +25,12 @@ from typing import ClassVar, Self
 
 from netprotocols._base import Protocol, bytes_to_ipv6
 from netprotocols._enums import IPProtocol
-from netprotocols.layer3.ip import _ip_protocol_class, _ip_protocol_name
+from netprotocols._tlv import walk_kind_length_value
+from netprotocols.layer3.ip import (
+    _ip_protocol_class,
+    _ip_protocol_enum,
+    _ip_protocol_name,
+)
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import (
     InvalidFieldError,
@@ -43,6 +48,9 @@ __all__ = [
 #: The one option type that is a lone byte with no length or data
 #: (RFC 8200 §4.2): Pad1, one byte of padding.
 _OPT_PAD1 = 0
+
+#: The lone-byte kinds, precomputed once for :func:`.walk_kind_length_value`.
+_LONE_BYTE_KINDS = frozenset({_OPT_PAD1})
 
 #: Option types this library decodes a typed :attr:`IPv6Option.value`
 #: for, beyond naming.
@@ -195,10 +203,7 @@ class _IPv6OptionsHeader(Protocol):
         :class:`~netprotocols.IPProtocol` (see
         :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
         this library does not enumerate."""
-        try:
-            return IPProtocol(self.next_header)
-        except ValueError:
-            return None
+        return _ip_protocol_enum(self.next_header)
 
     @property
     def parsed_options(self) -> tuple[IPv6Option, ...]:
@@ -211,39 +216,17 @@ class _IPv6OptionsHeader(Protocol):
             missing or its data runs past the header (bounded — never
             hangs or over-reads).
         """
-        raw = self.options
-        parsed: list[IPv6Option] = []
-        cursor = 0
-        while cursor < len(raw):
-            option_type = raw[cursor]
-            if option_type == _OPT_PAD1:
-                parsed.append(IPv6Option(type=option_type))
-                cursor += 1
-                continue
-            if cursor + 1 >= len(raw):
-                raise InvalidFieldError(
-                    f"{self.__class__.__name__} option missing its length byte",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            length = raw[cursor + 1]
-            if cursor + 2 + length > len(raw):
-                raise InvalidFieldError(
-                    f"{self.__class__.__name__} option data runs past the "
-                    f"header",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            parsed.append(
-                IPv6Option(
-                    type=option_type,
-                    data=raw[cursor + 2 : cursor + 2 + length],
-                )
+        return tuple(
+            IPv6Option(type=option_type, data=data)
+            for option_type, data in walk_kind_length_value(
+                self.options,
+                lone_byte_kinds=_LONE_BYTE_KINDS,
+                terminator_kind=None,
+                min_option_length=None,
+                length_includes_header=False,
+                protocol=type(self),
             )
-            cursor += 2 + length
-        return tuple(parsed)
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -360,10 +343,7 @@ class IPv6Routing(Protocol):
         :class:`~netprotocols.IPProtocol` (see
         :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
         this library does not enumerate."""
-        try:
-            return IPProtocol(self.next_header)
-        except ValueError:
-            return None
+        return _ip_protocol_enum(self.next_header)
 
     @property
     def segments(self) -> tuple[IPv6Address, ...] | None:
@@ -464,7 +444,4 @@ class IPv6Fragment(Protocol):
         :class:`~netprotocols.IPProtocol` (see
         :attr:`~netprotocols.IPv4.protocol_enum`); ``None`` for a value
         this library does not enumerate."""
-        try:
-            return IPProtocol(self.next_header)
-        except ValueError:
-            return None
+        return _ip_protocol_enum(self.next_header)

--- a/src/netprotocols/layer4/tcp.py
+++ b/src/netprotocols/layer4/tcp.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol
+from netprotocols._base import Protocol, hex_str
 from netprotocols.layer4._ports import tcp_app_class
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import (
@@ -270,12 +270,12 @@ class TCP(Protocol):
     @property
     def flags_hex_str(self) -> str:
         """The flag bits as a hexadecimal string, e.g. ``"0x012"``."""
-        return f"{self.flags:#05x}"
+        return hex_str(self.flags, 5)
 
     @property
     def checksum_hex_str(self) -> str:
         """The checksum as a hexadecimal string, e.g. ``"0x2e5b"``."""
-        return f"{self.checksum:#06x}"
+        return hex_str(self.checksum, 6)
 
     # -- options TLV list (parsed on demand, never re-encoded) --
 

--- a/src/netprotocols/layer4/tcp.py
+++ b/src/netprotocols/layer4/tcp.py
@@ -16,6 +16,7 @@ from struct import Struct
 from typing import ClassVar, Self
 
 from netprotocols._base import Protocol, hex_str
+from netprotocols._tlv import walk_kind_length_value
 from netprotocols.layer4._ports import tcp_app_class
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import (
@@ -29,6 +30,9 @@ __all__ = ["TCP", "TCPOption"]
 #: §3.2): End of Option List terminates the parse, No-Operation pads.
 _OPT_EOL = 0
 _OPT_NOP = 1
+
+#: The lone-byte kinds, precomputed once for :func:`.walk_kind_length_value`.
+_LONE_BYTE_KINDS = frozenset({_OPT_EOL, _OPT_NOP})
 
 #: Kind/length/value option kinds this library decodes.
 _OPT_MSS = 2
@@ -291,43 +295,14 @@ class TCP(Protocol):
             below the 2-byte TLV minimum or runs past the options bytes
             (bounded — never hangs or over-reads).
         """
-        raw = self.options
-        parsed: list[TCPOption] = []
-        cursor = 0
-        while cursor < len(raw):
-            kind = raw[cursor]
-            if kind in (_OPT_EOL, _OPT_NOP):
-                parsed.append(TCPOption(kind=kind))
-                if kind == _OPT_EOL:
-                    break
-                cursor += 1
-                continue
-            if cursor + 1 >= len(raw):
-                raise InvalidFieldError(
-                    "TCP option missing its length byte",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            length = raw[cursor + 1]
-            if length < 2:
-                raise InvalidFieldError(
-                    f"TCP option length must be at least 2, got {length}",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                    expected=">=2",
-                    actual=length,
-                )
-            if cursor + length > len(raw):
-                raise InvalidFieldError(
-                    "TCP option value runs past the options bytes",
-                    protocol=type(self),
-                    field="options",
-                    offset=cursor,
-                )
-            parsed.append(
-                TCPOption(kind=kind, data=raw[cursor + 2 : cursor + length])
+        return tuple(
+            TCPOption(kind=kind, data=data)
+            for kind, data in walk_kind_length_value(
+                self.options,
+                lone_byte_kinds=_LONE_BYTE_KINDS,
+                terminator_kind=_OPT_EOL,
+                min_option_length=2,
+                length_includes_header=True,
+                protocol=type(self),
             )
-            cursor += length
-        return tuple(parsed)
+        )

--- a/src/netprotocols/layer4/udp.py
+++ b/src/netprotocols/layer4/udp.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from struct import Struct
 from typing import ClassVar, Self
 
-from netprotocols._base import Protocol
+from netprotocols._base import Protocol, hex_str
 from netprotocols.layer4._ports import udp_app_class
 from netprotocols.registry import Registry
 
@@ -58,4 +58,4 @@ class UDP(Protocol):
     @property
     def checksum_hex_str(self) -> str:
         """The checksum as a hexadecimal string, e.g. ``"0x1c2a"``."""
-        return f"{self.checksum:#06x}"
+        return hex_str(self.checksum, 6)

--- a/src/netprotocols/layer7/dns.py
+++ b/src/netprotocols/layer7/dns.py
@@ -19,7 +19,7 @@ from ipaddress import IPv4Address, IPv6Address
 from struct import Struct
 from typing import ClassVar, NamedTuple, Self
 
-from netprotocols._base import Protocol, bytes_to_ipv4, bytes_to_ipv6
+from netprotocols._base import Protocol, bytes_to_ipv4, bytes_to_ipv6, hex_str
 from netprotocols.registry import Registry
 from netprotocols.utils.exceptions import InvalidFieldError
 
@@ -603,7 +603,7 @@ class DNS(Protocol):
     @property
     def flags_hex_str(self) -> str:
         """The flags word as a hexadecimal string, e.g. ``"0x8180"``."""
-        return f"{self.flags:#06x}"
+        return hex_str(self.flags, 6)
 
     # -- first question (parsed on demand, never re-encoded) --
 

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -130,7 +130,9 @@ def ipv6_headers(draw: st.DrawFn) -> IPv6:
     )
 
 
-def _ipv6_options_headers[P: Protocol](cls: type[P]) -> st.SearchStrategy[P]:
+def _ipv6_options_headers[P: (IPv6HopByHopOptions, IPv6DestinationOptions)](
+    cls: type[P],
+) -> st.SearchStrategy[P]:
     """Shared strategy for the two TLV-style extension headers
     (:class:`IPv6HopByHopOptions`, :class:`IPv6DestinationOptions`):
     ``hdr_ext_len`` and ``options`` are the interdependent pair —
@@ -168,7 +170,7 @@ def ipv6_routing_headers(draw: st.DrawFn) -> IPv6Routing:
     )
 
 
-def _icmp_headers[P: Protocol](cls: type[P]) -> st.SearchStrategy[P]:
+def _icmp_headers[P: (ICMPv4, ICMPv6)](cls: type[P]) -> st.SearchStrategy[P]:
     """Shared strategy for :class:`ICMPv4`/:class:`ICMPv6`: both are
     the same shape (``rest`` fixed at 4 bytes, ``body`` free)."""
 

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -8,6 +8,7 @@ from conftest import corpus_frames
 from netprotocols import (
     ARP,
     GRE,
+    IGMP,
     TCP,
     UDP,
     Ethernet,
@@ -110,6 +111,22 @@ class TestCorpusChecksums:
             assert compute(header) == header.checksum
             assert verify(header)
 
+    def test_igmp_checksums_recompute_to_wire_values(self):
+        """IGMP has no pseudo-header and ignores ``payload`` (its body
+        is already part of ``bytes(layer)``) — the one arm of
+        :func:`compute`/:func:`verify` the transport-checksum cases
+        above never exercise."""
+        igmp_layers = [
+            layer
+            for _, _, frame in CORPUS
+            for layer in walk(frame)[0]
+            if isinstance(layer, IGMP)
+        ]
+        assert igmp_layers
+        for igmp in igmp_layers:
+            assert compute(igmp) == igmp.checksum
+            assert verify(igmp)
+
     def test_corrupted_byte_is_detected(self):
         _, transport, ip, payload = CASES[0]
         corrupted = (
@@ -155,8 +172,15 @@ class TestGREChecksum:
 
     def test_computing_without_the_checksum_bit_is_rejected(self):
         plain = GRE(flags=0, protocol_type=0x0800)
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             compute(plain, payload=b"x")
+        err = excinfo.value
+        assert err.protocol is GRE
+        assert err.field == "checksum"
+        assert str(err) == (
+            "Computing a GRE checksum requires the Checksum-Present "
+            "bit and its field (RFC 2784 §2.5)"
+        )
 
     def test_checksum_bit_without_its_field_is_rejected(self):
         broken = GRE(flags=0x8000, protocol_type=0x0800)  # no fields
@@ -266,10 +290,41 @@ class TestChecksumRules:
                 return
         pytest.fail("no payload drove the TCP checksum to 0x0000")
 
-    def test_pseudo_header_layers_require_ip(self):
-        udp, _ = self.make_udp(0)
-        with pytest.raises(InvalidFieldError):
-            compute(udp)
+    @pytest.mark.parametrize(
+        "layer",
+        [
+            UDP(src_port=53, dst_port=4242, length=12, checksum=0),
+            TCP(
+                src_port=1,
+                dst_port=2,
+                seq=0,
+                ack=0,
+                data_offset=5,
+                reserved=0,
+                flags=0,
+                window=0,
+                checksum=0,
+                urgent_pointer=0,
+            ),
+            ICMPv6(type=128, code=0, checksum=0, rest=b"\x00" * 4),
+        ],
+        ids=["udp", "tcp", "icmpv6"],
+    )
+    def test_pseudo_header_layers_require_ip(self, layer):
+        """Every pseudo-header layer's missing-``ip`` error names its
+        own class — regression against `compute`'s ICMPv6/TCP/UDP arms
+        losing track of which layer asked (each passes `layer` through
+        to `_require_ip`, which only uses it to build this message)."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            compute(layer)
+        err = excinfo.value
+        assert err.protocol is type(layer)
+        assert err.field == "checksum"
+        assert str(err) == (
+            f"Computing a {type(layer).__name__} checksum requires the "
+            f"enclosing IPv4/IPv6 layer (its pseudo-header covers the "
+            f"addresses)"
+        )
 
     def test_layers_without_checksums_are_rejected(self):
         eth = Ethernet(
@@ -277,8 +332,55 @@ class TestChecksumRules:
             src="00:07:0d:af:f4:54",
             ethertype=0x0800,
         )
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             compute(eth)
+        err = excinfo.value
+        assert err.protocol is Ethernet
+        assert err.field == "checksum"
+        assert str(err) == "Ethernet has no checksum field to compute"
+
+    def test_compute_payload_defaults_to_empty_bytes(self):
+        """`compute`'s ``payload`` parameter defaults to ``b""`` —
+        regression against a corrupted default silently changing every
+        checksum computed without an explicit payload."""
+        icmp = ICMPv4(type=8, code=0, checksum=0, rest=b"\x00" * 4)
+        assert compute(icmp) == compute(icmp, payload=b"")
+
+    def test_verify_payload_defaults_to_empty_bytes(self):
+        from dataclasses import replace
+
+        icmp = ICMPv4(type=8, code=0, checksum=0, rest=b"\x00" * 4)
+        filled = replace(icmp, checksum=compute(icmp))
+        assert verify(filled)
+        assert verify(filled) == verify(filled, payload=b"")
+
+    def test_ipv4_pseudo_header_length_field_is_unsigned(self):
+        """The IPv4 pseudo-header's length field is a 16-bit *unsigned*
+        value (RFC 793 §3.1; RFC 768) — a segment length above 32767
+        (representable unsigned, not signed) must still pack without
+        overflowing. The IPv6 pseudo-header's analogous 32-bit length
+        field has the same signed/unsigned distinction but only at
+        payload sizes (>2 GiB) no realistic test can reach; see the
+        note by ``[tool.mutmut]`` in pyproject.toml."""
+        payload = b"\x00" * 40000
+        udp = UDP(src_port=1, dst_port=2, length=8 + len(payload), checksum=0)
+        ip = IPv4(
+            version=4,
+            ihl=5,
+            dscp=0,
+            ecn=0,
+            total_length=20 + 8 + len(payload),
+            identification=1,
+            flags=2,
+            fragment_offset=0,
+            ttl=64,
+            protocol=17,
+            checksum=0,
+            src="192.0.2.1",
+            dst="192.0.2.2",
+        )
+        checksum = compute(udp, ip=ip, payload=payload)
+        assert 0 <= checksum <= 0xFFFF
 
 
 class TestPacketWithChecksums:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -23,6 +23,12 @@ from netprotocols import (
     SOARecord,
     TruncatedHeaderError,
 )
+from netprotocols.layer7.dns import (
+    _HEADER_LEN,
+    _MAX_NAME_POINTERS,
+    _labels,
+    _read_name,
+)
 from test_corpus import walk
 
 CORPUS_DNS = pcap_frames(FIXTURES / "udp_dns.pcap")
@@ -460,43 +466,193 @@ class TestDNSContract:
     def test_looping_pointer_raises_not_hangs(self):
         # Pointer at offset 12 that references itself.
         loop = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\xc0\x0c"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(loop).question_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert err.expected == f"<={_MAX_NAME_POINTERS} pointers"
+        assert err.actual == _MAX_NAME_POINTERS + 1
+        assert str(err) == "DNS name compression loops"
 
     def test_reserved_label_bits_rejected(self):
         # Label length byte with 0x40 set (reserved), not a pointer.
         bad = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x40\x00"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(bad).question_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert str(err) == "reserved DNS label length bits set"
 
     def test_name_running_past_message_raises(self):
         # Declares a 9-byte label but the buffer ends first.
         bad = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x09abc"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(bad).question_type
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 10
+        assert str(err) == "DNS name runs past the message"
 
     def test_lone_pointer_byte_raises_reading_past_name(self):
         raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\xc0"
-        with pytest.raises(InvalidFieldError):
-            _ = DNS.decode(raw).question_type  # via _read_name
-        with pytest.raises(InvalidFieldError):
-            _ = DNS.decode(raw).question_name  # via _labels
+        dns = DNS.decode(raw)
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = dns.question_type  # via _read_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert str(err) == "truncated DNS compression pointer"
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _ = dns.question_name  # via _labels
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert str(err) == "truncated DNS compression pointer"
 
     def test_reserved_length_bits_raise_reading_past_name(self):
         raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x40\x00"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(raw).question_type  # via _read_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert str(err) == "reserved DNS label length bits set"
 
     def test_label_overruns_message_in_labels(self):
         # Declares a 9-byte label but only three bytes follow.
         raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\x09abc"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(raw).question_name  # via _labels
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == 0
+        assert str(err) == "DNS label runs past the message"
 
     def test_question_without_qtype_qclass_raises(self):
         raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + encode_name("a")
         with pytest.raises(InvalidFieldError):
             _ = DNS.decode(raw).question_type
+
+
+def pointer_chain(hops: int) -> bytes:
+    """``hops`` chained 2-byte compression pointers ending in a root
+    label: pointer 0 (at sections offset 0) targets pointer 1, ...,
+    the last one targets a trailing zero byte. Offsets are message-
+    relative (``_HEADER_LEN`` back in), matching what ``_labels``
+    subtracts when it follows a pointer."""
+    sections = bytearray()
+    for i in range(hops):
+        target = _HEADER_LEN + (i + 1) * 2
+        sections += bytes([0xC0 | (target >> 8), target & 0xFF])
+    sections += b"\x00"  # root, ends the walk
+    return bytes(sections)
+
+
+class TestReadNameAndLabelsDirectly:
+    """Unit tests against :func:`_read_name`/:func:`_labels` themselves,
+    at the level of their own byte-cursor arithmetic — independent of
+    the higher-level :class:`DNS` scenarios above, some of which cannot
+    tell these functions' errors apart from an unrelated raise a level
+    up (e.g. ``_question_fixed``'s own truncation check also raises
+    ``InvalidFieldError``, so a generic ``pytest.raises`` there cannot
+    prove *this* function is what raised, or with which message)."""
+
+    def test_read_name_treats_reaching_the_end_as_truncated(self):
+        """A label that exactly consumes the buffer, with no
+        terminating zero byte and no room for one, is still truncated
+        — regression against loosening the upper bound on the loop's
+        bounds check from ``<`` to ``<=``, which would let the cursor
+        land one past the last valid index and read out of range."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _read_name(b"\x03abc", 0)
+        assert excinfo.value.offset == 4
+
+    def test_read_name_recognizes_pointer_with_nonzero_low_bits(self):
+        """Only the top two bits mark a pointer (RFC 1035 §4.1.4) — a
+        length byte with a nonzero low bit alongside them, like 0xC1,
+        is still a pointer, not a reserved-bits label length."""
+        assert _read_name(b"\xc1\x00", 0) == 2
+
+    def test_read_name_pointer_truncated_at_one_byte_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _read_name(b"\xc0", 0)
+        assert str(excinfo.value) == "truncated DNS compression pointer"
+
+    def test_read_name_pointer_with_exactly_two_bytes_available(self):
+        assert _read_name(b"\xc0\x0c", 0) == 2
+
+    def test_labels_recognizes_pointer_with_nonzero_low_bits(self):
+        """Same pointer-detection guard as ``_read_name`` above, and
+        the same shift-and-mask arithmetic that turns it into a target
+        offset (``((length & 0x3F) << 8) | next_byte``): a length byte
+        of 0xC1 with a following byte of 0x00 must resolve to message
+        offset 256 exactly, not some other value a broken shift would
+        produce."""
+        sections = b"\xc1\x00" + bytes(243)  # -> offset 256 (sections[244])
+        assert _labels(sections, 0) == "."
+
+    def test_labels_pointer_with_exactly_two_bytes_available(self):
+        sections = b"\x00\xc0\x0c"  # pointer at offset 1 -> offset 12 (root)
+        assert _labels(sections, 1) == "."
+
+    def test_labels_exactly_at_the_pointer_limit_still_resolves(self):
+        """Exactly ``_MAX_NAME_POINTERS`` hops must still resolve —
+        pins the boundary from below against an off-by-one (starting
+        the counter at 1 instead of 0, incrementing by 2 instead of 1,
+        or comparing with ``>=`` instead of ``>``) that would reject a
+        chain the RFC allows."""
+        assert _labels(pointer_chain(_MAX_NAME_POINTERS), 0) == "."
+
+    def test_labels_one_more_than_the_pointer_limit_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _labels(pointer_chain(_MAX_NAME_POINTERS + 1), 0)
+        err = excinfo.value
+        assert err.expected == f"<={_MAX_NAME_POINTERS} pointers"
+        assert err.actual == _MAX_NAME_POINTERS + 1
+
+    def test_labels_declared_length_longer_than_available_data(self):
+        """A label whose declared length overruns the buffer is caught
+        right there (``DNS label runs past the message``, offset at
+        the length byte) — not silently truncated by a Python slice
+        and only caught a loop later, with a different message and
+        offset, by a bounds check shifted by one or two bytes."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _labels(bytes([5]) + b"abcd", 0)
+        err = excinfo.value
+        assert err.offset == 0
+        assert str(err) == "DNS label runs past the message"
+
+    def test_labels_label_exactly_reaches_buffer_end_no_terminator(self):
+        """A label whose data exactly fills the rest of the buffer
+        must *not* be rejected by the label-overrun check itself
+        (that would be one byte too strict) — the next loop
+        iteration's top-of-loop bounds check is what catches the
+        missing terminator, with its own message and offset."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            _labels(bytes([4]) + b"abcd", 0)  # length 4, no root after
+        err = excinfo.value
+        assert err.offset == 5
+        assert str(err) == "DNS name runs past the message"
+
+    def test_labels_decodes_non_ascii_bytes_with_replacement_char(self):
+        """A label byte outside ASCII decodes via the ``replace``
+        error handler rather than raising — regression against
+        dropping or misspelling that handler, which is invisible on a
+        plain-ASCII label because the error-handling path is never
+        reached at all without a genuine decode error."""
+        assert _labels(bytes([1, 0xFF]) + b"\x00", 0) == "�"
+
+    def test_labels_of_an_empty_name_is_the_root_dot(self):
+        assert _labels(b"\x00", 0) == "."
 
 
 class TestDNSDispatch:
@@ -632,5 +788,10 @@ class TestSectionParsingIsShared:
         """Offsets are section-relative now; a pointer below the header
         length cannot address anything real."""
         raw = struct.pack("!HHHHHH", 1, 0x8180, 1, 0, 0, 0) + b"\xc0\x02"
-        with pytest.raises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError) as excinfo:
             _ = DNS.decode(raw).question_name
+        err = excinfo.value
+        assert err.protocol is DNS
+        assert err.field == "sections"
+        assert err.offset == -10
+        assert str(err) == "DNS name runs past the message"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -77,7 +77,7 @@ class TestCorpusFiguresInDocs:
         )
 
     @pytest.mark.parametrize(
-        "module", ["vlan.py", "gre.py", "dhcp.py", "ipv6_ext.py"]
+        "module", ["vlan.py", "gre.py", "dhcp.py", "ipv6_ext.py", "_tlv.py"]
     )
     def test_layout_map_lists_every_shipped_module(self, module: str) -> None:
         """The layout map went stale by omission, not by wrong values."""

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,18 @@
+"""Enum lockstep: every ``IPProtocol``/``EtherType`` member must carry a
+display name (CONTRIBUTING.md's enum-lockstep enforcement point)."""
+
+from netprotocols import EtherType, IPProtocol
+
+
+class TestEnumCompleteness:
+    def test_every_ip_protocol_member_has_a_display_name(self):
+        for member in IPProtocol:
+            assert member.display_name
+
+    def test_every_ethertype_member_has_a_display_name(self):
+        for member in EtherType:
+            assert member.display_name
+
+    def test_extension_header_display_names(self):
+        assert IPProtocol.HOPOPT.display_name == "IPv6 Hop-by-Hop Options"
+        assert IPProtocol.IPV6_FRAG.display_name == "IPv6 Fragment"

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -24,6 +24,7 @@ reproduces a nightly run locally.
 
 import contextlib
 import os
+import sys
 
 import pytest
 from hypothesis import given, settings
@@ -39,6 +40,7 @@ from netprotocols import (
     TCP,
     UDP,
     VLAN,
+    DNSOverTCP,
     Ethernet,
     ICMPv4,
     ICMPv6,
@@ -50,6 +52,7 @@ from netprotocols import (
     IPv6HopByHopOptions,
     IPv6Routing,
     Packet,
+    Protocol,
     ProtocolError,
     TCPOption,
 )
@@ -80,9 +83,75 @@ ALL_PROTOCOLS = (
     TCP,
     UDP,
     DNS,
+    DNSOverTCP,
     DHCP,
     GRE,
 )
+
+
+def _shipped_protocol_classes() -> set[type[Protocol]]:
+    """Every concrete protocol class netprotocols ships, discovered by
+    walking Protocol.__subclasses__() to every depth rather than a second
+    hand list that could drift the same way ALL_PROTOCOLS can.
+
+    Two artifacts of live-class introspection need filtering:
+    * @dataclass(slots=True) rebuilds a class after `class Foo(Protocol):`
+      already registered the pre-slots object as a Protocol subclass, so
+      both the rebuilt class and an orphaned duplicate stay reachable from
+      __subclasses__() forever. Keep only the object actually bound under
+      its own name in its defining module.
+    * Other test modules (test_registry.py's Fake/OtherFake,
+      test_walk.py's NonAdvancing) define their own throwaway Protocol
+      subclasses; once those modules are imported (any full-suite run)
+      they show up here too. Restrict to classes whose __module__ starts
+      with 'netprotocols'.
+    * Private intermediate bases (_ICMP, _IPv6OptionsHeader) share a shape
+      but are never registered/decoded standalone — excluded by the
+      leading-underscore convention the codebase already uses for exactly
+      that.
+    """
+    found: set[type[Protocol]] = set()
+    stack = list(Protocol.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        if cls in found:
+            continue
+        found.add(cls)
+        stack.extend(cls.__subclasses__())
+
+    def is_shipped(cls: type[Protocol]) -> bool:
+        if not cls.__module__.startswith("netprotocols"):
+            return False
+        if cls.__name__.startswith("_"):
+            return False
+        module = sys.modules.get(cls.__module__)
+        return module is not None and getattr(module, cls.__name__, None) is cls
+
+    return {cls for cls in found if is_shipped(cls)}
+
+
+def test_all_protocols_covers_every_shipped_protocol() -> None:
+    """ALL_PROTOCOLS must name exactly the concrete protocols this library
+    ships: nothing missing (a new protocol silently skipping the
+    decode-never-escapes-ProtocolError fuzz property) and nothing stale
+    (a renamed/removed class left behind)."""
+    shipped = _shipped_protocol_classes()
+    assert len(shipped) >= len(ALL_PROTOCOLS), (
+        f"protocol discovery found only {len(shipped)} classes, fewer "
+        f"than ALL_PROTOCOLS already lists ({len(ALL_PROTOCOLS)}) -- "
+        "the introspection is broken, not the list"
+    )
+    missing = shipped - set(ALL_PROTOCOLS)
+    stale = set(ALL_PROTOCOLS) - shipped
+    assert not missing, (
+        f"not fuzzed -- add to ALL_PROTOCOLS: "
+        f"{sorted(c.__name__ for c in missing)}"
+    )
+    assert not stale, (
+        f"ALL_PROTOCOLS lists class(es) no longer shipped: "
+        f"{sorted(c.__name__ for c in stale)}"
+    )
+
 
 CORPUS_FRAMES = [frame for _, _, frame in corpus_frames()]
 

--- a/tests/test_ipv6_ext.py
+++ b/tests/test_ipv6_ext.py
@@ -8,7 +8,6 @@ import pytest
 from conftest import FIXTURES, pcap_frames
 from netprotocols import (
     Ethernet,
-    EtherType,
     ICMPv6,
     InvalidFieldError,
     IPProtocol,
@@ -426,17 +425,3 @@ class TestRegistryGating:
             next_header=60, hdr_ext_len=0, options=b"\x01\x04\x00\x00\x00\x00"
         )
         assert dst_opts.next_protocol() is IPv6DestinationOptions
-
-
-class TestEnumCompleteness:
-    def test_every_ip_protocol_member_has_a_display_name(self):
-        for member in IPProtocol:
-            assert member.display_name
-
-    def test_every_ethertype_member_has_a_display_name(self):
-        for member in EtherType:
-            assert member.display_name
-
-    def test_extension_header_display_names(self):
-        assert IPProtocol.HOPOPT.display_name == "IPv6 Hop-by-Hop Options"
-        assert IPProtocol.IPV6_FRAG.display_name == "IPv6 Fragment"

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -104,6 +104,26 @@ class TestMinOptionLength:
             length_includes_header=False,
         ) == [(5, b"")]
 
+    @pytest.mark.parametrize("min_option_length", [None, 0, 1])
+    @pytest.mark.parametrize("declared_length", [0, 1])
+    def test_length_includes_header_enforces_a_floor_of_two_regardless(
+        self, min_option_length, declared_length
+    ):
+        """When the length counts its own two header bytes, a declared
+        length below 2 can never advance the cursor (0 leaves it in
+        place; 1 backs it up into the length byte) -- this floor is
+        structural, so it applies even if a caller passes no
+        min_option_length, or one weaker than 2. Regression against a
+        hang: every one of these must raise, never loop forever."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(
+                bytes([2, declared_length]),
+                min_option_length=min_option_length,
+            )
+        err = excinfo.value
+        assert err.expected == ">=2"
+        assert err.actual == declared_length
+
 
 class TestLengthIncludesHeaderTrue:
     """TCP/IPv4 shape: the length byte counts the kind and length bytes

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -1,0 +1,211 @@
+"""Unit tests for the shared kind/length/value option-TLV walker.
+
+Exercises :func:`netprotocols._tlv.walk_kind_length_value` directly, at
+the level of the walker's own parameters, independent of the three call
+sites (TCP, IPv4, and the IPv6 options headers) whose protocol-level
+tests already cover it indirectly — see tests/test_tcp.py,
+tests/test_ip.py, and tests/test_ipv6_ext.py.
+"""
+
+import pytest
+
+from netprotocols import InvalidFieldError
+from netprotocols._tlv import walk_kind_length_value
+
+
+class _Protocol:
+    """A stand-in protocol class: the walker only ever reads its name
+    (for the error message) and identity (for ``err.protocol``), never
+    an instance of it."""
+
+
+def walk(raw: bytes, **overrides: object) -> list[tuple[int, bytes]]:
+    """Run the walker with TCP/IPv4-shaped defaults (EOL/NOP as the
+    lone bytes, EOL terminating, a 2-byte length floor, and a length
+    byte that counts itself), overridable per test."""
+    kwargs: dict[str, object] = {
+        "lone_byte_kinds": frozenset({0, 1}),
+        "terminator_kind": 0,
+        "min_option_length": 2,
+        "length_includes_header": True,
+        "protocol": _Protocol,
+    }
+    kwargs.update(overrides)
+    return list(walk_kind_length_value(raw, **kwargs))  # type: ignore[arg-type]
+
+
+class TestLoneByteKinds:
+    def test_lone_byte_kind_yields_empty_data(self):
+        assert walk(b"\x01\x01") == [(1, b""), (1, b"")]
+
+    def test_multiple_lone_bytes_in_a_row(self):
+        assert walk(b"\x01\x01\x01") == [(1, b""), (1, b""), (1, b"")]
+
+    def test_lone_byte_kind_without_terminator_keeps_walking(self):
+        """IPv6 shape: Pad1 (0) is a lone byte but not a terminator, so
+        a TLV option following it still parses."""
+        assert walk(
+            b"\x00\x05\x02\xca\xfe",
+            lone_byte_kinds=frozenset({0}),
+            terminator_kind=None,
+            min_option_length=None,
+            length_includes_header=False,
+        ) == [(0, b""), (5, b"\xca\xfe")]
+
+
+class TestTerminator:
+    def test_terminator_stops_the_walk(self):
+        """A terminator kind ends the walk right there, even with more
+        bytes left in the buffer: those bytes are padding, not more
+        options, and are never inspected — not even to notice they
+        would otherwise be malformed TLV data."""
+        assert walk(b"\x00\xff\xff\xff") == [(0, b"")]
+
+    def test_terminator_as_the_only_byte(self):
+        assert walk(b"\x00") == [(0, b"")]
+
+    def test_non_terminator_lone_byte_does_not_stop(self):
+        assert walk(b"\x01\x00") == [(1, b""), (0, b"")]
+
+    def test_no_terminator_configured_never_stops_early(self):
+        """IPv6 shape: with terminator_kind=None, the lone-byte kind
+        (Pad1) never ends the walk, however many appear."""
+        assert walk(
+            b"\x00\x00\x00",
+            lone_byte_kinds=frozenset({0}),
+            terminator_kind=None,
+            min_option_length=None,
+            length_includes_header=False,
+        ) == [(0, b""), (0, b""), (0, b"")]
+
+
+class TestMinOptionLength:
+    def test_length_below_minimum_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x02\x01\x00")
+        err = excinfo.value
+        assert err.protocol is _Protocol
+        assert err.field == "options"
+        assert err.offset == 0
+        assert err.expected == ">=2"
+        assert err.actual == 1
+        assert str(err) == "_Protocol option length must be at least 2, got 1"
+
+    def test_length_equal_to_the_minimum_is_accepted(self):
+        assert walk(b"\x02\x02") == [(2, b"")]
+
+    def test_no_floor_when_min_option_length_is_none(self):
+        """IPv6 has no length floor: a declared length of 0 is legal."""
+        assert walk(
+            b"\x05\x00",
+            lone_byte_kinds=frozenset(),
+            terminator_kind=None,
+            min_option_length=None,
+            length_includes_header=False,
+        ) == [(5, b"")]
+
+
+class TestLengthIncludesHeaderTrue:
+    """TCP/IPv4 shape: the length byte counts the kind and length bytes
+    themselves, so the data slice is ``raw[cursor+2:cursor+length]``
+    and the cursor advances by ``length``."""
+
+    def test_data_slice_excludes_the_two_header_bytes(self):
+        assert walk(b"\x02\x04\xca\xfe") == [(2, b"\xca\xfe")]
+
+    def test_cursor_advances_by_the_declared_length(self):
+        assert walk(b"\x02\x04\xca\xfe\x01") == [(2, b"\xca\xfe"), (1, b"")]
+
+    def test_length_running_past_the_buffer_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x02\x05\xca\xfe")
+        err = excinfo.value
+        assert err.protocol is _Protocol
+        assert err.field == "options"
+        assert err.offset == 0
+        assert str(err) == "_Protocol option value runs past the options bytes"
+
+
+class TestLengthIncludesHeaderFalse:
+    """IPv6 shape: the length byte counts only the trailing data, so
+    the data slice is ``raw[cursor+2:cursor+2+length]`` and the cursor
+    advances by ``2 + length``."""
+
+    def false_mode(self, raw: bytes) -> list[tuple[int, bytes]]:
+        return walk(
+            raw,
+            lone_byte_kinds=frozenset(),
+            terminator_kind=None,
+            min_option_length=None,
+            length_includes_header=False,
+        )
+
+    def test_data_slice_is_exactly_the_declared_length(self):
+        assert self.false_mode(b"\x05\x02\xca\xfe") == [(5, b"\xca\xfe")]
+
+    def test_cursor_advances_by_two_plus_the_declared_length(self):
+        assert self.false_mode(b"\x05\x02\xca\xfe\x01\x01\x00") == [
+            (5, b"\xca\xfe"),
+            (1, b"\x00"),
+        ]
+
+    def test_length_running_past_the_buffer_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            self.false_mode(b"\x05\x03\xca\xfe")
+        err = excinfo.value
+        assert err.protocol is _Protocol
+        assert err.field == "options"
+        assert err.offset == 0
+        assert str(err) == "_Protocol option data runs past the header"
+
+
+class TestMissingLengthByte:
+    def test_kind_with_no_following_byte_raises(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x02")
+        err = excinfo.value
+        assert err.protocol is _Protocol
+        assert err.field == "options"
+        assert err.offset == 0
+        assert str(err) == "_Protocol option missing its length byte"
+
+    def test_offset_is_relative_to_the_options_bytes(self):
+        """A prior option shifts where the failure is reported."""
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x01\x02")
+        assert excinfo.value.offset == 1
+
+
+class TestFieldParameter:
+    def test_field_defaults_to_options(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x02")
+        assert excinfo.value.field == "options"
+
+    def test_field_is_overridable(self):
+        with pytest.raises(InvalidFieldError) as excinfo:
+            walk(b"\x02", field="sections")
+        assert excinfo.value.field == "sections"
+
+
+class TestEmptyInput:
+    def test_empty_buffer_yields_nothing(self):
+        assert walk(b"") == []
+
+
+class TestIsAGenerator:
+    def test_no_error_before_iteration_begins(self):
+        """``walk_kind_length_value`` is a generator function: calling
+        it builds the generator object without running any of its
+        body, so a bad buffer only raises once a caller starts pulling
+        values from it."""
+        generator = walk_kind_length_value(
+            b"\x02",
+            lone_byte_kinds=frozenset({0, 1}),
+            terminator_kind=0,
+            min_option_length=2,
+            length_includes_header=True,
+            protocol=_Protocol,
+        )
+        with pytest.raises(InvalidFieldError):
+            next(generator)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,6 @@
-"""Tests that the release workflow cannot publish without the QA ladder.
+"""Tests that the release workflow cannot publish without the QA ladder,
+and that every workflow file under .github/workflows/ holds this
+project's baseline structural bar.
 
 A published version can only be yanked, never replaced, so the gate that
 stops a broken tag reaching PyPI is worth asserting rather than trusting.
@@ -7,9 +9,16 @@ job, or ``workflow_call:`` from the CI workflow, and releases keep
 working while the gate quietly stops existing.
 
 These parse the workflow YAML by indentation rather than with a YAML
-library, to avoid adding a dependency for four assertions. The files are
-small and uniformly two-space indented; a parse failure here fails the
-test loudly instead of passing vacuously.
+library, to avoid adding a dependency for a handful of assertions. The
+files are small and uniformly two-space indented; a parse failure here
+fails the test loudly instead of passing vacuously.
+
+The commit-SHA-pinning check in particular is parametrized over every
+file a glob of .github/workflows/*.yml finds, rather than a fixed list
+of workflow names. A fixed list quietly stops covering a file the
+moment someone adds a new one and forgets to update the list here --
+the same failure mode as ALL_PROTOCOLS silently skipping DNSOverTCP
+(see the fuzz-completeness test), just relocated to CI's own workflows.
 """
 
 import re
@@ -20,6 +29,9 @@ import pytest
 WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
 CI = WORKFLOWS / "ci.yml"
 RELEASE = WORKFLOWS / "release.yml"
+FUZZ = WORKFLOWS / "fuzz.yml"
+DEPENDABOT = WORKFLOWS.parent / "dependabot.yml"
+ALL_WORKFLOWS = sorted(WORKFLOWS.glob("*.yml"))
 
 
 def job_blocks(workflow: Path) -> dict[str, str]:
@@ -46,6 +58,11 @@ def job_blocks(workflow: Path) -> dict[str, str]:
 @pytest.fixture(scope="module")
 def release_jobs() -> dict[str, str]:
     return job_blocks(RELEASE)
+
+
+@pytest.fixture(scope="module")
+def ci_jobs() -> dict[str, str]:
+    return job_blocks(CI)
 
 
 class TestReleaseGate:
@@ -102,7 +119,7 @@ class TestReleaseGate:
 
     def test_every_local_reusable_reference_resolves(self) -> None:
         """A `uses: ./…` pointing at nothing fails the release, not CI."""
-        for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        for workflow in ALL_WORKFLOWS:
             for ref in re.findall(r"uses:\s*(\./\S+)", workflow.read_text()):
                 # removeprefix, not lstrip: lstrip("./") would strip the
                 # leading dot of ".github" as well.
@@ -116,3 +133,148 @@ class TestReleaseGate:
                     f"{workflow.name} calls {ref}, but that workflow does "
                     f"not declare a workflow_call trigger"
                 )
+
+
+class TestActionPinning:
+    """Every third-party action, in every workflow, must be pinned.
+
+    Parametrized over ``ALL_WORKFLOWS`` -- a glob of
+    .github/workflows/*.yml -- rather than a fixed list of files, so a
+    workflow added after this test was written is covered automatically
+    instead of silently skipped.
+    """
+
+    @pytest.mark.parametrize("workflow", ALL_WORKFLOWS, ids=lambda p: p.name)
+    def test_remote_actions_are_pinned_to_a_commit_sha(
+        self, workflow: Path
+    ) -> None:
+        """A branch or tag ref (`@v4`, `@main`) is a moving target: the
+        code that runs under it can change without this repository's
+        own history recording it. `uses: ./…` local reusable-workflow
+        references are exempt -- they resolve to a file in this repo
+        (checked above) and cannot be "pinned" to a SHA at all.
+        """
+        for line in workflow.read_text().splitlines():
+            match = re.match(r"\s*uses:\s*(\S+)", line)
+            if not match:
+                continue
+            ref = match.group(1)
+            if ref.startswith("."):
+                continue
+            _, sep, pin = ref.rpartition("@")
+            assert sep and re.fullmatch(r"[0-9a-f]{40}", pin), (
+                f"{workflow.name}: {ref!r} is not pinned to a 40-character "
+                f"commit SHA"
+            )
+
+
+class TestCIWorkflow:
+    """Structural checks on jobs added to ci.yml's own QA ladder."""
+
+    def test_has_a_dependency_scan_job(self, ci_jobs: dict[str, str]) -> None:
+        """Third-party CI dependencies must be audited for known CVEs."""
+        block = ci_jobs.get("dependency-scan")
+        assert block is not None, "ci.yml has no dependency-scan job"
+        assert "pip-audit" in block, (
+            "dependency-scan job no longer runs pip-audit"
+        )
+
+    def test_build_verifies_reproducibility(
+        self, ci_jobs: dict[str, str]
+    ) -> None:
+        """The build job must diff two independent builds, not just one."""
+        block = ci_jobs.get("build")
+        assert block is not None, "ci.yml has no build job"
+        assert "reproducible" in block.lower(), (
+            "build job no longer verifies that the wheel build is reproducible"
+        )
+        assert block.count("uv build") >= 3, (
+            "reproducible-build-diff step must build the wheel twice, in "
+            "addition to the job's own initial build, to have anything "
+            "to diff"
+        )
+
+
+class TestReleaseWorkflow:
+    def test_publish_attests_build_provenance(
+        self, release_jobs: dict[str, str]
+    ) -> None:
+        """Downloaders must be able to verify the wheel/sdist provenance."""
+        publish = release_jobs.get("publish")
+        assert publish is not None, "release.yml has no publish job"
+        assert "attest-build-provenance" in publish, (
+            "publish job no longer attests build provenance for the "
+            "artifacts it uploads"
+        )
+
+
+class TestFuzzWorkflow:
+    def test_has_a_concurrency_group(self) -> None:
+        """Without one, an overlapping nightly run could waste a runner
+        racing a still-running previous one instead of replacing it."""
+        assert re.search(r"^concurrency:", FUZZ.read_text(), re.M), (
+            "fuzz.yml no longer declares a top-level concurrency group"
+        )
+
+
+# Each new workflow file's defining job, and one distinctive thing that
+# job must still do. A missing file or job fails outright; a present job
+# missing its needle means the workflow was gutted without anyone
+# noticing, since none of these run on every push the way ci.yml does.
+NEW_WORKFLOW_REQUIREMENTS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "mutation.yml": ("mutation", ("mutmut run",)),
+    "codeql.yml": (
+        "analyze",
+        ("codeql-action/init", "codeql-action/analyze"),
+    ),
+    "scorecard.yml": ("analysis", ("ossf/scorecard-action",)),
+    "docs-lint.yml": ("lychee", ("lycheeverse/lychee-action",)),
+    "pr-title-lint.yml": (
+        "lint-pr-title",
+        ("action-semantic-pull-request",),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "filename", sorted(NEW_WORKFLOW_REQUIREMENTS), ids=lambda name: name
+)
+def test_new_workflow_has_its_defining_job(filename: str) -> None:
+    workflow = WORKFLOWS / filename
+    assert workflow.is_file(), f"{filename} is missing from .github/workflows/"
+    job_name, needles = NEW_WORKFLOW_REQUIREMENTS[filename]
+    blocks = job_blocks(workflow)
+    block = blocks.get(job_name)
+    assert block is not None, f"{filename} has no {job_name!r} job"
+    for needle in needles:
+        assert needle in block, (
+            f"{filename}'s {job_name!r} job no longer runs {needle!r}"
+        )
+
+
+def test_dependabot_declares_the_required_ecosystems() -> None:
+    """dependabot.yml must keep both Python and Actions pins current.
+
+    Every `uses:` SHA this suite checks (TestActionPinning) will drift
+    out of date the moment nothing bumps it -- that's github-actions'
+    job. The Python side (uv, or pip as a fallback ecosystem name) is
+    what keeps the dev dependency-group underneath dependency-scan
+    current.
+    """
+    assert DEPENDABOT.is_file(), ".github/dependabot.yml is missing"
+    ecosystems = set(
+        re.findall(
+            r'package-ecosystem:\s*"?([A-Za-z0-9_-]+)"?',
+            DEPENDABOT.read_text(),
+        )
+    )
+    assert ecosystems & {"uv", "pip"}, (
+        f"dependabot.yml declares {ecosystems or '{}'}, none of which is "
+        f"'uv' or 'pip' -- Python dependency updates would stop being "
+        f"tracked"
+    )
+    assert "github-actions" in ecosystems, (
+        f"dependabot.yml declares {ecosystems or '{}'}, missing "
+        f"'github-actions' -- the SHA pins this test suite requires "
+        f"would go stale silently"
+    )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -210,6 +210,8 @@ class TestActionPinning:
 class TestCIWorkflow:
     """Structural checks on jobs added to ci.yml's own QA ladder."""
 
+    REPRODUCIBILITY_STEP_NAME = "Verify the wheel build is reproducible"
+
     def test_has_a_dependency_scan_job(self, ci_jobs: dict[str, str]) -> None:
         """Third-party CI dependencies must be audited for known CVEs."""
         block = ci_jobs.get("dependency-scan")
@@ -218,36 +220,145 @@ class TestCIWorkflow:
             "dependency-scan job no longer runs pip-audit"
         )
 
+    @classmethod
+    def _reproducibility_step_script(cls, build_job: str) -> str:
+        """The literal ``run:`` script of the build job's "Verify the
+        wheel build is reproducible" step, isolated from the rest of
+        the job.
+
+        ``job_blocks`` returns a job's *entire* raw text -- every other
+        step's name, ``run:`` script, and echoed strings besides this
+        one. Checking for tokens against that whole blob cannot tell
+        the difference between this step's own executed commands and a
+        lookalike word occurring anywhere else in the job (another
+        step's log message, an unrelated comment, or a step that only
+        describes a check in a string it echoes). Isolating this step's
+        own script is what lets the checks below tie the hashing and
+        the comparison to commands this step actually runs.
+        """
+        match = re.search(
+            rf"(?m)^ {{6}}- name: {re.escape(cls.REPRODUCIBILITY_STEP_NAME)}\n"
+            rf" {{8}}run: \|\n"
+            rf"(?P<script>(?: {{10}}.*\n)+)",
+            build_job,
+        )
+        assert match is not None, (
+            f"build job has no {cls.REPRODUCIBILITY_STEP_NAME!r} step "
+            f"with an inline 'run: |' script"
+        )
+        return match.group("script")
+
+    @staticmethod
+    def _assert_diffs_two_independent_builds(script: str) -> None:
+        """Verify the reproducibility step's script actually hashes two
+        independently built wheels and fails on a reachable mismatch,
+        rather than merely containing words that describe doing so.
+
+        A bare substring/regex search over raw text is satisfied by an
+        ``echo`` string that narrates "would hash dist-repro-1 and
+        dist-repro-2, compare $hash1 != $hash2, and exit 1 on
+        mismatch" without ever running a `sha256sum`, or by a real
+        `sha256sum`/`if`/`exit 1` that IS present in the script but not
+        wired together -- e.g. `exit 1` sitting in an unrelated,
+        permanently-false branch while the real `if [ "$hash1" !=
+        "$hash2" ]; then` block does nothing. Each check here ties a
+        token to the specific, executable bash construct it must
+        appear in, and the last one requires `exit 1` to be inside the
+        *body* of the actual hash-mismatch `if` block, not merely
+        present somewhere in the script.
+        """
+        assert "uv build -o dist-repro-1" in script, (
+            "reproducibility step no longer builds a first independent "
+            "wheel into dist-repro-1"
+        )
+        assert "uv build -o dist-repro-2" in script, (
+            "reproducibility step no longer builds a second independent "
+            "wheel into dist-repro-2"
+        )
+        assert re.search(r"hash1=\$\(sha256sum\s+\S*dist-repro-1\S*", script), (
+            "reproducibility step no longer assigns hash1 from an "
+            "actual sha256sum of the dist-repro-1 wheel"
+        )
+        assert re.search(r"hash2=\$\(sha256sum\s+\S*dist-repro-2\S*", script), (
+            "reproducibility step no longer assigns hash2 from an "
+            "actual sha256sum of the dist-repro-2 wheel"
+        )
+        # Known accepted limitation: `body` is captured non-greedily up
+        # to the first line that is just `fi`, not necessarily the one
+        # that actually balances this `if`. A deliberately nested dead
+        # branch inside the real mismatch block -- e.g. `if false; then
+        # exit 1; fi` sitting inside the outer `if [ "$hash1" !=
+        # "$hash2" ]; then ... fi` -- would still read as "exit 1 is in
+        # body" without being reachable. Closing that would mean
+        # tracking `if`/`fi` nesting depth instead of matching to the
+        # first `fi`, which is more machinery than a YAML/bash text
+        # heuristic like this one is worth carrying for a case the real
+        # ci.yml step doesn't (and has no reason to) construct.
+        mismatch = re.search(
+            r'if \[ "?\$hash1"?\s*!=\s*"?\$hash2"?\s*\];?\s*then\n'
+            r"(?P<body>(?:.*\n)*?)"
+            r"^ *fi *$",
+            script,
+            re.M,
+        )
+        assert mismatch is not None, (
+            "reproducibility step no longer has a reachable "
+            '\'if [ "$hash1" != "$hash2" ]; then ... fi\' block '
+            "comparing the two builds' hashes"
+        )
+        assert "exit 1" in mismatch.group("body"), (
+            "the hash-mismatch branch no longer fails the job with "
+            "exit 1 -- a differing hash would be reported without "
+            "ever failing CI"
+        )
+
     def test_build_verifies_reproducibility(
         self, ci_jobs: dict[str, str]
     ) -> None:
         """The build job must actually compare two independent builds'
-        artifacts, not merely claim to and build the wheel some number
-        of times -- a block containing the word "reproducible" and
-        three "uv build" calls would previously pass this test without
-        ever diffing anything."""
+        artifacts, not merely claim to and mention the right words --
+        a block containing the word "reproducible" plus echoed
+        mentions of "sha256sum", "$hash1 != $hash2", and "exit 1"
+        would previously pass this test without ever hashing anything
+        or failing on a real mismatch, because every assertion here
+        used to search the whole raw `build` job block rather than
+        this step's own, actually-executed script."""
         block = ci_jobs.get("build")
         assert block is not None, "ci.yml has no build job"
-        assert "reproducible" in block.lower(), (
-            "build job no longer verifies that the wheel build is reproducible"
+        script = self._reproducibility_step_script(block)
+        self._assert_diffs_two_independent_builds(script)
+
+    def test_build_reproducibility_check_rejects_a_cosmetic_stand_in(
+        self,
+    ) -> None:
+        """Regression test for the gap in the previous version of
+        :meth:`test_build_verifies_reproducibility`.
+
+        The old test only checked that "reproducible", "sha256sum",
+        a "$hash1 ... != ... $hash2" pattern, and "exit 1" each
+        occurred *somewhere* in the raw `build` job block. This
+        fixture's step builds both wheels, but its "hashing" and
+        "comparison" are just words inside one echoed string -- no
+        `sha256sum` call, no `hash1`/`hash2` assignment, and no real
+        `if`/`exit 1` ever run. Every old assertion (verified by hand
+        against the pre-fix logic) is satisfied by this text, so this
+        case would have slipped past it silently; it must fail the
+        tightened checks instead.
+        """
+        cosmetic_step = (
+            f"      - name: {self.REPRODUCIBILITY_STEP_NAME}\n"
+            "        run: |\n"
+            "          uv build -o dist-repro-1\n"
+            "          uv build -o dist-repro-2\n"
+            '          echo "sha256sum check: would compare "$hash1" '
+            '!= "$hash2" and exit 1 on mismatch"\n'
+            '          echo "Wheel build is reproducible."\n'
         )
-        assert block.count("uv build") >= 3, (
-            "reproducible-build-diff step must build the wheel twice, in "
-            "addition to the job's own initial build, to have anything "
-            "to diff"
-        )
-        assert "sha256sum" in block, (
-            "reproducible-build-diff step no longer hashes the built "
-            "artifacts to compare them"
-        )
-        assert re.search(r'\$hash1"?\s*!=\s*"?\$hash2', block), (
-            "reproducible-build-diff step no longer compares the two "
-            "builds' hashes against each other"
-        )
-        assert "exit 1" in block, (
-            "reproducible-build-diff step no longer fails the job when "
-            "the compared hashes differ"
-        )
+        script = self._reproducibility_step_script(cosmetic_step)
+        with pytest.raises(
+            AssertionError, match="sha256sum of the dist-repro-1 wheel"
+        ):
+            self._assert_diffs_two_independent_builds(script)
 
 
 class TestReleaseWorkflow:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -288,35 +288,39 @@ class TestMutationWorkflow:
         "netprotocols.layer7.dns.x__labels*",
     )
 
-    def test_run_applies_the_documented_dns_scope_filters(self) -> None:
-        """Checks the *exact* set of filters `mutmut run` is actually
-        invoked with, parsed the way bash itself would read the
-        continuation lines -- not just anywhere in the file, and not a
-        bare substring check.
+    @staticmethod
+    def _parse_mutmut_run_filters(text: str) -> list[str]:
+        """Parse the quoted argument lines of a `mutmut run` invocation
+        exactly as bash would read the continuation lines -- not just
+        anywhere in the file, and not a bare substring check.
 
         A bare substring check over a loosely-extracted block has two
         independent gaps a more literal, line-by-line parse closes:
 
         1. Each argument line must end with a continuation backslash
            to keep the shell command going onto the next line. A line
-           silently missing it ends the real `mutmut run` invocation
-           right there -- anything quoted on later lines is never
+           without one ends the real `mutmut run` invocation right
+           there -- anything on later lines, quoted or not, is never
            actually passed to mutmut, no matter how legitimate it
            looks in the source. Requiring the backslash explicitly
            here (rather than tolerating its absence and hoping the
            parse boundary happens to land in the right place) is what
            makes the check trace real bash semantics instead of an
            incidental regex artifact.
-        2. Presence-only checking cannot notice an *extra* filter
-           tacked onto the command -- pyproject.toml's only_mutate
-           comment documents exactly four filters, and a fifth would
-           silently widen the audited DNS scope without failing
-           anything. Comparing the complete parsed filter set against
-           EXPECTED_FILTERS, rather than checking each expected
-           pattern's presence, catches both a missing filter and an
-           extra one.
+        2. A line that bash *does* still consider part of the command
+           (because the previous line ended in " \\") but that isn't a
+           single-quoted filter -- an unquoted word, say -- is still a
+           real positional argument as far as bash and mutmut are
+           concerned; bash expands it (glob expansion, in the unquoted
+           case) and hands it over like any other argument. Silently
+           stopping the parse there, the same as at a legitimate
+           unbackslashed last line, would let such a line slip past
+           the equality check below unnoticed. So a continued line
+           that fails to parse as a quoted filter fails this check
+           loudly instead: it is never the normal way for the command
+           to end, only a normal-looking line with nothing after it
+           is.
         """
-        text = MUTATION.read_text()
         match = re.search(
             r"(?m)^          uv run --frozen mutmut run \\\n"
             r"(?P<rest>(?:.*\n)*)",
@@ -327,19 +331,41 @@ class TestMutationWorkflow:
             "expected 'uv run --frozen mutmut run \\' shape"
         )
 
-        # Parse the quoted argument lines exactly as bash would read
-        # them: a line ending in " \" continues the command onto the
-        # next line, and a line without one is the last argument --
-        # parsing stops there even if more quoted-looking lines follow,
-        # because bash would never see them as part of this command.
         filters: list[str] = []
+        continues = True
         for line in match.group("rest").splitlines():
+            if not continues:
+                # The previous line ended the bash command (no
+                # trailing " \"). Whatever follows in the file --
+                # more workflow steps, comments, blank lines -- was
+                # never part of this invocation, so it is out of
+                # scope for this parse, not a parse failure.
+                break
             argument = re.fullmatch(r"            '([^']+)'( \\)?", line)
-            if argument is None:
-                break
+            assert argument is not None, (
+                "mutation.yml's mutmut run command still continues "
+                f"(the previous line ended with ' \\') onto a line "
+                f"that is not a single-quoted filter argument: "
+                f"{line!r} -- bash would still pass this to mutmut "
+                f"as a real positional argument"
+            )
             filters.append(argument.group(1))
-            if argument.group(2) is None:
-                break
+            continues = argument.group(2) is not None
+        return filters
+
+    def test_run_applies_the_documented_dns_scope_filters(self) -> None:
+        """Checks the *exact* set of filters `mutmut run` is actually
+        invoked with.
+
+        Presence-only checking cannot notice an *extra* filter tacked
+        onto the command -- pyproject.toml's only_mutate comment
+        documents exactly four filters, and a fifth would silently
+        widen the audited DNS scope without failing anything.
+        Comparing the complete parsed filter set against
+        EXPECTED_FILTERS, rather than checking each expected pattern's
+        presence, catches both a missing filter and an extra one.
+        """
+        filters = self._parse_mutmut_run_filters(MUTATION.read_text())
 
         assert sorted(filters) == sorted(self.EXPECTED_FILTERS), (
             f"mutation.yml's mutmut run step actually applies "
@@ -348,6 +374,38 @@ class TestMutationWorkflow:
             f"{sorted(self.EXPECTED_FILTERS)} -- it would mutate either "
             f"more or less of dns.py than was ever audited"
         )
+
+    def test_run_rejects_an_unquoted_argument_on_a_continued_line(
+        self,
+    ) -> None:
+        """Regression test: a continued line that is not a quoted
+        filter must fail loudly, not be silently dropped.
+
+        All four real filters are present and correctly continued,
+        followed by one more continued line that is an unquoted
+        wildcard rather than a quoted filter. Bash would still pass
+        that word to mutmut as a fifth positional argument -- it is
+        not a shell syntax error, just an argument this parse must not
+        let slide by unnoticed. Before the fix that replaced a bare
+        `break` with this assertion, the loop stopped as soon as the
+        unquoted line failed to match, leaving `filters` holding
+        exactly the four expected entries and the equality check in
+        `test_run_applies_the_documented_dns_scope_filters` passing
+        despite the extra argument -- this proves that gap is closed.
+        """
+        malformed = (
+            "          uv run --frozen mutmut run \\\n"
+            "            'netprotocols.checksum.*' \\\n"
+            "            'netprotocols._tlv.*' \\\n"
+            "            'netprotocols.layer7.dns.x__read_name*' \\\n"
+            "            'netprotocols.layer7.dns.x__labels*' \\\n"
+            "            some_extra_target\n"
+        )
+
+        with pytest.raises(
+            AssertionError, match="not a single-quoted filter argument"
+        ):
+            self._parse_mutmut_run_filters(malformed)
 
 
 # Each new workflow file's defining job, and one distinctive thing that

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -289,9 +289,26 @@ class TestMutationWorkflow:
     )
 
     def test_run_applies_the_documented_dns_scope_filters(self) -> None:
+        """Checks the filters inside the actual `mutmut run` argument
+        block, not just anywhere in the file -- a bare substring check
+        would still pass if a filter were dropped from the real command
+        while its text lingered in a comment (this file's own comment
+        block above the step names all four, for exactly the reason
+        that error would be easy to make)."""
         text = MUTATION.read_text()
+        match = re.search(
+            r"(?m)^          uv run --frozen mutmut run \\\n"
+            r"(?P<filters>(?:            '[^']+'\s*\\?\n?)+)",
+            text,
+        )
+        assert match is not None, (
+            "mutation.yml's mutmut run step no longer matches the "
+            "expected 'uv run --frozen mutmut run \\' + quoted-filter-"
+            "lines shape"
+        )
+        filters = match.group("filters")
         for pattern in self.EXPECTED_FILTERS:
-            assert pattern in text, (
+            assert pattern in filters, (
                 f"mutation.yml's mutmut run step is missing the "
                 f"{pattern!r} filter documented next to only_mutate in "
                 f"pyproject.toml -- it would mutate more of dns.py than "

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -289,31 +289,65 @@ class TestMutationWorkflow:
     )
 
     def test_run_applies_the_documented_dns_scope_filters(self) -> None:
-        """Checks the filters inside the actual `mutmut run` argument
-        block, not just anywhere in the file -- a bare substring check
-        would still pass if a filter were dropped from the real command
-        while its text lingered in a comment (this file's own comment
-        block above the step names all four, for exactly the reason
-        that error would be easy to make)."""
+        """Checks the *exact* set of filters `mutmut run` is actually
+        invoked with, parsed the way bash itself would read the
+        continuation lines -- not just anywhere in the file, and not a
+        bare substring check.
+
+        A bare substring check over a loosely-extracted block has two
+        independent gaps a more literal, line-by-line parse closes:
+
+        1. Each argument line must end with a continuation backslash
+           to keep the shell command going onto the next line. A line
+           silently missing it ends the real `mutmut run` invocation
+           right there -- anything quoted on later lines is never
+           actually passed to mutmut, no matter how legitimate it
+           looks in the source. Requiring the backslash explicitly
+           here (rather than tolerating its absence and hoping the
+           parse boundary happens to land in the right place) is what
+           makes the check trace real bash semantics instead of an
+           incidental regex artifact.
+        2. Presence-only checking cannot notice an *extra* filter
+           tacked onto the command -- pyproject.toml's only_mutate
+           comment documents exactly four filters, and a fifth would
+           silently widen the audited DNS scope without failing
+           anything. Comparing the complete parsed filter set against
+           EXPECTED_FILTERS, rather than checking each expected
+           pattern's presence, catches both a missing filter and an
+           extra one.
+        """
         text = MUTATION.read_text()
         match = re.search(
             r"(?m)^          uv run --frozen mutmut run \\\n"
-            r"(?P<filters>(?:            '[^']+'\s*\\?\n?)+)",
+            r"(?P<rest>(?:.*\n)*)",
             text,
         )
         assert match is not None, (
             "mutation.yml's mutmut run step no longer matches the "
-            "expected 'uv run --frozen mutmut run \\' + quoted-filter-"
-            "lines shape"
+            "expected 'uv run --frozen mutmut run \\' shape"
         )
-        filters = match.group("filters")
-        for pattern in self.EXPECTED_FILTERS:
-            assert pattern in filters, (
-                f"mutation.yml's mutmut run step is missing the "
-                f"{pattern!r} filter documented next to only_mutate in "
-                f"pyproject.toml -- it would mutate more of dns.py than "
-                f"was ever audited"
-            )
+
+        # Parse the quoted argument lines exactly as bash would read
+        # them: a line ending in " \" continues the command onto the
+        # next line, and a line without one is the last argument --
+        # parsing stops there even if more quoted-looking lines follow,
+        # because bash would never see them as part of this command.
+        filters: list[str] = []
+        for line in match.group("rest").splitlines():
+            argument = re.fullmatch(r"            '([^']+)'( \\)?", line)
+            if argument is None:
+                break
+            filters.append(argument.group(1))
+            if argument.group(2) is None:
+                break
+
+        assert sorted(filters) == sorted(self.EXPECTED_FILTERS), (
+            f"mutation.yml's mutmut run step actually applies "
+            f"{sorted(filters)}, which does not exactly match the "
+            f"filters documented next to only_mutate in pyproject.toml, "
+            f"{sorted(self.EXPECTED_FILTERS)} -- it would mutate either "
+            f"more or less of dns.py than was ever audited"
+        )
 
 
 # Each new workflow file's defining job, and one distinctive thing that

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -14,8 +14,8 @@ files are small and uniformly two-space indented; a parse failure here
 fails the test loudly instead of passing vacuously.
 
 The commit-SHA-pinning check in particular is parametrized over every
-file a glob of .github/workflows/*.yml finds, rather than a fixed list
-of workflow names. A fixed list quietly stops covering a file the
+file a glob of .github/workflows/*.yml and *.yaml finds, rather than a
+fixed list of workflow names. A fixed list quietly stops covering a file the
 moment someone adds a new one and forgets to update the list here --
 the same failure mode as ALL_PROTOCOLS silently skipping DNSOverTCP
 (see the fuzz-completeness test), just relocated to CI's own workflows.
@@ -31,7 +31,7 @@ CI = WORKFLOWS / "ci.yml"
 RELEASE = WORKFLOWS / "release.yml"
 FUZZ = WORKFLOWS / "fuzz.yml"
 DEPENDABOT = WORKFLOWS.parent / "dependabot.yml"
-ALL_WORKFLOWS = sorted(WORKFLOWS.glob("*.yml"))
+ALL_WORKFLOWS = sorted([*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")])
 
 
 def job_blocks(workflow: Path) -> dict[str, str]:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -30,6 +30,7 @@ WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
 CI = WORKFLOWS / "ci.yml"
 RELEASE = WORKFLOWS / "release.yml"
 FUZZ = WORKFLOWS / "fuzz.yml"
+MUTATION = WORKFLOWS / "mutation.yml"
 DEPENDABOT = WORKFLOWS.parent / "dependabot.yml"
 ALL_WORKFLOWS = sorted([*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")])
 
@@ -220,7 +221,11 @@ class TestCIWorkflow:
     def test_build_verifies_reproducibility(
         self, ci_jobs: dict[str, str]
     ) -> None:
-        """The build job must diff two independent builds, not just one."""
+        """The build job must actually compare two independent builds'
+        artifacts, not merely claim to and build the wheel some number
+        of times -- a block containing the word "reproducible" and
+        three "uv build" calls would previously pass this test without
+        ever diffing anything."""
         block = ci_jobs.get("build")
         assert block is not None, "ci.yml has no build job"
         assert "reproducible" in block.lower(), (
@@ -230,6 +235,18 @@ class TestCIWorkflow:
             "reproducible-build-diff step must build the wheel twice, in "
             "addition to the job's own initial build, to have anything "
             "to diff"
+        )
+        assert "sha256sum" in block, (
+            "reproducible-build-diff step no longer hashes the built "
+            "artifacts to compare them"
+        )
+        assert re.search(r'\$hash1"?\s*!=\s*"?\$hash2', block), (
+            "reproducible-build-diff step no longer compares the two "
+            "builds' hashes against each other"
+        )
+        assert "exit 1" in block, (
+            "reproducible-build-diff step no longer fails the job when "
+            "the compared hashes differ"
         )
 
 
@@ -253,6 +270,33 @@ class TestFuzzWorkflow:
         assert re.search(r"^concurrency:", FUZZ.read_text(), re.M), (
             "fuzz.yml no longer declares a top-level concurrency group"
         )
+
+
+class TestMutationWorkflow:
+    # pyproject.toml's [tool.mutmut] only_mutate covers the whole of
+    # checksum.py, _tlv.py, and dns.py, but the audited DNS surface is
+    # only its name-compression byte walk -- mutmut has no config-level
+    # way to scope below a whole file, so pyproject.toml's own comment
+    # documents these positional filters as the way to reproduce that
+    # narrower scope. If the workflow step doesn't pass them, it mutates
+    # (and reports on) all of dns.py's untriaged record/RDATA/dataclass
+    # code every night, silently wider than what was ever audited.
+    EXPECTED_FILTERS = (
+        "netprotocols.checksum.*",
+        "netprotocols._tlv.*",
+        "netprotocols.layer7.dns.x__read_name*",
+        "netprotocols.layer7.dns.x__labels*",
+    )
+
+    def test_run_applies_the_documented_dns_scope_filters(self) -> None:
+        text = MUTATION.read_text()
+        for pattern in self.EXPECTED_FILTERS:
+            assert pattern in text, (
+                f"mutation.yml's mutmut run step is missing the "
+                f"{pattern!r} filter documented next to only_mutate in "
+                f"pyproject.toml -- it would mutate more of dns.py than "
+                f"was ever audited"
+            )
 
 
 # Each new workflow file's defining job, and one distinctive thing that

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -289,8 +289,12 @@ class TestCIWorkflow:
         # branch inside the real mismatch block -- e.g. `if false; then
         # exit 1; fi` sitting inside the outer `if [ "$hash1" !=
         # "$hash2" ]; then ... fi` -- would still read as "exit 1 is in
-        # body" without being reachable. Closing that would mean
-        # tracking `if`/`fi` nesting depth instead of matching to the
+        # body" without being reachable. The same blind spot covers an
+        # `elif` arm: `if [ "$hash1" != "$hash2" ]; then echo ...; elif
+        # false; then exit 1; fi` textually places "exit 1" inside the
+        # captured body even though it can only run when the mismatch
+        # branch does NOT. Closing either case would mean tracking
+        # `if`/`elif`/`fi` control flow instead of matching to the
         # first `fi`, which is more machinery than a YAML/bash text
         # heuristic like this one is worth carrying for a case the real
         # ci.yml step doesn't (and has no reason to) construct.
@@ -358,6 +362,39 @@ class TestCIWorkflow:
         with pytest.raises(
             AssertionError, match="sha256sum of the dist-repro-1 wheel"
         ):
+            self._assert_diffs_two_independent_builds(script)
+
+    def test_build_reproducibility_check_rejects_a_non_failing_mismatch(
+        self,
+    ) -> None:
+        """Regression test for the other gap in the previous version of
+        :meth:`test_build_verifies_reproducibility`: the cosmetic-stand-in
+        fixture above trips the ``hash1=`` assertion, so it never reaches
+        -- and never proves correct -- the two strongest checks after it,
+        the reachable ``if [ "$hash1" != "$hash2" ]; then ... fi`` block
+        match and the "exit 1 inside that block" requirement.
+
+        This fixture's step performs the real `sha256sum` assignments and
+        has a real, reachable hash-mismatch `if`/`fi` block -- so it must
+        clear the `hash1`/`hash2` and `if`/`fi`-match checks -- but that
+        block only echoes an error instead of exiting non-zero. A step
+        like this would report a hash difference without ever failing
+        CI, so it must still be rejected, by the `exit 1`-in-body check
+        specifically.
+        """
+        non_failing_step = (
+            f"      - name: {self.REPRODUCIBILITY_STEP_NAME}\n"
+            "        run: |\n"
+            "          uv build -o dist-repro-1\n"
+            "          uv build -o dist-repro-2\n"
+            "          hash1=$(sha256sum dist-repro-1/*.whl | cut -d ' ' -f1)\n"
+            "          hash2=$(sha256sum dist-repro-2/*.whl | cut -d ' ' -f1)\n"
+            '          if [ "$hash1" != "$hash2" ]; then\n'
+            '            echo "::error::not reproducible"\n'
+            "          fi\n"
+        )
+        script = self._reproducibility_step_script(non_failing_step)
+        with pytest.raises(AssertionError, match="exit 1"):
             self._assert_diffs_two_independent_builds(script)
 
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -135,6 +135,47 @@ class TestReleaseGate:
                 )
 
 
+def uses_ref(line: str) -> str | None:
+    """The action reference on a ``uses:`` step line, or ``None`` if the
+    line isn't one. Matches both the standard YAML list form
+    (``- uses: ...``) and the bare form (``uses: ...``) -- a regex
+    anchored past only the list marker's optional dash previously
+    missed every real ``- uses:`` line in this repo, silently turning
+    :class:`TestActionPinning` into a no-op."""
+    match = re.match(r"\s*(?:-\s*)?uses:\s*(\S+)", line)
+    return match.group(1) if match else None
+
+
+class TestUsesRefMatching:
+    """Regression coverage for :func:`uses_ref` itself, independent of
+    which real workflow files currently exist -- this is what actually
+    failed silently before, so it gets tested directly rather than only
+    through TestActionPinning's end-to-end check."""
+
+    def test_matches_the_list_form(self):
+        assert (
+            uses_ref("      - uses: actions/checkout@" + "a" * 40)
+            == "actions/checkout@" + "a" * 40
+        )
+
+    def test_matches_the_bare_form(self):
+        assert (
+            uses_ref("      uses: actions/checkout@" + "a" * 40)
+            == "actions/checkout@" + "a" * 40
+        )
+
+    def test_list_form_with_a_moving_tag_is_still_extracted(self):
+        """Extraction doesn't itself judge the ref -- TestActionPinning
+        does that -- but it must not silently drop an unpinned list-form
+        line the way the pre-fix regex did."""
+        assert uses_ref("      - uses: actions/checkout@v4") == (
+            "actions/checkout@v4"
+        )
+
+    def test_non_uses_line_does_not_match(self):
+        assert uses_ref("      run: echo hello") is None
+
+
 class TestActionPinning:
     """Every third-party action, in every workflow, must be pinned.
 
@@ -155,11 +196,8 @@ class TestActionPinning:
         (checked above) and cannot be "pinned" to a SHA at all.
         """
         for line in workflow.read_text().splitlines():
-            match = re.match(r"\s*uses:\s*(\S+)", line)
-            if not match:
-                continue
-            ref = match.group(1)
-            if ref.startswith("."):
+            ref = uses_ref(line)
+            if ref is None or ref.startswith("."):
                 continue
             _, sep, pin = ref.rpartition("@")
             assert sep and re.fullmatch(r"[0-9a-f]{40}", pin), (

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,9 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -68,6 +70,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/4a/587eb36dcc240a54c8660f599464516b469ecad96f0dbdb6bccbedb50745/ast_serialize-0.8.0-cp39-abi3-win32.whl", hash = "sha256:31883542dd6c94d178f5db3d32fbd69c5eb88b3a7c018e7ac8cc0c45195ddbed", size = 1068858, upload-time = "2026-08-07T11:28:57.541Z" },
     { url = "https://files.pythonhosted.org/packages/5f/a4/3e887bbd92164e183cb6e412c6a3e9198ddd446d7fe405958293ef5ef49c/ast_serialize-0.8.0-cp39-abi3-win_amd64.whl", hash = "sha256:861794565b06337005c1447ef23103a3d5a627d08bdc827870d00d0b28ef5f51", size = 1111839, upload-time = "2026-08-07T11:28:59Z" },
     { url = "https://files.pythonhosted.org/packages/25/6c/b400476d3ceba681ab929787edc9554f6d88fcc69435eb681b00fc0457a5/ast_serialize-0.8.0-cp39-abi3-win_arm64.whl", hash = "sha256:b2a5978662fd4db463dfb4b974d2b10ac6430b98f5333aabc7051909df3561d0", size = 1083655, upload-time = "2026-08-07T11:29:00.349Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -269,6 +280,60 @@ wheels = [
 ]
 
 [[package]]
+name = "libcst"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/098e5c91ff1537f00c85a6438b6cb1863d17144680cc91f47c87f104a200/libcst-1.9.0.tar.gz", hash = "sha256:087b58a9afe076bb08e2d726478e1f16cb928d67ffa9092817e033c335de522a", size = 914739, upload-time = "2026-07-29T21:28:43.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/bb/d22c37c33dfe18084634f5ef89f8f0749ffe7b6e0ad312722aafd86bbbdb/libcst-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd1a3500c41784075c4946a995d5ad89f68fa0d226b63ff3c4d78f6ea6dd23e5", size = 2043159, upload-time = "2026-07-29T19:24:49.013Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b8/2dedef84d72e7271119217503b69ed6dc5d0b2077685e163caae669d9c70/libcst-1.9.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:611cebd3bbc2014576f4dcc7b845b3c594c96ddc287a3db9b78f22eff156a7d3", size = 2203245, upload-time = "2026-07-29T19:24:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/90/e02ac2dad647423f947bb11f8322bfdba8ccfdd380e6c7b695add2d1acd4/libcst-1.9.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8d731abe1307720ea1a52d447555e8443a6d130e0e520243c0634a58f6edbc9d", size = 2255388, upload-time = "2026-07-29T19:24:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5f/6089a51518cfd2ff40950eb26bcc36951d7b6d4f4213568aa0290265aff7/libcst-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5351d92ca6ac1cc32e097700e1161ad1ceaa4d9b2cca5abadb1e94576b325", size = 2268982, upload-time = "2026-07-29T19:24:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/78/26881ec466fb70cbc129dca26ccb5a52a0061face2c5822e4b61f00f9699/libcst-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03165a264653bb77f6a11b412ae09c08bdb0c25864f3b8d42b816ac64b9d4b9e", size = 2378174, upload-time = "2026-07-29T19:24:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/7a/a4dba5f11faf12a12ffba06d18019987851aab33b590242a602ffd4fb1bd/libcst-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:b755ed4a4bc2faee849b54820023137d60d4c199e0a0822f0ff0c1bc49e49b48", size = 2103462, upload-time = "2026-07-29T19:24:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/13/57cb129093e0d6744b3c914ba6cbbdf51ed1b2c823882936c553a3a0cf1b/libcst-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e50576bad7d56459d9792cd0b0dfe5469dad13646e9a9c0a8b1ba20b269f332", size = 1979825, upload-time = "2026-07-29T19:24:58.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b1/befc0544283bb3923a928accf79ed685e5a725524bdb3491826670affc07/libcst-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8b9df30f524317b097dc53065b25dda33d6a4cc3c7c8bf4fc83ca7559c58cc0", size = 2043754, upload-time = "2026-07-29T19:24:59.885Z" },
+    { url = "https://files.pythonhosted.org/packages/45/50/fef7c172a8457c95894edf5fb04805024899cdfea41fa01b0636587b79e1/libcst-1.9.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e465a7bc9c2b9533eb9e06d2391f8819f811b5112919d4064c9fb8565aaafa08", size = 2203548, upload-time = "2026-07-29T19:25:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/764cd2be1fd99d774fc44039c319dc0ed1d9d9afeaa02759a05121cccd4b/libcst-1.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8504b422c95676a8c27b517e1ac01413ece91bf356865c587ca9bdcd5708a2f7", size = 2255274, upload-time = "2026-07-29T19:25:02.764Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a7/474748a27a02fa83e3556b260d5f5236ca48164fa7beffecf3b2cad24dca/libcst-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bcb9f9d4fcfe2ec7a40d2c26e03a538d5d9dc189c38551eb3f94ab661afee7c0", size = 2269126, upload-time = "2026-07-29T19:25:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b7/655e45363b8cf87b91e41e060b21c89e5316c7ef36eb14a1a498b27bb71e/libcst-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8d671c39a431c309476099b8ec811e412503ec0f4465f6fc907cb51c70e8e6b", size = 2378602, upload-time = "2026-07-29T19:25:06.424Z" },
+    { url = "https://files.pythonhosted.org/packages/db/13/6da63f0902ece43bf9d737017251ad7ad06edd9d3c4e1856450403cb4473/libcst-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:4d382fba04077eb556a1ea4295a4482e192aa93639c5a07ba0885841965ea0c0", size = 2103486, upload-time = "2026-07-29T19:25:07.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/dccb1a55e38b4e47256a97242d61d2bef5366c744faf88fb087d4fa0f995/libcst-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:a621e261990148c1cfbe26c1798bd2375c131cf358a44a7a4659fc41c1a336e1", size = 1979907, upload-time = "2026-07-29T19:25:09.532Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2a/4943c71d90975bc59034a057dea346b365c276f308c1d31f5cf2bd85492d/libcst-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eccf4c57d273cdd3fe1c67b72cf9bb1bbd4547aa011824e96ccf5b7136057aa4", size = 2044529, upload-time = "2026-07-29T19:25:11.04Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1168b98c2a0f338be3a44753647baab051feaf6167cc887bf4447f8fd920/libcst-1.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32395244edfe6538e0ea2bf82051d60103d3f54861274805c4fb3745efb70a85", size = 2203519, upload-time = "2026-07-29T19:25:12.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7d/2eaa697a80f899bcf2245680bbfcc1e478eb3b3328c21d4b2880bdf00dac/libcst-1.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:444e84c76cd035cd2fe136838c1a524d34b08216521f6f5093df8a6f6cfa5799", size = 2255879, upload-time = "2026-07-29T19:25:14.137Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/793b9fd96dd52d202f5f2b88d7e54f05ebed767d1bb3b32395a1817bf6ab/libcst-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb5d0946f2b4c6711b5d69fe4f833b364f9e7a1a2b08f88b98619dc18975099a", size = 2269807, upload-time = "2026-07-29T19:25:15.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/1bc7aaea03971c45e8a885fed9fc1c73176dbbd00b0296a3cde9529bafd6/libcst-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45808c03528b3ad40b14095348a918e08d98c47b4a125d631cb78e817c0a5b16", size = 2378171, upload-time = "2026-07-29T19:25:17.289Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f7/bc49e367d2bc8817213594dd52cf6b2da2dbbda90b5382d60653999274ac/libcst-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:568288cdbfe3b4ca3ae4852cb0a439ff053dd54c841bc4995bf2b71238b5de40", size = 2177847, upload-time = "2026-07-29T19:25:19.35Z" },
+    { url = "https://files.pythonhosted.org/packages/87/80/4d81577a22e6d535d1a3409f3a1c6903e09036f0e17fc47f92169dbc3501/libcst-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:107593af46945593e7825821793393262bc4fa1d3ea24c3ed487b61269bbbdf8", size = 2058134, upload-time = "2026-07-29T19:25:20.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7f/c3f3a0e7a1a2adaa76e815e82a7814d6bfe7d49432276bba652248c68d0b/libcst-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f6248cb07444ab9a6733a855737a9febed8b9adca51347019348b09a3ac7dfe9", size = 2036102, upload-time = "2026-07-29T19:25:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/af/2f5543255b2c7d749b966adeccc6bfb1652cf8b425afb913d0f3f025a865/libcst-1.9.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:496c24e0d3240bc7da45dae543aff3f5b6509978c39262d6b84ed2fb999dded2", size = 2194806, upload-time = "2026-07-29T19:25:24.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/03f4cddce426d005e208b39ea7b2d456e667cdee0f1891360f0fc8430f20/libcst-1.9.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ea490fa8540503db5f321f0268becab46eb50f710e8cec8041e241fd66f6874f", size = 2246762, upload-time = "2026-07-29T19:25:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/31/9d5fe1e43dc3dbcc74f70f3e0e73fcdd8d84effc1059d8b45974f0d0d2eb/libcst-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50ab94bb2524b419056d4003032b8c67102ac800f8d85b3c4260a01746d94dbb", size = 2259633, upload-time = "2026-07-29T19:25:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/6752b28d88c3a19b3bc0b9e1838443b6760d5c862b4f4b37955402659e24/libcst-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a2faaf92500d0226358125630f5aab4758e8aad3f2d70a10892ec3c700781a54", size = 2368043, upload-time = "2026-07-29T19:25:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/94/775825b2637f8ab05694b6a4b3802ae6783b4e799f9b58d2400c7e2d4369/libcst-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c7b548512db25af9c2997a95fa731bd6b6928ecbad6c0915d7482d8bb42d34f", size = 2176432, upload-time = "2026-07-29T19:25:29.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/88ad67427c6fd9db929e087912b0a540e5140e5cb77e7ca4170edaac8531/libcst-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:497d5329345f1f5df84e41b0bbd00204b64a2fd30dfe3cfaeaebca633a31e877", size = 2052931, upload-time = "2026-07-29T19:25:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/ad790b043a38b10cea13166c8dd716654ad8b227c20f12eebf6326191cd9/libcst-1.9.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:a5068bf6114f6f4d79af7a6c80a28d1deb50441150ea1db13b5458ab34bec159", size = 2043987, upload-time = "2026-08-11T05:54:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/d3cd8275cc54ffc9817ade91442b3e6e9edd1a4518bd4e6dda13e3152dbe/libcst-1.9.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:7acfd18adcdd32dcf41ce676cf121002afcbe9ad2c72dc0c18d78465beedc228", size = 2204003, upload-time = "2026-08-11T05:54:04.031Z" },
+    { url = "https://files.pythonhosted.org/packages/da/62/87eddccb11d5d221d50ac4fff4b6e9b8d48c547028d01f7d0fbc5c8a1d75/libcst-1.9.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:86361e2b426bd1b403e52375703c8b764e226e571adcb30442510710681edbf0", size = 2256053, upload-time = "2026-08-11T05:54:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/a44126aeb9fca8b4e342e0cc803ea00ca8f6cd5712619a7897b3eba13797/libcst-1.9.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8c14abe844bec8b021111b3985474e49f5af799c020e8e40dedcac87c97a40c5", size = 2270576, upload-time = "2026-08-11T05:54:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/51/3af3dd44b117d66486e0ed61e43a16b7fc8cc5c372e1dd4ca0e70b888d46/libcst-1.9.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:8930971d2299b7006bb5d10c10038f44efb6da89d5bca2823595e31a9cdb96af", size = 2378573, upload-time = "2026-08-11T05:54:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e8/e545087d298dbf6494e84a8092f0f5dbd62eedacabd4ecd6b364367b4804/libcst-1.9.0-cp315-cp315-win_amd64.whl", hash = "sha256:5891ce9cff815077614f509e3a23888c5ddb8081d6188e8ba1172c0ccc369022", size = 2177937, upload-time = "2026-08-11T05:54:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/84/17/93a00a8e03494a84db102dd0e3d35b8876b1084ca2c194b331a168d86eb1/libcst-1.9.0-cp315-cp315-win_arm64.whl", hash = "sha256:1260b5d070a3324447a53a00387225a55472a62077ce01922d30a2a78cc4b138", size = 2058633, upload-time = "2026-08-11T05:54:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/c3751b12eb81822ea0b6131d374a98bc6c024c4b9ec5f6ea8f53dc23e967/libcst-1.9.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:02ee2dbdb5c218116f16a021350fc267a14be205b50d81c33f5d73857ab6fbf7", size = 2036178, upload-time = "2026-08-11T05:54:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/48ff486eb5adc593f4818569e8896b74b672414ab4722a74b17e4c4cf31e/libcst-1.9.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:3e5b684191a0462b2d40a73261ea7f4da6a49e7a030b7e0fceca46bebb51dfe5", size = 2195496, upload-time = "2026-08-11T05:54:17.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/18/b13a4669864d41a4801fed7b86ede1049dc9a1e1dde250a7ee1f9c3b1285/libcst-1.9.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:2b150c4f298fe54eb0fe73abf71f57db74d070796140a8c206c9615b6861f01e", size = 2245769, upload-time = "2026-08-11T05:54:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c7/cf2d46744825e84afbd7228fdeeea8d23cf6c4b2074253c27efb7705c653/libcst-1.9.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:50b913e37187f00a6fb88962009364e1cf1b1284aa1762304f34b52b972f2218", size = 2260576, upload-time = "2026-08-11T05:54:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/5433d3d62250b2e4325938db101766bcab2a006819684713bcccb6259a88/libcst-1.9.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9f92c75283030fd58fb7d6e560168a00381e0e3368ec8a026a3ec8a828a05f93", size = 2368709, upload-time = "2026-08-11T05:54:23.276Z" },
+    { url = "https://files.pythonhosted.org/packages/87/39/9f0e1690727623f99489895db0e42048a3e1e8cea0627517c593e437fd83/libcst-1.9.0-cp315-cp315t-win_amd64.whl", hash = "sha256:4adf97bb1aff8039b0bd4991e2f838be6e4fad552821b26b71a5d1a653c2582f", size = 2177866, upload-time = "2026-08-11T05:54:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/79/9dc7811883e67ea771057e8937bc536eb3e77f3635fc5a93cd85b6fe1ea8/libcst-1.9.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8f0dd08a5773d7051e105250b2a2c73d8065ea9b2d68e7e1bdc5244660e75f93", size = 2052908, upload-time = "2026-08-11T05:54:26.835Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +435,70 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f9/a63500696f3f35c443ef566528e55630bf7e064436416278927f7bc9c408/mutmut-3.7.0.tar.gz", hash = "sha256:dc93260fabb3a6fd3693aa8d1746825885cb6f9e66c7f9cc1a0f34fc6388e14a", size = 63735, upload-time = "2026-07-31T10:52:58.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/16/93e3e6aa30e5bc4141724463ae9d9bcc283d08b02aa85dbf5a2b665f3108/mutmut-3.7.0-py3-none-any.whl", hash = "sha256:1d2f9a1bfa4a474b2213df6b17223150b492bf4a85af0eda4fb322297337fb32", size = 59070, upload-time = "2026-07-31T10:53:00.005Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -444,6 +573,7 @@ bench = [
 ]
 dev = [
     { name = "hypothesis" },
+    { name = "mutmut" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -459,6 +589,7 @@ bench = [
 ]
 dev = [
     { name = "hypothesis", specifier = ">=6.100" },
+    { name = "mutmut", specifier = ">=3.7.0" },
     { name = "mypy", specifier = ">=1.14" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=6.0" },
@@ -481,6 +612,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
 ]
 
 [[package]]
@@ -532,6 +672,89 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.4"
 source = { registry = "https://pypi.org/simple" }
@@ -566,12 +789,87 @@ wheels = [
 ]
 
 [[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A full code-quality review and refactor pass across source, tests, and CI, done ahead of onboarding a large batch of new protocols. The codebase was already unusually mature (99.95% coverage, strict mypy, comprehensive CI) — this is a surgical pass on the genuine gaps found, not a rewrite.

**Source deduplication:**
- Added a shared `hex_str()` helper in `_base.py`, replacing 11 duplicated hex-formatting properties across 8 files
- Added `_ip_protocol_enum()`/`_ethertype_enum()` helpers beside the existing `_ip_protocol_name()`/`_ethertype_name()`, replacing 9 duplicated enum-fallback properties across 6 files — also fixed `arp.py`'s `ptype_name`, which was hand-rolling logic `ethernet.py` already centralized, and a 4th, previously undetected copy of the same pattern in `vlan.py`
- Added a new `_tlv.py` module unifying three duplicated TLV/options-parsing loops (TCP, IPv4, IPv6 extension headers) behind one generic, bounds-checked cursor walker

**Test hardening:**
- Fixed a real gap: `DNSOverTCP` was missing from `test_fuzz.py`'s `ALL_PROTOCOLS`; added a `Protocol.__subclasses__()`-walking completeness test so this can't silently recur
- Relocated `TestEnumCompleteness` out of `test_ipv6_ext.py` into its own `test_enums.py`
- Brought `conftest.py`/`strategies.py` under strict mypy (sized the full-suite gap at 639 errors across 22 files — too large for this pass, staged incrementally)
- A scoped `mutmut` mutation-testing audit against `checksum.py`, `_tlv.py`, and DNS's name-compression walk closed several genuine test gaps (an untested IGMP checksum path, weak error-identity assertions, a signed/unsigned boundary case) and documented two accepted-equivalent-mutant survivors

**CI/CD hardening:** SHA-pinned GitHub Actions + concurrency groups on `ci.yml`/`release.yml`/`fuzz.yml`, a dependency-vulnerability-scan job, a reproducible-build hash check, a nightly scoped mutation-testing workflow, CodeQL's default Python analysis, an OSSF Scorecard workflow + README badge, a `lychee` docs link-checker, Conventional-Commits PR-title linting, and Dependabot for both the `uv` and `github-actions` ecosystems.

**Docs sync:** `ARCHITECTURE.md`'s layout map and cookbook, and `docs/CLAIMS.md`'s drift-prone figures (module count, wheel size, line/statement/raise-site counts), updated to reflect the refactor per the repo's own re-measurement convention.

**Deliberately left alone**, with reasoning preserved in the commit history: the `object.__new__`/`object.__setattr__` decode-shortcut duplication (sits on the benchmark-gated hot path; the underlying finding argued against fixing it), forcing DNS's two byte-walk functions together (different termination semantics), generalizing ARP's single-consumer enum-fallback helpers, and 5 test-redundancy candidates (flagged for a human confirmation pass, not deleted).

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `uv run pytest --cov=netprotocols --cov-report=term` — 1148 passed, 99.95% coverage (gate: 98%)
- [x] `pytest tests/test_docs.py`
- [x] `pytest tests/test_workflows.py`
- [x] `scripts/benchmark.py --check --threshold 15 --compare` — -4.8% vs. baseline, within threshold
- [ ] New CI jobs (mutation nightly, dependency audit, CodeQL, Scorecard, reproducible-build check, docs-lint, PR-title-lint) verified locally for YAML validity and logic, but GitHub-native runtime behavior (permissions, OIDC scopes, third-party action expectations) can only be confirmed once this PR's own CI run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7YhSxmmB2VT8B5inbXP6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7YhSxmmB2VT8B5inbXP6z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public helper for consistent hexadecimal value formatting.
  - Improved validation and error reporting for TCP, IPv4, and IPv6 options.

- **Security & Quality**
  - Added dependency auditing, code scanning, security scoring, fuzzing, mutation testing, reproducible-build checks, and release provenance verification.
  - Added automated pull request title and documentation link checks.

- **Documentation**
  - Updated architecture, contribution, measurement, and project documentation.

- **Testing**
  - Expanded checksum, protocol, workflow, enum, DNS, and parser coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->