### PR TITLE
test: tighten DNS corpus assertions to close CodeQL false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Development
+- **Tightened three DNS corpus assertions in `tests/test_dns.py` from substring/`endswith` checks to exact equality, closing 3 open CodeQL `py/incomplete-url-substring-sanitization` alerts (#166).** `test_names_decompress_to_real_domains` asserted `"example.com" in names` / `"accounts.youtube.com" in names` against a `set` decoded from a fixed pcap corpus, and `test_answers_parse_to_real_records` asserted `cname.rdata_text.endswith("google.com")` against the same corpus — not security-relevant trust checks, but exactly the substring/suffix pattern the rule flags regardless of what the value's actually validating. Both now compare against the known exact decoded values instead (`names == {"example.com", "accounts.youtube.com"}`, `rdata_text == "www3.l.google.com"`), which removes the pattern CodeQL keys on and is strictly more precise than the checks it replaces.
+
 ## [2.2.1] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Development
+
 - **Tightened three DNS corpus assertions in `tests/test_dns.py` from substring/`endswith` checks to exact equality, closing 3 open CodeQL `py/incomplete-url-substring-sanitization` alerts (#166).** `test_names_decompress_to_real_domains` asserted `"example.com" in names` / `"accounts.youtube.com" in names` against a `set` decoded from a fixed pcap corpus, and `test_answers_parse_to_real_records` asserted `cname.rdata_text.endswith("google.com")` against the same corpus — not security-relevant trust checks, but exactly the substring/suffix pattern the rule flags regardless of what the value's actually validating. Both now compare against the known exact decoded values instead (`names == {"example.com", "accounts.youtube.com"}`, `rdata_text == "www3.l.google.com"`), which removes the pattern CodeQL keys on and is strictly more precise than the checks it replaces.
 
 ## [2.2.1] - 2026-09-07

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -134,8 +134,7 @@ class TestCorpusDNS:
 
     def test_names_decompress_to_real_domains(self):
         names = {walk(frame)[0][-1].question_name for frame in CORPUS_DNS}
-        assert "example.com" in names
-        assert "accounts.youtube.com" in names
+        assert names == {"example.com", "accounts.youtube.com"}
 
     def test_answers_parse_to_real_records(self):
         records = [
@@ -148,9 +147,9 @@ class TestCorpusDNS:
         # An A record's RDATA decodes to the dotted IPv4 in rdata_text.
         a = next(r for r in records if r.rtype_name == "A")
         assert a.rdata == socket.inet_aton(a.rdata_text)
-        # A CNAME's RDATA decompresses to a real target domain.
+        # A CNAME's RDATA decompresses to the real target domain.
         cname = next(r for r in records if r.rtype_name == "CNAME")
-        assert cname.rdata_text.endswith("google.com")
+        assert cname.rdata_text == "www3.l.google.com"
 
     def test_authority_soa_and_additional_opt(self):
         stacks = [walk(frame)[0][-1] for frame in CORPUS_DNS]


### PR DESCRIPTION
## Summary

Closes #166. CodeQL flagged 3 open `py/incomplete-url-substring-sanitization` alerts (#7, #8, #9) in `tests/test_dns.py`, all on assertions checking decoded DNS names against a fixed pcap corpus (`CORPUS_DNS`) — not security-relevant URL/domain trust checks, but exactly the raw substring/`endswith` pattern the rule is built to flag. Rather than dismissing the alerts via the code-scanning API, this tightens the checks to exact equality against the known decoded values, which removes the flagged pattern entirely and is strictly more precise than what it replaces.

## What's included

- `tests/test_dns.py`: `test_names_decompress_to_real_domains` now asserts `names == {"example.com", "accounts.youtube.com"}` instead of two `in` membership checks; `test_answers_parse_to_real_records` now asserts `cname.rdata_text == "www3.l.google.com"` instead of `.endswith("google.com")`. Both replacement values were confirmed by running the actual decoder against `tests/fixtures/udp_dns.pcap`, not assumed.
- `CHANGELOG.md`: `### Development` entry under a new `## [Unreleased]` section.

## Verification

- [x] `uv run ruff check` and `uv run ruff format --check` are clean
- [x] `uv run mypy` is clean (strict)
- [x] `uv run pytest` passes locally (CI runs it on Python 3.12 / 3.13 / 3.14)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

```
uv run --frozen pytest --cov=netprotocols --cov-report=term
...
TOTAL   2055   1   99%
Required test coverage of 98.0% reached. Total coverage: 99.95%
```

### New protocol or dispatch change — also:

N/A — no new protocol or dispatch change, this block doesn't apply.

## Notes

No alerts were dismissed via the code-scanning API for this fix — the substring/`endswith` pattern CodeQL keys on is gone from the code, so the next analysis of `master` (this PR's own CodeQL run included) shouldn't reproduce findings at these locations, and GitHub should auto-close #7/#8/#9 as fixed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXX5fFdPYfwpXfj6LiqiLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXX5fFdPYfwpXfj6LiqiLr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Tightened DNS corpus validation to require exact expected domain names and CNAME targets.
  - Improved test precision by replacing partial-match checks with exact comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->