### PR TITLE
ci: add commit-message prefixes to dependabot config so PR titles pass lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
     groups:
       # netprotocols ships zero runtime dependencies today, so every
       # update currently comes from the "dev" dependency-group (pytest,
@@ -47,3 +49,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- `pr-title-lint.yml` enforces Conventional Commits shape on PR titles, but Dependabot's default titles (e.g. "Bump actions/checkout from 5.1.0 to 7.0.1") have no type prefix, so every dependency-bump PR fails that check.
- GitHub's `commit-message.prefix` option in `dependabot.yml` also drives the generated PR title, not just the commit message, so setting it per ecosystem (`chore` for the `uv` group, `ci` for `github-actions`) fixes this at the source going forward.
- The 6 currently-open dependabot PRs (#159–#164) are being retitled by hand separately since this config change doesn't retroactively affect them.

## Test plan
- [x] `lint` / `typecheck` / `build` required checks pass on this PR
- [ ] Next weekly Dependabot run produces PRs with `chore:`/`ci:`-prefixed titles that pass `pr-title-lint.yml` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update commit messages to use consistent prefixes for package and workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->