### PR TITLE
ci: improve OpenSSF Scorecard coverage (permissions, packaging, signed releases, SBOM, security policy, fuzzing)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @EONRaider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# No job here needs to write anything -- lint/typecheck/test/build/pyodide/
+# benchmark all read the checked-out tree and call out to local tools.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -66,3 +66,30 @@ jobs:
           name: hypothesis-nightly-failure-${{ github.run_id }}
           path: .hypothesis
           retention-days: 30
+
+  # Coverage-guided fuzzing of the same target, via Atheris rather than
+  # Hypothesis's example strategies above -- it drives decode_frame with
+  # libFuzzer's mutation engine instead of Hypothesis's, so it explores
+  # a different part of the input space. Pinned to Python 3.12 only,
+  # like the "fuzz" job above: Atheris hooks CPython internals directly
+  # and tends to lag new interpreter releases, so it isn't given the
+  # full 3.12/3.13/3.14 matrix the compatibility-gate "test" job in
+  # ci.yml runs.
+  atheris:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: "3.12"
+      - name: Run Atheris against decode_frame
+        run: |
+          uv run --frozen --with atheris \
+            python tests/fuzz/fuzz_decode_frame.py -max_total_time=300
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: atheris-crash-${{ github.run_id }}
+          path: crash-*
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,48 @@ jobs:
       # exact commit -- run before the artifacts are published so a
       # failed attestation blocks the release instead of trailing it.
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             dist/*.whl
             dist/*.tar.gz
-      - run: uv publish --trusted-publishing always
+      # attest-build-provenance stores the attestation server-side via
+      # GitHub's API but doesn't attach anything to the release itself --
+      # copy its bundle to a name the github-release job can upload as a
+      # downloadable asset. The default bundle-path filename carries no
+      # recognizable suffix, so it must be renamed rather than uploaded
+      # as-is.
+      - name: Rename provenance bundle for release upload
+        run: |
+          cp "${{ steps.attest.outputs.bundle-path }}" \
+            "netprotocols-${GITHUB_REF_NAME#v}.sigstore.json"
+      # Zero runtime dependencies makes this a straightforward inventory
+      # of exactly one component (netprotocols itself) built from the
+      # wheel that is about to be published, not the dev/build toolchain.
+      - name: Generate SBOM
+        run: |
+          uv venv .sbom-venv
+          uv pip install --python .sbom-venv/bin/python dist/*.whl
+          uvx --from cyclonedx-bom cyclonedx-py environment .sbom-venv \
+            --pyproject pyproject.toml --mc-type library \
+            -o "netprotocols-${GITHUB_REF_NAME#v}.cdx.json"
+      - name: Upload release assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-assets
+          path: |
+            netprotocols-*.sigstore.json
+            netprotocols-*.cdx.json
+          retention-days: 5
+      # Scorecard's Packaging check looks for this action's `uses:` line
+      # specifically -- `uv publish` builds and uploads to PyPI just as
+      # well, but isn't one of the publishing mechanisms it recognizes.
+      # PyPI's trusted-publisher binding is keyed on repo + workflow
+      # filename + environment, not which step calls it, so this needs
+      # no reconfiguration on PyPI's side. `id-token: write` above is
+      # what it uses to authenticate.
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 (v1.14.2)
 
   github-release:
     needs: publish
@@ -86,6 +122,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-assets
       # CHANGELOG.md is the single source of truth for release notes, so
       # extract this tag's own section rather than maintaining a second
       # copy anywhere. A missing section fails loudly instead of
@@ -110,4 +150,5 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" \
             --title "netprotocols ${GITHUB_REF_NAME#v}" \
             --notes-file release-notes.md \
-            --latest
+            --latest \
+            netprotocols-*.sigstore.json netprotocols-*.cdx.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of netprotocols receives security
+fixes. Older versions are not backported.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately rather than opening a
+public issue.
+
+- Preferred: use GitHub's [private vulnerability
+  reporting](https://github.com/EONRaider/NETProtocols/security/advisories/new)
+  for this repository.
+- Alternative: email livewire_voodoo@protonmail.com with a description
+  of the vulnerability, the affected version, and steps to reproduce
+  it.
+
+You should expect an initial response within 5 business days. We aim
+to confirm the vulnerability, assess its severity, and agree on a
+disclosure timeline with you within that window.
+
+We follow coordinated disclosure: once a fix is available, we will
+credit reporters (unless anonymity is requested) in the release notes
+and CHANGELOG.md. We ask that you not publicly disclose the
+vulnerability until a fixed version has been released, and in any case
+not before 90 days have elapsed since your initial report, whichever
+comes first.
+
+## Scope
+
+netprotocols is a pure decoding/encoding library for network protocol
+headers. Of particular interest are:
+
+- Crashes, hangs, or excessive resource consumption when decoding
+  untrusted, malformed, or adversarial byte sequences (e.g. via
+  `decode_frame`).
+- Any deviation from documented behavior that could mislead a caller
+  about the contents of a decoded packet.
+
+Vulnerabilities in third-party tooling used only in CI (linters, type
+checkers, the build backend) are out of scope for this policy --
+please report those upstream instead.

--- a/tests/fuzz/fuzz_decode_frame.py
+++ b/tests/fuzz/fuzz_decode_frame.py
@@ -1,0 +1,26 @@
+"""Atheris coverage-guided fuzz harness for :func:`decode_frame`.
+
+Run directly (not via pytest): ``decode_frame`` is documented to return
+a :class:`~netprotocols.walk.Packet` or raise
+:class:`~netprotocols.utils.exceptions.ProtocolError` for any input --
+never anything else -- so any other exception here is a real bug.
+
+    python tests/fuzz/fuzz_decode_frame.py -max_total_time=120
+"""
+
+import contextlib
+import sys
+
+import atheris
+
+from netprotocols.utils.exceptions import ProtocolError
+from netprotocols.walk import decode_frame
+
+
+def TestOneInput(data: bytes) -> None:
+    with contextlib.suppress(ProtocolError):
+        decode_frame(data, lax=False)
+
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
## Summary

Ground-truthed against the actual published OpenSSF Scorecard (fetched
from api.securityscorecards.dev: 6.8 aggregate) rather than inferring
scores from workflow YAML alone, and cross-checked with GitHub's own
code scanning alerts (which mirror scorecard.yml's SARIF upload).

- **Token-Permissions** (scored 0): `ci.yml` had no `permissions:`
  block at all. Added `contents: read` at the top level — no job in it
  needs write access.
- **Packaging** (scored -1, "not detected"): `release.yml` published
  via `uv publish`, which Scorecard's Packaging check doesn't recognize
  as a publishing workflow. Switched to `pypa/gh-action-pypi-publish`,
  pinned to a full commit SHA. OIDC trusted publishing keeps working
  since PyPI's binding is keyed on repo + workflow filename +
  environment, not which step calls it.
- **Signed-Releases** (scored -1, "no releases found" — all 7 existing
  releases have zero assets): a real Sigstore attestation was already
  being generated via `actions/attest-build-provenance`, just never
  attached to the release. Renamed its bundle to `*.sigstore.json` and
  upload it as a release asset via a new `release-assets` artifact
  passed between the `publish` and `github-release` jobs.
- **SBOM** check: added a release-asset CycloneDX SBOM alongside it
  (source-tree SBOMs cap at 5/10; a release-asset SBOM can reach
  10/10). Zero runtime dependencies makes this a straightforward,
  accurate one-component inventory.
- **Security-Policy** (scored 0): added `SECURITY.md` with a contact
  channel (GitHub private vulnerability reporting + email) and an
  explicit 90-day disclosure timeline.
- Added `.github/CODEOWNERS` — free, and a real prerequisite if a
  co-maintainer ever joins.
- **Fuzzing** (scored 0): Scorecard's Python fuzzing detector looks for
  a literal `import atheris`; the existing Hypothesis-based property
  tests don't match it no matter how thorough. Added an Atheris
  coverage-guided harness targeting `decode_frame` (the exact right
  target — it decodes untrusted wire bytes and is documented to return
  a `Packet` or raise `ProtocolError`, never anything else) and wired
  it into a new scheduled job in `fuzz.yml`, pinned to Python 3.12
  since Atheris hooks CPython internals and lags new interpreters.
  Verified atheris installs cleanly on 3.12 and the harness runs clean
  (8M+ executions, no crashes) before wiring it in.

**Left untouched, contrary to this repo's own prior assumptions**:
Binary-Artifacts, Code-Review, and Maintained were all already at
10/10 per the real API response (no `.pcap` fixture flagging, no
solo-maintainer penalty on Code-Review). Contributors/CII-Best-Practices
stay as documented "no remediation for small projects" items.

**Also applied outside this PR** (GitHub-admin settings, confirmed with
the repo owner first): a Tier 1 branch-protection ruleset on `master`
(block force-push, block branch deletion, plus a required-status-check
rule for `lint`/`typecheck`/`build` on PR merges — kept for engineering
practice even though Scorecard's tiered scoring means it can't earn
points beyond Tier 1 without a real second reviewer, which isn't
practical for a solo-maintained repo).

## Test plan

- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy`
      all pass
- [x] `uv run --frozen pytest --cov=netprotocols --cov-report=term`:
      1162 passed, 99.95% coverage (including `tests/test_workflows.py`'s
      30 structural checks on the edited workflow files)
- [x] `uv build` + wheel import still works
- [x] Dry-ran the SBOM generation and provenance-bundle-rename commands
      locally against a real build before committing them to the workflow
- [x] Ran the Atheris harness locally for 15s (8.4M executions, no
      crashes) with the exact `uv run --frozen --with atheris ...`
      invocation the new CI job uses
- [ ] First real `release.yml` run on the next tag push will confirm
      the SBOM/provenance-asset upload and `pypa/gh-action-pypi-publish`
      OIDC path end-to-end (not exercisable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a security policy outlining supported versions, vulnerability reporting, response expectations, disclosure practices, and scope.

- **Release Improvements**
  - Published packages through an updated PyPI release process.
  - Release assets now include provenance attestations and a CycloneDX software bill of materials.

- **Quality Improvements**
  - Added automated coverage-guided fuzz testing to help detect unexpected decoding failures and improve release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->